### PR TITLE
refactor: change persisted storage constant to function to avoid execution on time of import

### DIFF
--- a/src/lib/priority-queue/persisted.ts
+++ b/src/lib/priority-queue/persisted.ts
@@ -2,13 +2,19 @@ import { PriorityQueue } from '.'
 import { Context, SerializedContext } from '../../core/context'
 import { isBrowser } from '../../core/environment'
 
-const loc = isBrowser()
-  ? window.localStorage
-  : {
-      getItem() {},
-      setItem() {},
-      removeItem() {},
-    }
+let loc:
+  | Storage
+  | { getItem: () => void; setItem: () => void; removeItem: () => void } = {
+  getItem() {},
+  setItem() {},
+  removeItem() {},
+}
+
+try {
+  loc = isBrowser() ? window.localStorage : loc
+} catch (err) {
+  console.warn('Unable to access localStorage', err)
+}
 
 function persisted(key: string): Context[] {
   const items = loc.getItem(key)


### PR DESCRIPTION
**Description :-**
- We are building an application that is hosted as an iframe with in another application.
- We would like to check if cookie access is enabled and then call `await AnalyticsBrowser.load({ writeKey })` but just importing AnalyticsBrowser crashes the application.

**Steps to reproduce:-**
- `git clone https://github.com/peeyushsingla1/testing-segment-analytics`
- `yarn && yarn start`
- Block all cookies from chrome(as our application lives in iframe setting block third party cookies caused this issue).

![Screenshot 2021-11-07 at 12 16 02](https://user-images.githubusercontent.com/72206766/140642722-e30beb5d-62c4-40e1-8775-52329a0b985e.png)

- Visit application and it would break
![Screenshot 2021-11-07 at 12 09 17](https://user-images.githubusercontent.com/72206766/140642745-b6e89332-3d91-48da-ac0b-261bcf73def0.png)

**Technical Details:-**
* Issue is happening because of [persisted](https://github.com/segmentio/analytics-next/blob/4d04b4813dd7ba539d86c31b83ccb1f96dd08d21/src/lib/priority-queue/persisted.ts#L5)


## Testing

* Its internal implementation of persisted so I guess no tests required.
* One problem after the refactoring is below test start to fail, unsure why

```
 FAIL  src/plugins/legacy-video-plugins/__tests__/index.test.ts
  ● loadLegacyVideoPlugins › attaches video plugins to ajs

    SecurityError: localStorage is not available for opaque origins
```