### PR TITLE
Exclude destinations QA from the core QA tasks, and make them soft fail

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           paths: ['node_modules/']
           save: true
 
-  - label: ':hammer: QA'
+  - label: ':perfection: QA'
     key: qa
     agents:
       queue: v1
@@ -35,7 +35,7 @@ steps:
       queue: v1
     command: 'bk-snyk'
 
-  - label: ':hammer: Destinations QA'
+  - label: ':thisisfine: Destinations QA'
     key: destinations
     agents:
       queue: v1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,7 @@ steps:
       - echo "+++ Running Destinations QA Tests :pray:"
       - make test-qa-destinations
     soft_fail:
-      - exit_status: 1
+      - exit_status: '*'
     plugins:
       - ssh://git@github.com/segmentio/cache-buildkite-plugin#v2.0.0:
           key: "v1.1-cache-dev-{{ checksum 'yarn.lock' }}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,23 @@ steps:
       queue: v1
     command: 'bk-snyk'
 
+  - label: ':hammer: Destinations QA'
+    key: destinations
+    agents:
+      queue: v1
+    commands:
+      - npm config set "//registry.npmjs.org/:_authToken" $${NPM_TOKEN}
+      - yarn install
+      - yarn add --dev playwright
+      - echo "+++ Running Destinations QA Tests :pray:"
+      - make test-qa-destinations
+    soft_fail:
+      - exit_status: 1
+    plugins:
+      - ssh://git@github.com/segmentio/cache-buildkite-plugin#v2.0.0:
+          key: "v1.1-cache-dev-{{ checksum 'yarn.lock' }}"
+          paths: ['node_modules/']
+
   # Auto deploys branches
   - label: ':rocket: Release Branch'
     branches: '!master !v*'

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-qa: build-browser ## Runs all QA tests in a single command
 .PHONY: test-coverage
 
 test-qa-destinations: build-browser ## Runs Destination QA tests. options. DESTINATION=amplitude DEBUG=true
-	$(BIN)/jest --runTestsByPath qa/__tests__/destinations.test.ts --reporters="default" --reporters="<rootDir>/qa/lib/jest-reporter.js" ${args}
+	$(BIN)/jest --forceExit --runTestsByPath qa/__tests__/destinations.test.ts --reporters="default" --reporters="<rootDir>/qa/lib/jest-reporter.js" ${args}
 .PHONY: test-coverage
 
 test-integration: build-browser ## Runs all integration tests in a single command

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-coverage: node_modules ## Runs unit tests with coverage
 .PHONY: test-coverage
 
 test-qa: build-browser ## Runs all QA tests in a single command
-	$(BIN)/jest --runTestsByPath qa/__tests__/*.test.ts --reporters="default" --reporters="<rootDir>/qa/lib/jest-reporter.js" ${args}
+	$(BIN)/jest --runTestsByPath qa/__tests__/*.test.ts --testPathIgnorePatterns qa/__tests__/destinations.test.ts --reporters="default" --reporters="<rootDir>/qa/lib/jest-reporter.js" ${args}
 .PHONY: test-coverage
 
 test-qa-destinations: build-browser ## Runs Destination QA tests. options. DESTINATION=amplitude DEBUG=true


### PR DESCRIPTION
Destination QA tasks had been flaky and served their purpose already. Moving them to a soft-fail step to still be there in case of broad regression, but do not fail the build consistently. 

## Testing

Please, make sure to describe how you tested this change, include any gifs or screenshots you find necessary.