### PR TITLE
Pull request advisory visible only to the PR author

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,10 +2,8 @@
 
 Hello! And thanks for contributing to the Analytics-Next 🎉
 
+Please add a description of your PR, including the what and why
+
+Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
+
 --->
-
-_Description of your PR, including the what and why_
-
-## Testing
-
-Please, make sure to describe how you tested this change, include any gifs or screenshots you find necessary.


### PR DESCRIPTION
When creating a pull request through CLI tools the pull request template also makes into the final comment.

This patch makes the advisory visible only to the author while the comment is being composed, it won't be visible when saved.

Let me know if anyone also wants to touch up the phrasing