### PR TITLE
[bugfix] honor blocking unplanned events in tracking plan

### DIFF
--- a/src/core/events/interfaces.ts
+++ b/src/core/events/interfaces.ts
@@ -155,9 +155,13 @@ export interface SegmentEvent {
  * A Plan allows users to specify events and which destinations they would like them to be sent to
  */
 export interface Plan {
-  track?: {
-    [key: string]: PlanEvent
-  }
+  track?: TrackPlan
+}
+
+export interface TrackPlan {
+  [key: string]: PlanEvent | undefined
+  // __default SHOULD always exist, but marking as optional for extra safety.
+  __default?: PlanEvent
 }
 
 export interface PlanEvent {
@@ -172,7 +176,6 @@ export interface PlanEvent {
     [key: string]: boolean
   }
 }
-
 
 export interface ReservedTraits {
   address: Partial<{

--- a/src/lib/__tests__/is-plan-event-enabled.test.ts
+++ b/src/lib/__tests__/is-plan-event-enabled.test.ts
@@ -1,0 +1,36 @@
+import { Plan } from '../../core/events/interfaces'
+import { isPlanEventEnabled } from '../is-plan-event-enabled'
+
+describe('isPlanEventEnabled', () => {
+  it('handles tracking plans that allow unplanned events', () => {
+    const plan: Plan['track'] = {
+      __default: { enabled: true, integrations: {} },
+    }
+
+    expect(isPlanEventEnabled(plan, { enabled: true, integrations: {} })).toBe(
+      true
+    )
+    expect(isPlanEventEnabled(plan, { enabled: false, integrations: {} })).toBe(
+      false
+    )
+    expect(isPlanEventEnabled(plan, undefined)).toBe(true)
+  })
+
+  it('handles tracking plans that disallow unplanned events', () => {
+    const plan: Plan['track'] = {
+      __default: { enabled: false, integrations: {} },
+    }
+
+    expect(isPlanEventEnabled(plan, { enabled: true, integrations: {} })).toBe(
+      true
+    )
+    expect(isPlanEventEnabled(plan, { enabled: false, integrations: {} })).toBe(
+      false
+    )
+    expect(isPlanEventEnabled(plan, undefined)).toBe(false)
+  })
+
+  it('allows event when tracking plan does not exist', () => {
+    expect(isPlanEventEnabled(undefined, undefined)).toBe(true)
+  })
+})

--- a/src/lib/is-plan-event-enabled.ts
+++ b/src/lib/is-plan-event-enabled.ts
@@ -1,0 +1,20 @@
+import { PlanEvent, TrackPlan } from '../core/events/interfaces'
+
+/**
+ * Determines whether a track event is allowed to be sent based on the
+ * user's tracking plan.
+ * If the user does not have a tracking plan or the event is allowed based
+ * on the tracking plan configuration, returns true.
+ */
+export function isPlanEventEnabled(
+  plan: TrackPlan | undefined,
+  planEvent: PlanEvent | undefined
+): boolean {
+  // Always prioritize the event's `enabled` status
+  if (typeof planEvent?.enabled === 'boolean') {
+    return planEvent.enabled
+  }
+
+  // Assume absence of a tracking plan means events are enabled
+  return plan?.__default?.enabled ?? true
+}

--- a/src/plugins/ajs-destination/index.ts
+++ b/src/plugins/ajs-destination/index.ts
@@ -13,6 +13,7 @@ import { isServer } from '../../core/environment'
 import { Plugin } from '../../core/plugin'
 import { attempt } from '../../core/queue/delivery'
 import { asPromise } from '../../lib/as-promise'
+import { isPlanEventEnabled } from '../../lib/is-plan-event-enabled'
 import { mergedOptions } from '../../lib/merged-options'
 import { pWhile } from '../../lib/p-while'
 import { PriorityQueue } from '../../lib/priority-queue'
@@ -24,8 +25,6 @@ import {
 import { tsubMiddleware } from '../routing-middleware'
 import { loadIntegration, resolveVersion, unloadIntegration } from './loader'
 import { LegacyIntegration } from './types'
-import { Plan, PlanEvent } from '../../core/events/interfaces'
-import { isPlanEventEnabled } from '../../lib/is-plan-event-enabled'
 
 const klona = (evt: SegmentEvent): SegmentEvent =>
   JSON.parse(JSON.stringify(evt))

--- a/src/plugins/ajs-destination/index.ts
+++ b/src/plugins/ajs-destination/index.ts
@@ -24,6 +24,8 @@ import {
 import { tsubMiddleware } from '../routing-middleware'
 import { loadIntegration, resolveVersion, unloadIntegration } from './loader'
 import { LegacyIntegration } from './types'
+import { Plan, PlanEvent } from '../../core/events/interfaces'
+import { isPlanEventEnabled } from '../../lib/is-plan-event-enabled'
 
 const klona = (evt: SegmentEvent): SegmentEvent =>
   JSON.parse(JSON.stringify(evt))
@@ -190,7 +192,7 @@ export class LegacyDestination implements Plugin {
     if (plan && ev && this.name !== 'Segment.io') {
       // events are always sent to segment (legacy behavior)
       const planEvent = plan[ev]
-      if (planEvent?.enabled === false) {
+      if (!isPlanEventEnabled(plan, planEvent)) {
         ctx.updateEvent('integrations', {
           ...ctx.event.integrations,
           All: false,

--- a/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/src/plugins/schema-filter/__tests__/index.test.ts
@@ -195,6 +195,62 @@ describe('schema filter', () => {
       expect(updateUserProfile.track).toHaveBeenCalled()
     })
 
+    it('does not drop events with same name when unplanned events are disallowed', async () => {
+      await ajs.register(
+        segment,
+        trackEvent,
+        trackPurchase,
+        updateUserProfile,
+        amplitude,
+        schemaFilter(
+          {
+            __default: { enabled: false, integrations: {} },
+            'Track Event': {
+              enabled: true,
+              integrations: {},
+            },
+          },
+          settings
+        )
+      )
+
+      await ajs.track('Track Event')
+
+      expect(segment.track).toHaveBeenCalled()
+      expect(amplitude.track).toHaveBeenCalled()
+      expect(trackEvent.track).toHaveBeenCalled()
+      expect(trackPurchase.track).toHaveBeenCalled()
+      expect(updateUserProfile.track).toHaveBeenCalled()
+    })
+
+    it('drop events with different names when unplanned events are disallowed', async () => {
+      await ajs.register(
+        segment,
+        trackEvent,
+        trackPurchase,
+        updateUserProfile,
+        amplitude,
+        schemaFilter(
+          {
+            __default: { enabled: false, integrations: {} },
+            'Fake Track Event': {
+              enabled: true,
+              integrations: {},
+            },
+          },
+          settings
+        )
+      )
+
+      await ajs.track('Track Event')
+
+      expect(segment.track).toHaveBeenCalled()
+      expect(amplitude.track).not.toHaveBeenCalled()
+      expect(trackEvent.track).not.toHaveBeenCalled()
+      expect(trackPurchase.track).not.toHaveBeenCalled()
+      expect(updateUserProfile.track).not.toHaveBeenCalled()
+    })
+
     it('drops enabled event for matching destination', async () => {
       await ajs.register(
         segment,

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -1,11 +1,12 @@
 import { LegacySettings } from '../../browser'
 import { Context } from '../../core/context'
-import { PlanEvent } from '../../core/events/interfaces'
+import { PlanEvent, TrackPlan } from '../../core/events/interfaces'
 import { Plugin } from '../../core/plugin'
+import { isPlanEventEnabled } from '../../lib/is-plan-event-enabled'
 import { RemotePlugin } from '../remote-loader'
 
 function disabledActionDestinations(
-  plan: PlanEvent,
+  plan: PlanEvent | undefined,
   settings: LegacySettings
 ): { [destination: string]: string[] } {
   if (!plan || !Object.keys(plan)) {
@@ -43,7 +44,7 @@ function disabledActionDestinations(
 }
 
 export function schemaFilter(
-  track: { [key: string]: PlanEvent } | undefined,
+  track: TrackPlan | undefined,
   settings: LegacySettings
 ): Plugin {
   function filter(ctx: Context): Context {
@@ -52,7 +53,7 @@ export function schemaFilter(
 
     if (plan && ev) {
       const planEvent = plan[ev]
-      if (planEvent?.enabled === false) {
+      if (!isPlanEventEnabled(plan, planEvent)) {
         ctx.updateEvent('integrations', {
           ...ctx.event.integrations,
           All: false,


### PR DESCRIPTION
This PR updates the schema-filter and ajs-destination plugins to properly support blocking uplanned track calls.

Our documentation currently states that a source's schema configuration can be setup to disallow unplanned track events: [documentation](https://segment.com/docs/protocols/enforce/schema-configuration/#:~:text=IMPORTANT%3A%20Unplanned%20event%20blocking%20is%20supported%20across%20all%20device%2Dmode%20and%20cloud%2Dmode%20Destinations.) 
The analytics library correctly drops events to destinations if a specific destination is disabled for an event, but the library wasn't reading the `__default` tracking plan settings that is updated when unplanned events are blocked at the source level.

I verified that the `__default` field is supposed to be present in the `settings.plan.track` object (the `__` prefix is to prevent collisions with user-provided event names, not to indicate it is private).

I tested a source using the Braze device mode (actions) destination and the classic Amplitude device mode destination, and both allow expected events and drop unplanned events after this change.