### PR TITLE
replaces package.json imports with generated version constant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ node_modules: package.json yarn.lock
 	@touch $@
 
 build: ## Builds typescript files and UMD library
-	yarn clean && yarn concurrently "yarn umd" "yarn pkg"
+	yarn clean && yarn build-prep && yarn concurrently "yarn umd" "yarn pkg"
 .PHONY: build
 
 build-browser:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-browser:
 .PHONY: build-browser
 
 build-prod: ## Builds libraries in prod mode
-	NODE_ENV=production yarn clean && yarn concurrently "NODE_ENV=production yarn umd" "NODE_ENV=production yarn pkg" "NODE_ENV=production yarn cjs"
+	NODE_ENV=production yarn clean && yarn build-prep && yarn concurrently "NODE_ENV=production yarn umd" "NODE_ENV=production yarn pkg" "NODE_ENV=production yarn cjs"
 .PHONY: build
 
 clean: ## Clean the build directory

--- a/example/next-env.d.ts
+++ b/example/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/example/package.json
+++ b/example/package.json
@@ -16,13 +16,13 @@
     "next": "^11.1.1",
     "prismjs": "^1.24.0",
     "rc-table": "^7.10.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-json-tree": "^0.13.0",
     "react-simple-code-editor": "^0.11.0"
   },
   "devDependencies": {
     "@types/faker": "^5.1.2",
-    "@types/react": "^16.9.49"
+    "@types/react": "^17.0.37"
   }
 }

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -8,12 +8,7 @@ import faker from 'faker'
 import { shuffle } from 'lodash'
 import Table from 'rc-table'
 
-import {
-  AnalyticsSettings,
-  AnalyticsBrowser,
-  Analytics,
-  Context,
-} from '../../dist/pkg'
+import { AnalyticsSettings, AnalyticsBrowser, Analytics, Context } from '../../'
 
 const jsontheme = {
   scheme: 'tomorrow',

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -183,13 +183,19 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^16.9.49":
-  version "16.9.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+"@types/react@^17.0.37":
+  version "17.0.37"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
+  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
   dependencies:
     "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 anser@1.4.9:
   version "1.4.9"
@@ -1507,7 +1513,7 @@ process@0.11.10, process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -1634,15 +1640,14 @@ react-base16-styling@^0.8.0:
     csstype "^3.0.2"
     lodash.curry "^4.1.1"
 
-react-dom@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-is@17.0.2:
   version "17.0.2"
@@ -1673,14 +1678,13 @@ react-simple-code-editor@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz#bb57c7c29b570f2ab229872599eac184f5bc673c"
   integrity sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw==
 
-react@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.7"
@@ -1744,10 +1748,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "sideEffects": false,
   "scripts": {
+    "build-prep": "sed -i '' \"s/export const version: .*$/export const version = '$npm_package_version'/\" src/generated/version.ts",
     "umd": "webpack",
     "pkg": "tsc",
     "cjs": "tsc -p tsconfig.cjs.json",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -27,7 +27,7 @@ import type {
   DestinationMiddlewareFunction,
   MiddlewareFunction,
 } from './plugins/middleware'
-import { version } from '../package.json'
+import { version } from './generated/version'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'

--- a/src/core/stats/__tests__/remote-metrics.test.ts
+++ b/src/core/stats/__tests__/remote-metrics.test.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils'
 import unfetch from 'unfetch'
 import { RemoteMetrics } from '../remote-metrics'
-import { version } from '../../../../package.json'
+import { version } from '../../../generated/version'
 
 jest.mock('unfetch', () => {
   return jest.fn()

--- a/src/core/stats/remote-metrics.ts
+++ b/src/core/stats/remote-metrics.ts
@@ -1,5 +1,5 @@
 import fetch from 'unfetch'
-import { version } from '../../../package.json'
+import { version } from '../../generated/version'
 import { getVersion } from '../../plugins/segmentio/normalize'
 
 export interface MetricsOptions {

--- a/src/generated/__tests__/version.test.ts
+++ b/src/generated/__tests__/version.test.ts
@@ -1,0 +1,18 @@
+import { version } from '../version'
+import { readFileSync } from 'fs'
+import { resolve as resolvePath } from 'path'
+
+function getPackageJsonVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(
+      resolvePath(__dirname, '..', '..', '..', 'package.json')
+    ).toString()
+  )
+  return packageJson.version
+}
+
+describe('version', () => {
+  it('matches version in package.json', async () => {
+    expect(version).toBe(getPackageJsonVersion())
+  })
+})

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,0 +1,2 @@
+/// The version is generated and should not be modified by hand.
+export const version = '1.32.0'

--- a/src/plugins/analytics-node/index.ts
+++ b/src/plugins/analytics-node/index.ts
@@ -2,7 +2,7 @@ import { Plugin } from '../../core/plugin'
 import { Context } from '../../core/context'
 import { SegmentEvent } from '../../core/events'
 import fetch from 'node-fetch'
-import { version } from '../../../package.json'
+import { version } from '../../generated/version'
 
 interface AnalyticsNodeSettings {
   writeKey: string

--- a/src/plugins/segmentio/__tests__/normalize.test.ts
+++ b/src/plugins/segmentio/__tests__/normalize.test.ts
@@ -5,7 +5,7 @@ import { normalize } from '../normalize'
 import { Analytics } from '../../../analytics'
 import { SegmentEvent } from '../../../core/events'
 import { JSDOM } from 'jsdom'
-import { version } from '../../../../package.json'
+import { version } from '../../../generated/version'
 
 describe('before loading', () => {
   let jsdom: JSDOM

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -5,7 +5,7 @@ import { SegmentEvent } from '../../core/events'
 import { tld } from '../../core/user/tld'
 import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
-import { version } from '../../../package.json'
+import { version } from '../../generated/version'
 
 let domain: string | undefined = undefined
 try {


### PR DESCRIPTION
- Replaces the package.json imports with a `version` constant that is generated at package build time. This code is heavily borrowed from @danieljackins work in https://github.com/segmentio/analytics-next/pull/331. Webpack was giving warnings that eventually we will have to use the default export when importing `package.json`, which would mean importing the entire file rather than just the version field. This strategy should be safe regardless of which bundler is used.
- Updates the version of `react`/`react-dom`/`@types/react` in the `example` project to meet the peer dependency requirements for next v11. This in addition to the above change allows `make dev` to work.

## Testing

- Added a unit test to ensure that the version constant is always in sync with what's in package.json.
- Tested with bundler (npm) example:
<img width="534" alt="npm-version" src="https://user-images.githubusercontent.com/14189820/143954012-74623620-ea72-46b0-94d2-1f51136c2c0b.png">
- Tested with standalone (web) example:
<img width="534" alt="web-version" src="https://user-images.githubusercontent.com/14189820/143954130-a774d23b-f0ab-4369-912c-e3b6515760b3.png">
