### PR TITLE
Ensure source middleware is added first in buffered operations

### DIFF
--- a/src/tester/__fixtures__/segment-snippet.ts
+++ b/src/tester/__fixtures__/segment-snippet.ts
@@ -50,6 +50,8 @@ export const snippet = (writeKey: string, load: boolean = true, extra = '') => `
         n.parentNode.insertBefore(t, n)
         analytics._loadOptions = e
       }
+      var smw1 = function ({}) {}
+      analytics.addSourceMiddleware(smw1);
       analytics.SNIPPET_VERSION = '4.13.1'
       ${load && `analytics.load('${writeKey}')`}
       analytics.page()


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR ensures that source middleware is added before other buffered operations are ran - for example on the initial page call in the segment snippet.

## Testing

MW ran on snippet page call: 
![image](https://user-images.githubusercontent.com/2866515/140173041-784d4fbb-dbd6-4e02-b710-a22954ebbada.png)