### PR TITLE
Allow integers in alias calls (legacy behavior)

### DIFF
--- a/src/core/arguments-resolver/index.ts
+++ b/src/core/arguments-resolver/index.ts
@@ -107,11 +107,13 @@ export const resolveUserArguments = (user: User): ResolveUser => {
 }
 
 export function resolveAliasArguments(
-  to: string,
-  from?: string | Options,
+  to: string | number,
+  from?: string | number | Options,
   options?: Options | Callback,
   callback?: Callback
 ): [string, string | null, Options, Callback | undefined] {
+  if (isNumber(to)) to = to.toString() // Legacy behaviour - allow integers for alias calls
+  if (isNumber(from)) from = from.toString()
   const args = [to, from, options, callback]
 
   const [aliasTo = to, aliasFrom = null] = args.filter(isString)


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This behavior allows the Analytics.js 1.0 behavior of passing integers into alias calls.

## Testing

Passing an integer works:
![image](https://user-images.githubusercontent.com/2866515/142269189-3ece84ef-95b7-4e93-b610-cd9edc3f6c96.png)