### PR TITLE
fixes make release version generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "sideEffects": false,
   "scripts": {
     "build-prep": "echo \"// This file is generated.\\nexport const version = '$npm_package_version'\" > src/generated/version.ts",
-    "version": "npm run build-prep",
+    "version": "npm run build-prep && git add src/generated/version.ts",
     "umd": "webpack",
     "pkg": "tsc",
     "cjs": "tsc -p tsconfig.cjs.json",

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.33.0'
+export const version = '1.33.1'


### PR DESCRIPTION
The `make release` command was updating `src/generated/version.ts` but was not comitting it before pushing changes to the repo. This change ensures that the generated file is included in the staged changes prior to `np` comitting changes.

## Testing

Tested these changes with my fork and now see `src/generated/version.ts` being updated:
https://github.com/chrisradek/analytics-next/commit/83957a77407fff145a85dcaec2e2211c5f9e025b