### PR TITLE
improving smoke tests reliability

### DIFF
--- a/qa/lib/runner.ts
+++ b/qa/lib/runner.ts
@@ -60,6 +60,8 @@ export async function run(params: ComparisonParams) {
       // do not Record GA calls because it thinks ajs-next is a bot and doesn't naturally trigger requests
       // we know GA works :)
       if (
+        // clarity.ms uses multiple subdomains
+        call.url.includes('clarity.ms') ||
         call.url.includes('doubleclick.net') ||
         // bot
         call.url.includes('googletagmanager') ||


### PR DESCRIPTION
Adding `clarity.ms` to the exclusion list, as the url sub-domain can change from session to session ( i.e., `a.clarity.ms` and `b.clarity.ms`. 

## Testing
- [x] Tested locally and it fixes the reliability issue for our smoke tests. 