### PR TITLE
Pass integrations to middleware

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -329,33 +329,13 @@ export class Analytics extends Emitter {
     const { sourceMiddlewarePlugin } = await import(
       /* webpackChunkName: "middleware" */ './plugins/middleware'
     )
-    const integrations = this.queue.plugins
-      .filter((plugin) => plugin.type === 'destination')
-      .reduce((acc, plugin) => {
-        const name = `${plugin.name
-          .toLowerCase()
-          .replace('.', '')
-          .split(' ')
-          .join('-')}Integration`
 
-        // @ts-expect-error
-        const integration = window[name] as
-          | (LegacyIntegration & { Integration?: LegacyIntegration })
-          | undefined
-
-        if (!integration) {
-          return acc
-        }
-
-        const nested = integration.Integration // hack - Google Analytics function resides in the "Integration" field
-        if (nested) {
-          acc[plugin.name] = nested
-          return acc
-        }
-
-        acc[plugin.name] = integration as LegacyIntegration
-        return acc
-      }, {} as Record<string, LegacyIntegration>)
+    const integrations: Record<string, boolean> = {}
+    this.queue.plugins.forEach((plugin) => {
+      if (plugin.type === 'destination') {
+        return (integrations[plugin.name] = true)
+      }
+    })
 
     const plugin = sourceMiddlewarePlugin(fn, integrations)
     await this.register(plugin)

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -329,7 +329,35 @@ export class Analytics extends Emitter {
     const { sourceMiddlewarePlugin } = await import(
       /* webpackChunkName: "middleware" */ './plugins/middleware'
     )
-    const plugin = sourceMiddlewarePlugin(fn)
+    const integrations = this.queue.plugins
+      .filter((plugin) => plugin.type === 'destination')
+      .reduce((acc, plugin) => {
+        const name = `${plugin.name
+          .toLowerCase()
+          .replace('.', '')
+          .split(' ')
+          .join('-')}Integration`
+
+        // @ts-expect-error
+        const integration = window[name] as
+          | (LegacyIntegration & { Integration?: LegacyIntegration })
+          | undefined
+
+        if (!integration) {
+          return acc
+        }
+
+        const nested = integration.Integration // hack - Google Analytics function resides in the "Integration" field
+        if (nested) {
+          acc[plugin.name] = nested
+          return acc
+        }
+
+        acc[plugin.name] = integration as LegacyIntegration
+        return acc
+      }, {} as Record<string, LegacyIntegration>)
+
+    const plugin = sourceMiddlewarePlugin(fn, integrations)
     await this.register(plugin)
     return this
   }

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -157,9 +157,9 @@ export class EventFactory {
 
     if (this.user.id()) {
       base.userId = this.user.id()
-    } else {
-      base.anonymousId = this.user.anonymousId()
     }
+
+    base.anonymousId = this.user.anonymousId()
 
     return base
   }

--- a/src/core/queue/__tests__/event-queue.test.ts
+++ b/src/core/queue/__tests__/event-queue.test.ts
@@ -481,7 +481,7 @@ describe('Flushing', () => {
 
       await eq.register(
         Context.system(),
-        sourceMiddlewarePlugin(skipAmplitude),
+        sourceMiddlewarePlugin(skipAmplitude, {}),
         ajs
       )
 

--- a/src/plugins/middleware/__tests__/index.test.ts
+++ b/src/plugins/middleware/__tests__/index.test.ts
@@ -15,7 +15,7 @@ describe(sourceMiddlewarePlugin, () => {
     next(payload)
   }
 
-  const xt = sourceMiddlewarePlugin(simpleMiddleware)
+  const xt = sourceMiddlewarePlugin(simpleMiddleware, {})
 
   it('creates a source middleware', () => {
     expect(xt.name).toEqual('Source Middleware simpleMiddleware')
@@ -38,7 +38,7 @@ describe(sourceMiddlewarePlugin, () => {
         next(payload)
       }
 
-      const xt = sourceMiddlewarePlugin(changeProperties)
+      const xt = sourceMiddlewarePlugin(changeProperties, {})
 
       expect(
         (
@@ -60,7 +60,7 @@ describe(sourceMiddlewarePlugin, () => {
         next(payload)
       }
 
-      const xt = sourceMiddlewarePlugin(facadeMiddleware)
+      const xt = sourceMiddlewarePlugin(facadeMiddleware, {})
 
       await xt.track!(
         new Context({
@@ -73,13 +73,13 @@ describe(sourceMiddlewarePlugin, () => {
 
     it('cancels the event if `next` is not called', async (done) => {
       const hangs: MiddlewareFunction = () => {}
-      const hangsXT = sourceMiddlewarePlugin(hangs)
+      const hangsXT = sourceMiddlewarePlugin(hangs, {})
 
       const doesNotHang: MiddlewareFunction = ({ next, payload }) => {
         next(payload)
       }
 
-      const doesNotHangXT = sourceMiddlewarePlugin(doesNotHang)
+      const doesNotHangXT = sourceMiddlewarePlugin(doesNotHang, {})
       const toReturn = new Context({ type: 'track' })
       const returnedCtx = await doesNotHangXT.track!(toReturn)
 

--- a/src/plugins/middleware/index.ts
+++ b/src/plugins/middleware/index.ts
@@ -8,7 +8,7 @@ import { LegacyIntegration } from '../ajs-destination/types'
 export interface MiddlewareParams {
   payload: SegmentFacade
 
-  integrations?: Record<string, LegacyIntegration>
+  integrations?: Record<string, boolean>
   next: (payload: MiddlewareParams['payload'] | null) => void
 }
 
@@ -80,7 +80,7 @@ export async function applyDestinationMiddleware(
 
 export function sourceMiddlewarePlugin(
   fn: MiddlewareFunction,
-  integrations: Record<string, LegacyIntegration>
+  integrations: Record<string, boolean>
 ): Plugin {
   async function apply(ctx: Context): Promise<Context> {
     let nextCalled = false

--- a/src/plugins/middleware/index.ts
+++ b/src/plugins/middleware/index.ts
@@ -7,7 +7,7 @@ import { SegmentFacade, toFacade } from '../../lib/to-facade'
 export interface MiddlewareParams {
   payload: SegmentFacade
 
-  integrations?: Record<string, boolean>
+  integrations?: SegmentEvent['integrations']
   next: (payload: MiddlewareParams['payload'] | null) => void
 }
 
@@ -79,7 +79,7 @@ export async function applyDestinationMiddleware(
 
 export function sourceMiddlewarePlugin(
   fn: MiddlewareFunction,
-  integrations: Record<string, boolean>
+  integrations: SegmentEvent['integrations']
 ): Plugin {
   async function apply(ctx: Context): Promise<Context> {
     let nextCalled = false

--- a/src/plugins/middleware/index.ts
+++ b/src/plugins/middleware/index.ts
@@ -3,7 +3,6 @@ import { SegmentEvent } from '../../core/events'
 import { Plugin } from '../../core/plugin'
 import { asPromise } from '../../lib/as-promise'
 import { SegmentFacade, toFacade } from '../../lib/to-facade'
-import { LegacyIntegration } from '../ajs-destination/types'
 
 export interface MiddlewareParams {
   payload: SegmentFacade

--- a/src/plugins/middleware/index.ts
+++ b/src/plugins/middleware/index.ts
@@ -3,11 +3,12 @@ import { SegmentEvent } from '../../core/events'
 import { Plugin } from '../../core/plugin'
 import { asPromise } from '../../lib/as-promise'
 import { SegmentFacade, toFacade } from '../../lib/to-facade'
+import { LegacyIntegration } from '../ajs-destination/types'
 
 export interface MiddlewareParams {
   payload: SegmentFacade
 
-  integrations?: SegmentEvent['integrations']
+  integrations?: Record<string, LegacyIntegration>
   next: (payload: MiddlewareParams['payload'] | null) => void
 }
 
@@ -77,7 +78,10 @@ export async function applyDestinationMiddleware(
   return evt
 }
 
-export function sourceMiddlewarePlugin(fn: MiddlewareFunction): Plugin {
+export function sourceMiddlewarePlugin(
+  fn: MiddlewareFunction,
+  integrations: Record<string, LegacyIntegration>
+): Plugin {
   async function apply(ctx: Context): Promise<Context> {
     let nextCalled = false
 
@@ -87,7 +91,7 @@ export function sourceMiddlewarePlugin(fn: MiddlewareFunction): Plugin {
           clone: true,
           traverse: false,
         }),
-        integrations: ctx.event.integrations ?? {},
+        integrations: integrations ?? {},
         next(evt) {
           nextCalled = true
           if (evt) {


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR passes the list of integrations to middleware, which was sometimes being passed as an empty object previously. It  also makes base events include anonymousIds when a user id is present.

## Testing

Testing completed locally (braze middleware being passed integrations properly now and setting Appboy in the event):
![image](https://user-images.githubusercontent.com/2866515/137212157-7a4183a9-13ed-45c5-9c29-f911273675b0.png)
