### PR TITLE
persisted.ts : Strengthen conditional checking for localStorage to prevent "null" from being used

### DIFF
--- a/src/lib/priority-queue/persisted.ts
+++ b/src/lib/priority-queue/persisted.ts
@@ -11,7 +11,7 @@ let loc:
 }
 
 try {
-  loc = isBrowser() ? window.localStorage : loc
+  loc = isBrowser() && window.localStorage ? window.localStorage : loc
 } catch (err) {
   console.warn('Unable to access localStorage', err)
 }


### PR DESCRIPTION
## Summary
DOM storage can be disabled for the Android WebView which results in "window.localStorage" being "null". Currently for technical reasons I believe Gopuff's Android app has DOM storage disabled. So because of this we are adding an extra condition to check for the existence of "window.localStorage". If not truthy, then ternary will inevitably return the default "loc" object as the stubbed implementation for "localStorage".

## Testing
The discovery of the issue and what needed to be remediated involved the following in the context of me being a Gopuff developer:
- Installed and launched debug APK build of Gopuff Android app
- Opened `chrome://inspect` in Chrome browser tab
- See the following error which originates from `persisted.ts`:
<img width="735" alt="Screen Shot 2021-12-07 at 2 31 55 PM" src="https://user-images.githubusercontent.com/2925882/145293975-6281a0bc-ca1c-4086-a933-7ae33dcce024.png">

## Unit Tests
I am not sure how we would want to go about nullifying`localStorage` on the `window` for a unit test. But that's what we need to do in order to test this case where there's a `window` object(i.e. isBrowser) but the browser's local storage is disabled(i.e. `localStorage === null`) 

