### PR TITLE
fix args resolver for nulls

### DIFF
--- a/src/core/arguments-resolver/index.ts
+++ b/src/core/arguments-resolver/index.ts
@@ -87,12 +87,15 @@ export function resolvePageArguments(
 
 export const resolveUserArguments = (user: User): ResolveUser => {
   return (...args): ReturnType<ResolveUser> => {
-    const id =
-      args.find(isString) ?? args.find(isNumber)?.toString() ?? user.id()
+    let id: string | ID | null = null
+    id = args.find(isString) ?? args.find(isNumber)?.toString() ?? user.id()
 
-    const objects = args.filter(
-      (obj) => isPlainObject(obj) || obj === null
-    ) as Array<object | null>
+    const objects = args.filter((obj) => {
+      if (id === null) {
+        return isPlainObject(obj)
+      }
+      return isPlainObject(obj) || obj === null
+    }) as Array<object | null>
 
     const data = objects[0] ?? {}
     const opts = objects[1] ?? {}

--- a/src/plugins/segmentio/__tests__/index.test.ts
+++ b/src/plugins/segmentio/__tests__/index.test.ts
@@ -87,6 +87,20 @@ describe('Segment.io', () => {
       assert(body.context.opt === true)
       assert(body.timestamp)
     })
+
+    it('should set traits with null id', async () => {
+      await analytics.identify(null, { trait: true }, { opt: true })
+
+      const [url, params] = spyMock.mock.calls[0]
+      expect(url).toMatchInlineSnapshot(`"https://api.segment.io/v1/i"`)
+
+      const body = JSON.parse(params.body)
+      assert(body.userId === null)
+      assert(body.traits.trait === true)
+      assert(!body.context.trait)
+      assert(body.context.opt === true)
+      assert(body.timestamp)
+    })
   })
 
   describe('#track', () => {
@@ -117,6 +131,21 @@ describe('Segment.io', () => {
       assert(body.groupId === 'id')
       assert(body.context.opt === true)
       assert(body.traits.trait === true)
+      assert(body.timestamp)
+    })
+
+    it('should set traits with null id', async () => {
+      await analytics.group(null, { trait: true }, { opt: true })
+
+      const [url, params] = spyMock.mock.calls[0]
+      expect(url).toMatchInlineSnapshot(`"https://api.segment.io/v1/g"`)
+
+      const body = JSON.parse(params.body)
+
+      assert(body.groupId === null)
+      assert(body.context.opt === true)
+      assert(body.traits.trait === true)
+      assert(!body.context.trait)
       assert(body.timestamp)
     })
   })


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

Similar to https://github.com/segmentio/analytics-next/pull/302, this PR handles null input for identify and group calls, and properly sets traits instead of in the context.

## Testing

![image](https://user-images.githubusercontent.com/2866515/139489072-9ef34dce-4e2e-488a-b772-b5cbe8b4caac.png)
