### PR TITLE
Recursively scan and convert any classes in event.properties

### DIFF
--- a/src/lib/to-facade.ts
+++ b/src/lib/to-facade.ts
@@ -14,7 +14,55 @@ export type SegmentFacade = Facade<SegmentEvent> & {
   obj: SegmentEvent
 }
 
+interface Properties {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+interface ClonedObj {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+const convertClassesToObjects = (
+  properties: Properties,
+  tmp: ClonedObj = {}
+) => {
+  if (typeof properties !== 'object') return properties
+  if (Object.prototype.toString.call(properties) === '[object Object]') {
+    if (
+      properties.constructor !== Object &&
+      typeof properties.constructor === 'function'
+    ) {
+      tmp = { ...properties }
+      for (const key in properties) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (properties.hasOwnProperty(key) && tmp[key] !== properties[key]) {
+          tmp[key] = convertClassesToObjects(properties[key])
+        }
+      }
+    } else {
+      for (const key in properties) {
+        if (key === '__proto__') {
+          Object.defineProperty(tmp, key, {
+            value: convertClassesToObjects(properties[key]),
+            configurable: true,
+            enumerable: true,
+            writable: true,
+          })
+        } else {
+          tmp[key] = convertClassesToObjects(properties[key])
+        }
+      }
+    }
+  }
+  return tmp
+}
+
 export function toFacade(evt: SegmentEvent, options?: Options): SegmentFacade {
+  if (evt.properties) {
+    evt.properties = convertClassesToObjects(evt.properties)
+  }
   let fcd = new Facade(evt, options)
 
   if (evt.type === 'track') {

--- a/src/plugins/segmentio/__tests__/index.test.ts
+++ b/src/plugins/segmentio/__tests__/index.test.ts
@@ -11,6 +11,13 @@ jest.mock('unfetch', () => {
   return jest.fn()
 })
 
+class StubbedClass {
+  name: string
+  constructor(name: string) {
+    this.name = name
+  }
+}
+
 describe('Segment.io', () => {
   let options: SegmentioSettings
   let analytics: Analytics
@@ -105,17 +112,22 @@ describe('Segment.io', () => {
 
   describe('#track', () => {
     it('should enqueue an event and properties', async () => {
-      await analytics.track('event', { prop: true }, { opt: true })
+      const stubbedClass = new StubbedClass('stub')
+      await analytics.track(
+        'event',
+        { prop: true, prop2: stubbedClass },
+        { opt: true }
+      )
       const [url, params] = spyMock.mock.calls[0]
       expect(url).toMatchInlineSnapshot(`"https://api.segment.io/v1/t"`)
 
       const body = JSON.parse(params.body)
-
       assert(body.event === 'event')
       assert(body.context.opt === true)
       assert(body.properties.prop === true)
       assert(body.traits == null)
       assert(body.timestamp)
+      expect(body.properties.prop2).toEqual({ name: 'stub' })
     })
   })
 


### PR DESCRIPTION
An edge case for when we're processing instances of classes with our cloning utilities occurs where the clone won't be properly made. The code introduced here is the code from the `klona/lite` package that `Facade` depends on, but changing this line to spread the properties of the class onto a new object instance, instead of a new class instance: https://github.com/lukeed/klona/blob/master/src/lite.js#L8

I'm wondering if there are other ways to address this issue and I'm open to feedback. We'll effectively be cloning objects twice now, and I'm wondering if we're better off doing some in-place replacement of any class instances with objects instead of full copies.