### PR TITLE
fix vite bundling stream error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "main": "dist/cjs/index.js",
   "module": "dist/pkg/index.js",
   "types": "dist/pkg/index.d.ts",
+  "browser": {
+    "./dist/cjs/node": "dist/cjs/node.browser.js",
+    "./dist/cjs/node.js": "dist/cjs/node.browser.js",
+    "./dist/pkg/node.js": "dist/pkg/node.browser.js",
+    "./dist/pkg/node": "./dist/pkg/node.browser.js"
+  },
   "files": [
     "dist/",
     "src/"

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.32.1'
+export const version = '1.33.0'

--- a/src/node.browser.ts
+++ b/src/node.browser.ts
@@ -1,0 +1,5 @@
+export class AnalyticsNode {
+  static async load(): Promise<never> {
+    throw new Error('AnalyticsNode is not available in browsers.')
+  }
+}


### PR DESCRIPTION
Fixes #353 

`@segment/analytics-next` version 1.33.0 began exporting `AnalyticsNode` which depends on `node-fetch`. `node-fetch` depends on some node.js APIs that aren't available in browsers, and `vite` attempted to pull them in when generating a bundle.

This change adds the `browser` field to `package.json` to provide a mapping of node.js files to browser-safe implementations. In this instance, a version of `AnalyticsNode` is added for browser bundles that throws an error if it is used.

I'm not entirely sure why `vite` isn't tree-shaking out the `AnalyticsNode` code when `AnalyticsNode` isn't being imported by an application. Nevertheless, `vite` does honor the browser field mappings.

## Testing

I tested these changes with a webpack and vite bundle.

### Why wasn't this caught in #352?
In #352 I also tested the changes with webpack and vite. What I didn't realize was that vite caches built artifacts in `node_modules/.vite`. I had initially ran `vite build` with a version of analytics-next that did not include the `AnalyticsNode` export, then after adding it ran `vite build` again. When I created a new project this time, I was able to see the `stream` error reported in #353.