### PR TITLE
Introduce Schema filter plugin

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -153,6 +153,14 @@ async function registerPlugins(
     })
   }
 
+  const schemaFilter = opts.plan?.track
+    ? await import(
+        /* webpackChunkName: "schemaFilter" */ './plugins/schema-filter'
+      ).then((mod) => {
+        return mod.schemaFilter(opts.plan?.track, legacySettings)
+      })
+    : undefined
+
   const mergedSettings = mergedOptions(legacySettings, options)
   const remotePlugins = await remoteLoader(legacySettings).catch(() => [])
 
@@ -163,6 +171,10 @@ async function registerPlugins(
     ...legacyDestinations,
     ...remotePlugins,
   ]
+
+  if (schemaFilter) {
+    toRegister.push(schemaFilter)
+  }
 
   const shouldIgnoreSegmentio =
     (opts.integrations?.All === false && !opts.integrations['Segment.io']) ||

--- a/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/src/plugins/remote-loader/__tests__/index.test.ts
@@ -22,6 +22,7 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'remote plugin',
           url: 'cdn/path/to/file.js',
           libraryName: 'testPlugin',
           settings: {},
@@ -39,6 +40,7 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'remote plugin',
           url: 'https://cdn.segment.com/actions/file.js',
           libraryName: 'testPlugin',
           settings: {},
@@ -54,6 +56,7 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'remote plugin',
           url: 'cdn/path/to/file.js',
           libraryName: 'testPlugin',
           settings: {
@@ -76,6 +79,7 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'remote plugin',
           url: 'cdn/path/to/file.js',
           libraryName: 'this wont resolve',
           settings: {},
@@ -127,11 +131,13 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'multiple plugins',
           url: 'multiple-plugins.js',
           libraryName: 'multiple-plugins',
           settings: { foo: true },
         },
         {
+          name: 'single plugin',
           url: 'single-plugin.js',
           libraryName: 'single-plugin',
           settings: { bar: false },
@@ -163,11 +169,13 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'flaky plugin',
           url: 'cdn/path/to/flaky.js',
           libraryName: 'flaky',
           settings: {},
         },
         {
+          name: 'async flaky plugin',
           url: 'cdn/path/to/asyncFlaky.js',
           libraryName: 'asyncFlaky',
           settings: {},
@@ -209,11 +217,13 @@ describe('Remote Loader', () => {
       integrations: {},
       remotePlugins: [
         {
+          name: 'valid plugin',
           url: 'valid',
           libraryName: 'valid',
           settings: { foo: true },
         },
         {
+          name: 'invalid plugin',
           url: 'invalid',
           libraryName: 'invalid',
           settings: { bar: false },

--- a/src/plugins/remote-loader/__tests__/integration.test.ts
+++ b/src/plugins/remote-loader/__tests__/integration.test.ts
@@ -43,6 +43,7 @@ describe.skip('Remote Plugin Integration', () => {
         // we should mock this file in case it becomes a problem
         // but I'd like to have a full integration test if possible
         {
+          name: 'amplitude',
           url:
             'https://ajs-next-integrations.s3-us-west-2.amazonaws.com/fab-5/amplitude-plugins.js',
           libraryName: 'amplitude-pluginsDestination',

--- a/src/plugins/remote-loader/index.ts
+++ b/src/plugins/remote-loader/index.ts
@@ -6,6 +6,8 @@ import { loadScript } from '../../lib/load-script'
 import { getCDN } from '../../lib/parse-cdn'
 
 export interface RemotePlugin {
+  /** The name of the remote plugin */
+  name: string
   /** The url of the javascript file to load */
   url: string
   /** The UMD/global name the plugin uses. Plugins are expected to exist here with the `PluginFactory` method signature */

--- a/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/src/plugins/schema-filter/__tests__/index.test.ts
@@ -1,0 +1,145 @@
+import { Plugin } from '../../../core/plugin'
+import { Analytics } from '../../../analytics'
+import { Context } from '../../../core/context'
+import { schemaFilter } from '..'
+import { AnalyticsBrowser, LegacySettings } from '../../../browser'
+import { TEST_WRITEKEY } from '../../../__tests__/test-writekeys'
+import { segmentio, SegmentioSettings } from '../../segmentio'
+
+const writeKey = TEST_WRITEKEY
+
+// TODO what happens if we only have defaults?
+const plan = {
+  track: {
+    'Track Event': {
+      enabled: true,
+      integrations: {
+        'Braze Web Mode (Actions)': false,
+      },
+    },
+    __default: {
+      enabled: true,
+      integrations: {},
+    },
+    hi: {
+      enabled: true,
+      integrations: {
+        'Braze Web Mode (Actions)': false,
+      },
+    },
+  },
+  identify: {
+    __default: {
+      enabled: true,
+    },
+  },
+  group: {
+    __default: {
+      enabled: true,
+    },
+  },
+}
+
+const settings: LegacySettings = {
+  integrations: {
+    'Braze Web Mode (Actions)': {},
+    'Segment.io': {},
+  },
+  remotePlugins: [
+    {
+      name: 'Braze Web Mode (Actions)',
+      libraryName: 'brazeDestination',
+      url:
+        'https://cdn.segment.com/next-integrations/actions/braze/9850d2cc8308a89db62a.js',
+      settings: {
+        subscriptions: [
+          {
+            partnerAction: 'trackEvent',
+          },
+          {
+            partnerAction: 'updateUserProfile',
+          },
+          {
+            partnerAction: 'trackPurchase',
+          },
+        ],
+      },
+    },
+  ],
+}
+
+const trackEvent: Plugin = {
+  name: 'Braze Web Mode (Actions) trackEvent',
+  type: 'destination',
+  version: '1.0',
+
+  load(_ctx: Context): Promise<void> {
+    return Promise.resolve()
+  },
+
+  isLoaded(): boolean {
+    return true
+  },
+
+  track: async (ctx) => ctx,
+  identify: async (ctx) => ctx,
+  page: async (ctx) => ctx,
+  group: async (ctx) => ctx,
+  alias: async (ctx) => ctx,
+}
+
+const trackPurchase: Plugin = {
+  ...trackEvent,
+  name: 'Braze Web Mode (Actions) trackPurchase',
+}
+
+const updateUserProfile: Plugin = {
+  ...trackEvent,
+  name: 'Braze Web Mode (Actions) updateUserProfile',
+}
+
+describe('schema filter', () => {
+  let options: SegmentioSettings
+  let filterXt: Plugin
+  let segment: Plugin
+  let analytics: Analytics
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
+
+    options = { apiKey: 'foo' }
+    analytics = new Analytics({ writeKey: options.apiKey })
+    segment = segmentio(analytics, options, {})
+    filterXt = schemaFilter(plan.track, settings)
+  })
+
+  it('loads plugin', async () => {
+    await analytics.register(filterXt)
+    expect(filterXt.isLoaded()).toBe(true)
+  })
+
+  it('does not drop events when no plan is defined', async () => {
+    jest.spyOn(segment, 'track')
+    jest.spyOn(trackEvent, 'track')
+    jest.spyOn(trackPurchase, 'track')
+    jest.spyOn(updateUserProfile, 'track')
+    // jest.spyOn(segment, 'track')
+
+    await analytics.register(
+      segment,
+      trackEvent,
+      trackPurchase,
+      updateUserProfile
+    )
+
+    await analytics.register(schemaFilter({}, settings))
+
+    const ev = await analytics.track('A Track Event')
+
+    expect(segment.track).toHaveBeenCalled()
+    expect(trackEvent.track).toHaveBeenCalledWith(ev)
+    expect(trackPurchase.track).toHaveBeenCalled()
+    expect(updateUserProfile.track).toHaveBeenCalled()
+  })
+})

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -63,9 +63,9 @@ export function schemaFilter(
         const disabledActions = disabledActionDestinations(planEvent, settings)
 
         ctx.updateEvent('integrations', {
-          ...disabledActions,
           ...ctx.event.integrations,
           ...planEvent?.integrations,
+          ...disabledActions,
         })
       }
     }

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -1,0 +1,75 @@
+import { LegacySettings } from '../../browser'
+import { Context, ContextCancelation } from '../../core/context'
+import { PlanEvent } from '../../core/events/interfaces'
+import { Plugin } from '../../core/plugin'
+
+function disabledActionDestinations(
+  plan: PlanEvent,
+  settings: LegacySettings
+): { [destination: string]: string[] } {
+  const plugins = settings.remotePlugins ?? []
+
+  const disabledIntegrations = Object.keys(plan.integrations).filter(
+    (i) => plan.integrations[i] === false
+  )
+
+  return plugins.reduce((acc, p) => {
+    // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONValue
+    if (p.settings['subscriptions']) {
+      if (disabledIntegrations.includes(p.name)) {
+        // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONValue
+        p.settings['subscriptions'].forEach(
+          // @ts-expect-error parameter 'sub' implicitly has an 'any' type
+          (sub) => (acc[`${p.name} ${sub.partnerAction}`] = false)
+        )
+      }
+    }
+    return acc
+  }, {})
+}
+
+export function schemaFilter(
+  track: { [key: string]: PlanEvent } | undefined,
+  settings: LegacySettings
+): Plugin {
+  function filter(ctx: Context): Context {
+    const plan = track
+    const ev = ctx.event.event
+
+    if (plan && ev) {
+      const planEvent = plan[ev]
+      if (planEvent?.enabled === false) {
+        ctx.updateEvent('integrations', {
+          ...ctx.event.integrations,
+          All: false,
+          'Segment.io': true,
+        })
+        return ctx
+      } else {
+        const disabledActions = disabledActionDestinations(planEvent, settings)
+
+        ctx.updateEvent('integrations', {
+          ...ctx.event.integrations,
+          ...planEvent?.integrations,
+          ...disabledActions,
+          'Segment.io': true,
+        })
+      }
+    }
+
+    return ctx
+  }
+
+  return {
+    name: 'Schema Filter',
+    version: '0.1.0',
+    isLoaded: () => true,
+    load: () => Promise.resolve(),
+    type: 'before',
+    page: filter,
+    alias: filter,
+    track: filter,
+    identify: filter,
+    group: filter,
+  }
+}

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -56,7 +56,6 @@ export function schemaFilter(
           ...disabledActions,
           ...ctx.event.integrations,
           ...planEvent?.integrations,
-          'Segment.io': true,
         })
       }
     }

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -1,5 +1,5 @@
 import { LegacySettings } from '../../browser'
-import { Context, ContextCancelation } from '../../core/context'
+import { Context } from '../../core/context'
 import { PlanEvent } from '../../core/events/interfaces'
 import { Plugin } from '../../core/plugin'
 
@@ -7,6 +7,10 @@ function disabledActionDestinations(
   plan: PlanEvent,
   settings: LegacySettings
 ): { [destination: string]: string[] } {
+  if (!plan || !Object.keys(plan)) {
+    return {}
+  }
+
   const plugins = settings.remotePlugins ?? []
 
   const disabledIntegrations = Object.keys(plan.integrations).filter(
@@ -49,9 +53,9 @@ export function schemaFilter(
         const disabledActions = disabledActionDestinations(planEvent, settings)
 
         ctx.updateEvent('integrations', {
+          ...disabledActions,
           ...ctx.event.integrations,
           ...planEvent?.integrations,
-          ...disabledActions,
           'Segment.io': true,
         })
       }


### PR DESCRIPTION
This PR introduces the Schema Filter plugin that filters events based on the Source Schema settings configurable on the Segment App.

Such behavior is already implemented for legacy destinations but did not cover remote plugins or destination actions.

## Testing

- If the schema is activated for all destinations, we should see all of them being called and no blocked destinations on the `integrations` object:
![Screen Shot 2021-11-10 at 3 21 36 PM](https://user-images.githubusercontent.com/484013/141212317-d5e3ca74-8e9c-4350-9566-4f18496c0a46.png)

- If Braze Web (Actions) is disabled, we should not see the braze endpoint being called and it should show as `false` in the `integrations` object:
![Screen Shot 2021-11-10 at 2 35 18 PM](https://user-images.githubusercontent.com/484013/141212438-f661bbc9-5144-4b3f-b09e-3881142ffc43.png)
![Screen Shot 2021-11-10 at 3 20 35 PM](https://user-images.githubusercontent.com/484013/141212401-f2510b95-c6ba-493e-8461-387b2b9f8c46.png)
 

