### PR TITLE
Allow updateEvent to override integrations set to true

### DIFF
--- a/src/core/context/__tests__/index.test.ts
+++ b/src/core/context/__tests__/index.test.ts
@@ -111,6 +111,41 @@ describe(Context, () => {
         lastName: 'Farah',
       })
     })
+
+    it('allows updating integrations set to true', () => {
+      const trueEvt: SegmentEvent = {
+        type: 'identify',
+        integrations: {
+          Amplitude: true,
+        },
+      }
+
+      const falseEvt: SegmentEvent = {
+        type: 'identify',
+        integrations: {
+          Amplitude: false,
+        },
+      }
+
+      const trueCtx = new Context(trueEvt)
+      trueCtx.updateEvent('integrations.Amplitude.sessionId', 'foo')
+      expect(trueCtx.event.integrations).toEqual({
+        Amplitude: {
+          sessionId: 'foo',
+        },
+      })
+
+      trueCtx.updateEvent('traits.address', {
+        street: '301 Brazos St',
+        state: 'TX',
+      })
+
+      const falseCtx = new Context(falseEvt)
+      falseCtx.updateEvent('integrations.Amplitude.sessionId', 'foo')
+      expect(falseCtx.event.integrations).toEqual({
+        Amplitude: false,
+      })
+    })
   })
 
   it('serializes a context to JSON', () => {

--- a/src/core/context/index.ts
+++ b/src/core/context/index.ts
@@ -97,6 +97,17 @@ export class Context implements AbstractContext {
   }
 
   public updateEvent(path: string, val: unknown): SegmentEvent {
+    // Allow integrations that are set to true to be overridden with integration settings.
+    // For example, allow {..., integrations: {Amplitude: true}} to be overwritten with
+    // {..., integrations: {Amplitude: {sessionId: 'foo'}}}.
+    if (path.split('.')[0] === 'integrations') {
+      const integrationName = path.split('.')[1]
+
+      if (this._event.integrations?.[integrationName] === true) {
+        delete this._event.integrations?.[integrationName]
+      }
+    }
+
     dset(this._event, path, val)
     return this._event
   }


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR allows integrations that are set to true in the integrations object to be updated with integration specific settings.

## Testing

- Updated unit tests
- Loading analytics with Amplitude set to true:
![image](https://user-images.githubusercontent.com/2866515/138367729-3cd20aea-9878-4c84-89c7-a1537fa3cf16.png)

- Loading analytics with Amplitude set to false:
![image](https://user-images.githubusercontent.com/2866515/138367780-84668811-8b0c-490a-9314-260a2eb802fb.png)

Please, make sure to describe how you tested this change, include any gifs or screenshots you find necessary.