### PR TITLE
Fixing an issue with custom cookie options

### DIFF
--- a/src/core/user/__tests__/index.test.ts
+++ b/src/core/user/__tests__/index.test.ts
@@ -623,6 +623,14 @@ describe('user', () => {
       expect(user.id()).toEqual('old')
       expect(user.traits()).toEqual({ trait: true })
     })
+
+    it('load should preserve the original User cookie options', () => {
+      user = new User(undefined, {
+        domain: 'foo',
+      }).load()
+      // @ts-ignore - we are testing the private properties here
+      expect(user.cookies['options'].domain).toEqual('foo')
+    })
   })
 })
 

--- a/src/core/user/index.ts
+++ b/src/core/user/index.ts
@@ -174,11 +174,13 @@ export class User {
   private idKey: string
   private traitsKey: string
   private anonKey: string
+  private cookieOptions?: CookieOptions
 
   options: UserOptions = {}
 
   constructor(options: UserOptions = defaults, cookieOptions?: CookieOptions) {
     this.options = options
+    this.cookieOptions = cookieOptions
 
     this.idKey = options.cookie?.key ?? defaults.cookie.key
     this.traitsKey = options.localStorage?.key ?? defaults.localStorage.key
@@ -329,7 +331,7 @@ export class User {
   }
 
   load(): User {
-    return new User(this.options)
+    return new User(this.options, this.cookieOptions)
   }
 
   save(): boolean {


### PR DESCRIPTION
I was testing passing down custom cookie options during the library initialization ( i.e., using a custom domain for cookie, rather than the one inferred by the library ) and noticed that the `load` method looses the custom options. This makes sure that the custom cookie options are respected. 

```typescript
  analytics.load(writeKey, {
    cookie: {
      domain: ".test"
    }
  })
```

## Testing
- [x] added a unit test to cover for the case 
- [x] will allow the QA system to do it job