### PR TITLE
Disable legacy debug

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -282,6 +282,10 @@ export class Analytics extends Emitter {
   }
 
   debug(toggle: boolean): Analytics {
+    // Make sure legacy ajs debug gets turned off if it was enabled before upgrading.
+    if (toggle === false && localStorage.getItem('debug')) {
+      localStorage.removeItem('debug')
+    }
     this._debug = toggle
     return this
   }


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR disables the debug setting used by legacy a.js when calling `debug(false)` in case a user had debug mode enabled when upgrading to ajs 2.0. See https://github.com/segmentio/analytics-next/issues/294

## Testing

Please, make sure to describe how you tested this change, include any gifs or screenshots you find necessary.