### PR TITLE
export AnalyticsNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "sideEffects": false,
   "scripts": {
     "build-prep": "echo \"// This file is generated.\\nexport const version = '$npm_package_version'\" > src/generated/version.ts",
+    "version": "npm run build-prep",
     "umd": "webpack",
     "pkg": "tsc",
     "cjs": "tsc -p tsconfig.cjs.json",
@@ -52,6 +53,7 @@
     "@segment/tsub": "^0.1.9",
     "dset": "^3.0.0",
     "js-cookie": "^2.2.1",
+    "node-fetch": "^2.6.1",
     "spark-md5": "^3.0.1",
     "tslib": "^2.1.0",
     "unfetch": "^4.1.0"
@@ -107,7 +109,6 @@
     "micro-memoize": "^4.0.9",
     "mime": "^2.4.6",
     "ngrok": "^3.3.0",
-    "node-fetch": "^2.6.1",
     "np": "^7.5.0",
     "p-map": "^4.0.0",
     "playwright": "^1.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './analytics'
 export * from './browser'
+export * from './node'
 
 export * from './core/context'
 export * from './core/events'


### PR DESCRIPTION
Fixes #351 

`AnalyticsNode` isn't currently being exported from our package. This means the package won't work in node.js environment since it depends on the `PersistentPriorityQueue` which in turn relies on `window` being present.

One possible concern I had was that exporting `AnalyticsNode` from the `index.ts` file could add bloat when bundled. `make size` shows no change in bundle size. I also tested bundling with `webpack` and `vite` (the latter still needs the `global` fix) and tree-shaking appeared to be working properly.

## Testing

I created a simple node.js script using and confirmed I was able to see my `track` call in the segment debugger.

Sample script:
```js
const { AnalyticsNode } = require('@segment/analytics-next');

async function run() {
    const [analytics, ctx] = await AnalyticsNode.load({writeKey: 'key'});
    await analytics.track("test");
}

run().then(() => console.log('ran')).catch(console.error);
```