### PR TITLE
Only use unfetch when native fetch is not available

### DIFF
--- a/src/plugins/segmentio/fetch-dispatcher.ts
+++ b/src/plugins/segmentio/fetch-dispatcher.ts
@@ -1,11 +1,15 @@
-import fetch from 'unfetch'
+import unfetch from 'unfetch'
+
+let fetch = unfetch
+if (typeof window !== 'undefined') {
+  fetch = window.fetch || unfetch
+}
 
 export type Dispatcher = (url: string, body: object) => Promise<unknown>
 
 export default function (): { dispatch: Dispatcher } {
   function dispatch(url: string, body: object): Promise<unknown> {
     return fetch(url, {
-      keepalive: true,
       headers: { 'Content-Type': 'text/plain' },
       method: 'post',
       body: JSON.stringify(body),


### PR DESCRIPTION
Currently we use unfetch by default, and unfetch doesn't throw when a request is cancelled by browser in rare cases. This PR uses native `fetch` which is available on most modern browsers, and fallback to unfetch in non-browser/legacy contexts. Additionally, I'm removing the `keepalive` flag ( originally had no effect when using unfetch ), as in rare cases when we have more than 64kb of `keepalive` requests we may start throwing. 

## Testing

Testing done manually, and verified that we are now using native fetch. 