### PR TITLE
get actions from custom CDN

### DIFF
--- a/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/src/plugins/remote-loader/__tests__/index.test.ts
@@ -32,6 +32,23 @@ describe('Remote Loader', () => {
     expect(loader.loadScript).toHaveBeenCalledWith('cdn/path/to/file.js')
   })
 
+  it('should attempt to load a script from a custom CDN', async () => {
+    window.analytics = {}
+    window.analytics._cdn = 'foo.com'
+    await remoteLoader({
+      integrations: {},
+      remotePlugins: [
+        {
+          url: 'https://cdn.segment.com/actions/file.js',
+          libraryName: 'testPlugin',
+          settings: {},
+        },
+      ],
+    })
+
+    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
+  })
+
   it('should attempt calling the library', async () => {
     await remoteLoader({
       integrations: {},

--- a/src/plugins/remote-loader/index.ts
+++ b/src/plugins/remote-loader/index.ts
@@ -3,6 +3,7 @@ import { JSONValue } from '../../core/events'
 import { Plugin } from '../../core/plugin'
 import { asPromise } from '../../lib/as-promise'
 import { loadScript } from '../../lib/load-script'
+import { getCDN } from '../../lib/parse-cdn'
 
 export interface RemotePlugin {
   /** The url of the javascript file to load */
@@ -42,11 +43,14 @@ export async function remoteLoader(
   settings: LegacySettings
 ): Promise<Plugin[]> {
   const allPlugins: Plugin[] = []
+  const cdn = window.analytics?._cdn ?? getCDN()
 
   const pluginPromises = (settings.remotePlugins ?? []).map(
     async (remotePlugin) => {
       try {
-        await loadScript(remotePlugin.url)
+        await loadScript(
+          remotePlugin.url.replace('https://cdn.segment.com', cdn)
+        )
 
         const libraryName = remotePlugin.libraryName
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR makes actions follow the same logic as AJSN for determining which CDN to retrieve it's files from so that they don't break in-domain instrumentation.

## Testing

Setting window.analytics._cdn attempts to load actions from custom cdn:
![image](https://user-images.githubusercontent.com/2866515/135527533-dace3d11-70b8-4f34-a092-81a9b21eaa1d.png)
