### PR TITLE
fixes npm prep-build step to be portable with mac os and linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build-prep": "sed -i '' \"s/export const version: .*$/export const version = '$npm_package_version'/\" src/generated/version.ts",
+    "build-prep": "echo \"// This file is generated.\\nexport const version = '$npm_package_version'\" > src/generated/version.ts",
     "umd": "webpack",
     "pkg": "tsc",
     "cjs": "tsc -p tsconfig.cjs.json",

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
-/// The version is generated and should not be modified by hand.
+// This file is generated.
 export const version = '1.32.0'


### PR DESCRIPTION
Updates the npm `prep-build` step to `echo` contents into a file rather than use `sed` to replace contents in a file.
Since this file contains a single constant that won't be maintained by hand, generating the full contents of the file is straightforward.

There are differences between the `sed` present on mac os versus gnu `sed`, specifically around the `-i` flag. To continue using `sed`, we'd need to specify a suffix for a backup file, then remove the backup file once the changes have been made. Either that, or ask mac os developers to install gnu sed on their system.

## Testing

Tested `make build` locally. If buildkite passes then that confirms the step works in linux as well.