### PR TITLE
updates auto-track to no longer require dependant packages to have @types/jquery to compile

### DIFF
--- a/src/core/auto-track.ts
+++ b/src/core/auto-track.ts
@@ -38,9 +38,13 @@ function linkNewTab(element: HTMLAnchorElement, href: string | null): boolean {
   return false
 }
 
+export interface JQueryShim<TElement = HTMLElement> {
+  toArray(): TElement[]
+}
+
 export function link(
   this: Analytics,
-  links: Element | Array<Element> | JQuery | null,
+  links: Element | Array<Element> | JQueryShim | null,
   event: string | Function,
   properties?: SegmentEvent['properties'] | Function
 ): Analytics {


### PR DESCRIPTION
Fixes #337 
- Updates public API (`analytics.trackLink` and any API using `link()` from auto-track.ts) to reference the `JQueryShim` interface instead of the `JQuery` type exposed from `@types/jquery`.

The `link` function in `auto-track.ts` is the only function that references the `JQuery` type from `@types/jquery` outside of tests, and is part of the public API. This function only needs to check if `toArray` exists on the `links` parameter, and this ends up being the only part of the jquery API we need to use.
This also decouples us from having to depend on a specific major version of jquery; as long as whatever version of jquery being used has the `toArray()` method that returns elements, then the compiler will be happy.

The only potential risk I see is if we decided we needed to use other jquery methods from the `link` function, but this seems extremely unlikely since the first thing we do is extract the elements from a jquery object.

## Testing

I created a repro case of the issue:
```ts
import { Analytics } from "@segment/analytics-next";
const analytics = new Analytics({writeKey: "test"});
analytics.trackLink({toArray() {return []}}, 'test')
```
and had `skipLibCheck` set to false:
```json
{
  "compilerOptions": {
    "target": "es2016",
    "module": "commonjs",
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "strict": true,
    "skipLibCheck": false
  }
}

```
Without these changes, running `npx tsc` resulted in 2 compile errors:
```
node_modules/@segment/analytics-next/dist/pkg/core/auto-track.d.ts:1:23 - error TS2688: Cannot find type definition file for 'jquery'.

1 /// <reference types="jquery" />
                        ~~~~~~

node_modules/@segment/analytics-next/dist/pkg/core/auto-track.d.ts:10:81 - error TS2304: Cannot find name 'JQuery'.

10 export declare function link(this: Analytics, links: Element | Array<Element> | JQuery | null, event: string | Function, properties?: SegmentEvent['properties'] | Function): Analytics;
```

I then installed a copy of the package with these changes and reran `npx tsc` and observed no compiler errors.