### PR TITLE
remove process.env requirement from getting version type

### DIFF
--- a/src/browser-umd.ts
+++ b/src/browser-umd.ts
@@ -1,4 +1,5 @@
 import { getCDN } from './lib/parse-cdn'
+import { setVersionType } from './plugins/segmentio/normalize'
 
 if (process.env.ASSET_PATH) {
   if (process.env.ASSET_PATH === '/dist/umd/') {
@@ -14,5 +15,7 @@ if (process.env.ASSET_PATH) {
     __webpack_public_path__ = cdn + '/analytics-next/bundles/'
   }
 }
+
+setVersionType('web')
 
 export * from './browser'

--- a/src/core/stats/remote-metrics.ts
+++ b/src/core/stats/remote-metrics.ts
@@ -1,6 +1,6 @@
 import fetch from 'unfetch'
 import { version } from '../../generated/version'
-import { getVersion } from '../../plugins/segmentio/normalize'
+import { getVersionType } from '../../plugins/segmentio/normalize'
 
 export interface MetricsOptions {
   host?: string
@@ -75,7 +75,7 @@ export class RemoteMetrics {
 
     formatted['library'] = 'analytics.js'
 
-    const type = getVersion()
+    const type = getVersionType()
     if (type === 'web') {
       formatted['library_version'] = `next-${version}`
     } else {

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -6,7 +6,6 @@ import { tld } from '../../core/user/tld'
 import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
 import { version } from '../../generated/version'
-import { getProcessEnv } from '../../lib/get-process-env'
 
 let domain: string | undefined = undefined
 try {
@@ -25,9 +24,15 @@ if (domain) {
   cookieOptions.domain = domain
 }
 
-export function getVersion(): string {
-  // process.env.VERSION will only exist in webpack build.
-  return getProcessEnv().VERSION ? 'web' : 'npm'
+// Default value will be updated to 'web' in `bundle-umd.ts` for web build.
+let _version: 'web' | 'npm' = 'npm'
+
+export function setVersionType(version: typeof _version) {
+  _version = version
+}
+
+export function getVersionType(): typeof _version {
+  return _version
 }
 
 export function sCookie(key: string, value: string): string | undefined {
@@ -128,7 +133,7 @@ export function normalize(
   }
 
   if (!ctx.library) {
-    const type = getVersion()
+    const type = getVersionType()
     if (type === 'web') {
       ctx.library = {
         name: 'analytics.js',

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { getCDN } from './lib/parse-cdn'
+import { setVersionType } from './plugins/segmentio/normalize'
 
 if (process.env.ASSET_PATH) {
   if (process.env.ASSET_PATH === '/dist/umd/') {
@@ -17,6 +18,8 @@ if (process.env.ASSET_PATH) {
       : 'https://cdn.segment.com/analytics-next/bundles/'
   }
 }
+
+setVersionType('web')
 
 import { install } from './standalone-analytics'
 import './lib/csp-detection'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin
-const { version } = require('./package.json')
 
 const isProd = process.env.NODE_ENV === 'production'
 const ASSET_PATH = isProd
@@ -14,7 +13,6 @@ const ASSET_PATH = isProd
 const plugins = [
   new CompressionPlugin({}),
   new webpack.EnvironmentPlugin({
-    VERSION: version,
     ASSET_PATH,
   }),
 ]


### PR DESCRIPTION
#343 made checking `process.env` safer, but it turned out this broke the UMD webpack config `EnvironmentPlugin`: it could no longer replace `process.env.VERSION` with a hard-coded value.

This change removes the need for `process.env.VERSION`. Instead, the `getVersion` (renamed to `getVersionType`) has been refactored to always return the type `npm` unless `setVersionType` is called. `setVersionType('web')` is now called from the `standalone.ts` and `browser-umd.ts` files which are only used for the hosted libraries.

This change also slightly reduces the size of the library!

## Testing

When running `make dev` and running the example, I see the `npm:` prefix on the version as expected since this example uses a bundler and not the UMD build.

When running `make standalone-example` and running the local-example, I don't see the `npm:` prefix on the version anymore (I did prior to this change).

I'd love to write a test for this but I didn't find any examples using our web build unless they were also running against classic. Is there a place to run UMD tests automatically already or is that something we can consider in the future?