### PR TITLE
update tslib to direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "dset": "^3.0.0",
     "js-cookie": "^2.2.1",
     "spark-md5": "^3.0.1",
+    "tslib": "^2.1.0",
     "unfetch": "^4.1.0"
   },
   "devDependencies": {
@@ -120,7 +121,6 @@
     "ts-jest": "^26.4.4",
     "ts-loader": "^9.1.1",
     "ts-node": "^9.0.0",
-    "tslib": "^2.1.0",
     "typescript": "^3.8.3",
     "wdio-chromedriver-service": "^6.0.4",
     "webpack": "^5.36.1",

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.32.0'
+export const version = '1.32.1'


### PR DESCRIPTION
Fixes https://github.com/segmentio/analytics-next/issues/346

Moves `tslib` from `devDependency` to `dependency`. This is needed so that devs using the package directly/bundling it themselves are guaranteed to have `tslib` available.

## Testing

No change to our bundled dist since tslib was present at build time. Tested with a new project using vite and doesn't have `tslib` available from other dependencies.

## P.S.
Looks like the generated version wasn't updated when we cut the last release.