### PR TITLE
adds checks to ensure process is defined before accessing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "24.1 KB"
+      "limit": "24.8 KB"
     }
   ],
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "24.8 KB"
+      "limit": "24.7 KB"
     }
   ],
   "prettier": {

--- a/src/browser-umd.ts
+++ b/src/browser-umd.ts
@@ -1,0 +1,18 @@
+import { getCDN } from './lib/parse-cdn'
+
+if (process.env.ASSET_PATH) {
+  if (process.env.ASSET_PATH === '/dist/umd/') {
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    __webpack_public_path__ = '/dist/umd/'
+  } else {
+    const cdn = window.analytics?._cdn ?? getCDN()
+    if (window.analytics) window.analytics._cdn = cdn
+
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    __webpack_public_path__ = cdn + '/analytics-next/bundles/'
+  }
+}
+
+export * from './browser'

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,7 +1,9 @@
+import { getProcessEnv } from './lib/get-process-env'
 import { getCDN } from './lib/parse-cdn'
 
-if (process.env.ASSET_PATH) {
-  if (process.env.ASSET_PATH === '/dist/umd/') {
+const processEnv = getProcessEnv()
+if (processEnv.ASSET_PATH) {
+  if (processEnv.ASSET_PATH === '/dist/umd/') {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/camelcase
     __webpack_public_path__ = '/dist/umd/'
@@ -79,7 +81,7 @@ export function loadLegacySettings(writeKey: string): Promise<LegacySettings> {
 
 function hasLegacyDestinations(settings: LegacySettings): boolean {
   return (
-    process.env.NODE_ENV !== 'test' &&
+    processEnv.NODE_ENV !== 'test' &&
     // just one integration means segmentio
     Object.keys(settings.integrations).length > 1
   )

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,22 +1,6 @@
 import { getProcessEnv } from './lib/get-process-env'
 import { getCDN } from './lib/parse-cdn'
 
-const processEnv = getProcessEnv()
-if (processEnv.ASSET_PATH) {
-  if (processEnv.ASSET_PATH === '/dist/umd/') {
-    // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    __webpack_public_path__ = '/dist/umd/'
-  } else {
-    const cdn = window.analytics?._cdn ?? getCDN()
-    if (window.analytics) window.analytics._cdn = cdn
-
-    // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    __webpack_public_path__ = cdn + '/analytics-next/bundles/'
-  }
-}
-
 import fetch from 'unfetch'
 import { Analytics, AnalyticsSettings, InitOptions } from './analytics'
 import { Context } from './core/context'
@@ -81,7 +65,7 @@ export function loadLegacySettings(writeKey: string): Promise<LegacySettings> {
 
 function hasLegacyDestinations(settings: LegacySettings): boolean {
   return (
-    processEnv.NODE_ENV !== 'test' &&
+    getProcessEnv().NODE_ENV !== 'test' &&
     // just one integration means segmentio
     Object.keys(settings.integrations).length > 1
   )

--- a/src/lib/__tests__/get-process-env.test.ts
+++ b/src/lib/__tests__/get-process-env.test.ts
@@ -1,0 +1,5 @@
+import { getProcessEnv } from '../get-process-env'
+
+it('it matches the contents of process.env', () => {
+  expect(getProcessEnv()).toBe(process.env)
+})

--- a/src/lib/get-process-env.ts
+++ b/src/lib/get-process-env.ts
@@ -3,11 +3,9 @@
  * Always returns an object make it similarly easy to use as `process.env`.
  */
 export function getProcessEnv(): { [key: string]: string | undefined } {
-  if (typeof process === 'undefined' || process === null) {
+  if (typeof process === 'undefined' || !process.env) {
     return {}
   }
-  if (!process.env) {
-    return {}
-  }
+
   return process.env
 }

--- a/src/lib/get-process-env.ts
+++ b/src/lib/get-process-env.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns `process.env` if it is available in the environment.
+ * Always returns an object make it similarly easy to use as `process.env`.
+ */
+export function getProcessEnv(): { [key: string]: string | undefined } {
+  if (typeof process === 'undefined' || process === null) {
+    return {}
+  }
+  if (!process.env) {
+    return {}
+  }
+  return process.env
+}

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -7,7 +7,6 @@ import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
 import { version } from '../../generated/version'
 import { getProcessEnv } from '../../lib/get-process-env'
-// import { getProcessEnv } from '../../lib/get-process-env'
 
 let domain: string | undefined = undefined
 try {

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -7,6 +7,7 @@ import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
 import { version } from '../../generated/version'
 import { getProcessEnv } from '../../lib/get-process-env'
+// import { getProcessEnv } from '../../lib/get-process-env'
 
 let domain: string | undefined = undefined
 try {
@@ -27,14 +28,7 @@ if (domain) {
 
 export function getVersion(): string {
   // process.env.VERSION will only exist in webpack build.
-  try {
-    if (getProcessEnv().VERSION) {
-      return 'web'
-    }
-    return 'npm'
-  } catch {
-    return 'npm'
-  }
+  return getProcessEnv().VERSION ? 'web' : 'npm'
 }
 
 export function sCookie(key: string, value: string): string | undefined {

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -6,6 +6,7 @@ import { tld } from '../../core/user/tld'
 import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
 import { version } from '../../generated/version'
+import { getProcessEnv } from '../../lib/get-process-env'
 
 let domain: string | undefined = undefined
 try {
@@ -27,7 +28,7 @@ if (domain) {
 export function getVersion(): string {
   // process.env.VERSION will only exist in webpack build.
   try {
-    if (process.env.VERSION) {
+    if (getProcessEnv().VERSION) {
       return 'web'
     }
     return 'npm'

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -1,10 +1,8 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { getCDN } from './lib/parse-cdn'
-import { getProcessEnv } from './lib/get-process-env'
 
-const processEnv = getProcessEnv()
-if (processEnv.ASSET_PATH) {
-  if (processEnv.ASSET_PATH === '/dist/umd/') {
+if (process.env.ASSET_PATH) {
+  if (process.env.ASSET_PATH === '/dist/umd/') {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/camelcase
     __webpack_public_path__ = '/dist/umd/'

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { getCDN } from './lib/parse-cdn'
+import { getProcessEnv } from './lib/get-process-env'
 
-if (process.env.ASSET_PATH) {
-  if (process.env.ASSET_PATH === '/dist/umd/') {
+const processEnv = getProcessEnv()
+if (processEnv.ASSET_PATH) {
+  if (processEnv.ASSET_PATH === '/dist/umd/') {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/camelcase
     __webpack_public_path__ = '/dist/umd/'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ const config = {
   devtool: 'source-map',
   entry: {
     index: {
-      import: path.resolve(__dirname, 'src/browser.ts'),
+      import: path.resolve(__dirname, 'src/browser-umd.ts'),
       library: {
         name: 'AnalyticsNext',
         type: 'umd',


### PR DESCRIPTION
Fixes #303 

I added a new function - `getProcessEnv()` that returns either `process.env` if process and process.env are defined, or an empty object. Also updated all references to `process.env` to use the result from `getProcessEnv()`.

## Testing

I ran the react sample in our README with a webpack config that does not shim environment variables into the bundle. Before these changes, I saw `process is undefined` in the console. After this change, the console is clear of errors.