### PR TITLE
Resolve indirect sourcemaps for easier debugging

### DIFF
--- a/example/next.config.js
+++ b/example/next.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  webpack: (config) => {
+    if (config.mode === 'development') {
+      config.module.rules.push({
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      })
+      if (!Array.isArray(config.ignoreWarnings)) {
+        config.ignoreWarnings = []
+      }
+
+      config.ignoreWarnings.push(/Failed to parse source map/)
+    }
+
+    return config
+  },
+}

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/faker": "^5.1.2",
-    "@types/react": "^17.0.37"
+    "@types/react": "^17.0.37",
+    "source-map-loader": "^3.0.1"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -197,6 +197,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+abab@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
+
 anser@1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.9.tgz#1f85423a5dcf8da4631a341665ff675b96845760"
@@ -938,7 +943,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -1804,6 +1809,20 @@ simple-swizzle@^0.2.2:
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
+
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
+source-map-loader@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.1.tgz#9ae5edc7c2d42570934be4c95d1ccc6352eba52d"
+  integrity sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==
+  dependencies:
+    abab "^2.0.5"
+    iconv-lite "^0.6.3"
+    source-map-js "^1.0.1"
 
 source-map@0.7.3:
   version "0.7.3"


### PR DESCRIPTION
This patch will follow and include indirect sourcemaps using `sourceMappingURL` (if available at the end of a `.js` file).

**Before**

<img width="1223" alt="before" src="https://user-images.githubusercontent.com/11316020/148468710-38d166c0-a311-44ee-bb5c-57ec13ad63c9.png">

___

**After**

<img width="1221" alt="after" src="https://user-images.githubusercontent.com/11316020/148468729-5604f3ba-6838-4341-87cd-4fa09b1210a7.png">
