### PR TITLE
Load middleware from custom cdn

### DIFF
--- a/src/plugins/remote-middleware/index.ts
+++ b/src/plugins/remote-middleware/index.ts
@@ -2,11 +2,11 @@ import { LegacySettings } from '../../browser'
 import { Context } from '../../core/context'
 import { isServer } from '../../core/environment'
 import { loadScript } from '../../lib/load-script'
+import { getCDN } from '../../lib/parse-cdn'
 import { MiddlewareFunction } from '../middleware'
 
-export const path =
-  process.env.LEGACY_INTEGRATIONS_PATH ??
-  'https://cdn.segment.com/next-integrations'
+const cdn = window.analytics?._cdn ?? getCDN()
+const path = cdn + '/next-integrations'
 
 export async function remoteMiddlewares(
   ctx: Context,


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

The middleware plugin was never updated alongside other components that load from the CDN to load from custom CDNs, this PR fixes that.

## Testing
Loads middleware from custom CDN:
![image](https://user-images.githubusercontent.com/2866515/142932916-bb41f7fa-cf22-42a6-8f8c-9acf635ae7a3.png)