### PR TITLE
Ensure document is loaded before appending (IE 11)

### DIFF
--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -60,7 +60,14 @@ if (shouldPolyfill()) {
     'src',
     'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.7.0/polyfill.min.js'
   )
-  document.body.appendChild(script)
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () =>
+      document.body.appendChild(script)
+    )
+  } else {
+    document.body.appendChild(script)
+  }
 
   script.onload = function (): void {
     attempt(install)


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR makes sure the document is loaded before appending script to the body, which in rare cases was causing an error in IE 11.

## Testing

Testing was done on a windows computer with IE 11, the error no longer appears and a.js loads properly