### PR TITLE
Fix analytics on initialize

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -84,7 +84,7 @@ async function flushBuffered(analytics: Analytics): Promise<void> {
       // @ts-expect-error
       typeof analytics[operation] === 'function'
     ) {
-      if (operation === 'addSourceMiddleware') {
+      if (operation === 'addSourceMiddleware' || operation === 'on') {
         // @ts-expect-error
         await analytics[operation].call(analytics, ...args)
       } else {
@@ -220,9 +220,6 @@ export class AnalyticsBrowser {
       plugins
     )
 
-    analytics.initialized = true
-    analytics.emit('initialize', settings, options)
-
     if (options.initialPageview) {
       analytics.page().catch(console.error)
     }
@@ -237,6 +234,8 @@ export class AnalyticsBrowser {
     }
 
     await flushBuffered(analytics)
+    analytics.initialized = true
+    analytics.emit('initialize', settings, options)
 
     return [analytics, ctx]
   }


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

--->

This PR provides a fix to event handler registration during setup. By flushing event emitters from the buffer prior to a full buffer flush, we register the events early enough for user provided callbacks to fire as desired.

## Testing

Added a test for this change which mimics the test for `setAnoymousId`. Used `index-local`, registering `initialize` callbacks within the script tag in the example before and after load fires to ensure the callback would execute as intended. 