### PR TITLE
[RFC] Allow messageId override

### DIFF
--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -169,7 +169,7 @@ export class EventFactory {
    * are provided in the `Options` parameter for an Event
    */
   private context(event: SegmentEvent): [object, object] {
-    const optionsKeys = ['integrations', 'anonymousId', 'timestamp', 'userId']
+    const optionsKeys = ['integrations', 'anonymousId', 'timestamp', 'userId', 'messageId']
 
     const options = event.options ?? {}
     delete options['integrations']
@@ -232,6 +232,7 @@ export class EventFactory {
     const evt: SegmentEvent = {
       ...body,
       messageId,
+      ...overrides.messageId,
     }
 
     return evt


### PR DESCRIPTION
Please view issue #370. Mainly just want to make this more easily overridden like userId and anonymousId can be per event.

tl;dr addSourceMiddleware doesn't cut it because I need to regen a messageId in my own track middleware, which is where all our events are fired and those events (outside segment's use case) need to use the same messageId.

- [ ] Test `tracking` events with messageId override
- [ ] Test `page` events with messageId override