### PR TITLE
Respect anonymousId being set in events

### DIFF
--- a/src/plugins/segmentio/__tests__/normalize.test.ts
+++ b/src/plugins/segmentio/__tests__/normalize.test.ts
@@ -91,6 +91,16 @@ describe('before loading', () => {
       assert(object.anonymousId?.length === 36)
     })
 
+    it('should accept anonymousId being set in an event', async () => {
+      const object: SegmentEvent = {
+        userId: 'baz',
+        type: 'track',
+        anonymousId: '👻',
+      }
+      normalize(analytics, object, options, {})
+      expect(object.anonymousId).toEqual('👻')
+    })
+
     it('should add .context', () => {
       normalize(analytics, object, options, {})
       assert(object.context)

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -109,6 +109,7 @@ export function normalize(
 
   json.context = json.context ?? json.options ?? {}
   const ctx = json.context
+  const anonId = json.anonymousId
 
   delete json.options
   json.writeKey = settings?.apiKey
@@ -132,7 +133,7 @@ export function normalize(
   referrerId(query, ctx)
 
   json.userId = json.userId || user.id()
-  json.anonymousId = user.anonymousId()
+  json.anonymousId = user.anonymousId(anonId)
   json.sentAt = new Date()
   json.timestamp = new Date()
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR makes the segment.io normalize function respect anonymousId being set in events, as outlined in our docs here https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/identity/#override-the-anonymous-id-using-the-options-object

## Testing

![image](https://user-images.githubusercontent.com/2866515/135350117-7540d3a9-44de-422d-ac69-82e6a1660395.png)
![image](https://user-images.githubusercontent.com/2866515/135350171-85c96cc8-7461-44ac-9278-fe2a8cc19510.png)
