### PR TITLE
Use decodeURIComponent for querystring api params

### DIFF
--- a/src/core/query-string/__tests__/gracefulDecodeURIComponent.test.ts
+++ b/src/core/query-string/__tests__/gracefulDecodeURIComponent.test.ts
@@ -1,0 +1,17 @@
+import { gracefulDecodeURIComponent } from '../gracefulDecodeURIComponent'
+
+describe('gracefulDecodeURIComponent', () => {
+  it('decodes a properly encoded URI component', () => {
+    const output = gracefulDecodeURIComponent(
+      'brown+fox+jumped+%40+the+fence%3F'
+    )
+
+    expect(output).toEqual('brown fox jumped @ the fence?')
+  })
+
+  it('returns the input string back as-is when input is malformed', () => {
+    const output = gracefulDecodeURIComponent('25%%2F35%')
+
+    expect(output).toEqual('25%%2F35%')
+  })
+})

--- a/src/core/query-string/__tests__/index.test.ts
+++ b/src/core/query-string/__tests__/index.test.ts
@@ -19,6 +19,13 @@ describe('queryString', () => {
         spy.mockRestore()
       })
 
+      it('accepts encoded emails as `ajs_uid` params', async () => {
+        const spy = jest.spyOn(analytics, 'identify')
+        await queryString(analytics, '?ajs_uid=user%40example.org')
+        expect(spy).toHaveBeenCalledWith('user@example.org', {})
+        spy.mockRestore()
+      })
+
       it('applies traits if `ajs_trait_` is present', async () => {
         const spy = jest.spyOn(analytics, 'identify')
         await queryString(analytics, '?ajs_uid=1234&ajs_trait_address=123 St')

--- a/src/core/query-string/gracefulDecodeURIComponent.ts
+++ b/src/core/query-string/gracefulDecodeURIComponent.ts
@@ -1,0 +1,16 @@
+/**
+ * Tries to gets the unencoded version of an encoded component of a
+ * Uniform Resource Identifier (URI). If input string is malformed,
+ * returns it back as-is.
+ *
+ * Note: All occurences of the `+` character become ` ` (spaces).
+ **/
+export function gracefulDecodeURIComponent(
+  encodedURIComponent: string
+): string {
+  try {
+    return decodeURIComponent(encodedURIComponent.replace(/\+/g, ' '))
+  } catch {
+    return encodedURIComponent
+  }
+}

--- a/src/core/query-string/index.ts
+++ b/src/core/query-string/index.ts
@@ -1,4 +1,5 @@
 import { pickPrefix } from './pickPrefix'
+import { gracefulDecodeURIComponent } from './gracefulDecodeURIComponent'
 import { Analytics } from '../../analytics'
 import { Context } from '../context'
 
@@ -16,7 +17,7 @@ export function queryString(
 
   const params = parsed.split('&').reduce((acc: QueryStringParams, str) => {
     const [k, v] = str.split('=')
-    acc[k] = decodeURI(v).replace('+', ' ')
+    acc[k] = gracefulDecodeURIComponent(v)
     return acc
   }, {})
 

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -2,6 +2,7 @@ import { CookieAttributes, get as getCookie, set as setCookie } from 'js-cookie'
 import { Analytics } from '../../analytics'
 import { LegacySettings } from '../../browser'
 import { SegmentEvent } from '../../core/events'
+import { gracefulDecodeURIComponent } from '../../core/query-string/gracefulDecodeURIComponent'
 import { tld } from '../../core/user/tld'
 import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
@@ -61,7 +62,7 @@ export function utm(query: string): Record<string, string> {
       if (utmParam === 'campaign') {
         utmParam = 'name'
       }
-      acc[utmParam] = decodeURIComponent(v.replace(/\+/g, ' '))
+      acc[utmParam] = gracefulDecodeURIComponent(v)
     }
     return acc
   }, {} as Record<string, string>)


### PR DESCRIPTION
Fixes #342

Note: I switched the utm param processing to also use the graceful version of `decodeURIComponent`, please think about any side-effects this may have that I don't know of. I think this is preferable since it'll prevent an error like that from breaking the end-user's page.