### PR TITLE
Allow overriding page context with properties

### DIFF
--- a/src/plugins/page-enrichment/__tests__/index.test.ts
+++ b/src/plugins/page-enrichment/__tests__/index.test.ts
@@ -61,6 +61,20 @@ describe('Page Enrichment', () => {
   `)
   })
 
+  test('enriches page events using properties', async () => {
+    const ctx = await ajs.page('My event', { banana: 'phone', referrer: 'foo' })
+
+    expect(ctx.event.context?.page).toMatchInlineSnapshot(`
+    Object {
+      "path": "/",
+      "referrer": "foo",
+      "search": "",
+      "title": "",
+      "url": "http://localhost/",
+    }
+  `)
+  })
+
   test('enriches identify events with the page context', async () => {
     const ctx = await ajs.identify('Netto', {
       banana: 'phone',

--- a/src/plugins/page-enrichment/index.ts
+++ b/src/plugins/page-enrichment/index.ts
@@ -2,6 +2,7 @@ import type { Context } from '@/core/context'
 import type { Plugin } from '@/core/plugin'
 
 interface PageDefault {
+  [key: string]: unknown
   path: string
   referrer: string
   search: string
@@ -79,6 +80,13 @@ function enrichPageContext(ctx: Context): Context {
   const event = ctx.event
   event.context = event.context || {}
   let pageContext = pageDefaults()
+  const pageProps = event.properties ?? {}
+
+  Object.keys(pageContext).forEach((key) => {
+    if (pageProps[key]) {
+      pageContext[key] = pageProps[key]
+    }
+  })
 
   if (event.context.page) {
     pageContext = Object.assign({}, pageContext, event.context.page)


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR adds some A.js classic parity, which would allow overriding the event.context.page object with properties.

## Testing

Set referrer/url using properties:
![image](https://user-images.githubusercontent.com/2866515/135523507-80a4108b-decd-4b3a-8c28-0a1a67d9509f.png)
