### PR TITLE
Dont load disabled action destinations

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -161,7 +161,10 @@ async function registerPlugins(
     : undefined
 
   const mergedSettings = mergedOptions(legacySettings, options)
-  const remotePlugins = await remoteLoader(legacySettings).catch(() => [])
+  const remotePlugins = await remoteLoader(
+    legacySettings,
+    analytics.integrations
+  ).catch(() => [])
 
   const toRegister = [
     validation,

--- a/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/src/plugins/remote-loader/__tests__/index.test.ts
@@ -18,17 +18,20 @@ describe('Remote Loader', () => {
   })
 
   it('should attempt to load a script from the url of each remotePlugin', async () => {
-    await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'remote plugin',
-          url: 'cdn/path/to/file.js',
-          libraryName: 'testPlugin',
-          settings: {},
-        },
-      ],
-    })
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {},
+          },
+        ],
+      },
+      {}
+    )
 
     expect(loader.loadScript).toHaveBeenCalledWith('cdn/path/to/file.js')
   })
@@ -36,35 +39,41 @@ describe('Remote Loader', () => {
   it('should attempt to load a script from a custom CDN', async () => {
     window.analytics = {}
     window.analytics._cdn = 'foo.com'
-    await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'remote plugin',
-          url: 'https://cdn.segment.com/actions/file.js',
-          libraryName: 'testPlugin',
-          settings: {},
-        },
-      ],
-    })
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'https://cdn.segment.com/actions/file.js',
+            libraryName: 'testPlugin',
+            settings: {},
+          },
+        ],
+      },
+      {}
+    )
 
     expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
   })
 
   it('should attempt calling the library', async () => {
-    await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'remote plugin',
-          url: 'cdn/path/to/file.js',
-          libraryName: 'testPlugin',
-          settings: {
-            name: 'Charlie Brown',
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {
+              name: 'Charlie Brown',
+            },
           },
-        },
-      ],
-    })
+        ],
+      },
+      {}
+    )
 
     expect(pluginFactory).toHaveBeenCalledTimes(1)
     expect(pluginFactory).toHaveBeenCalledWith(
@@ -74,18 +83,89 @@ describe('Remote Loader', () => {
     )
   })
 
+  it('should not load remote plugins when integrations object contains all: false', async () => {
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {
+              name: 'Charlie Brown',
+            },
+          },
+        ],
+      },
+      { All: false }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(0)
+  })
+
+  it('should load remote plugins when integrations object contains all: false but plugin: true', async () => {
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {
+              name: 'Charlie Brown',
+            },
+          },
+        ],
+      },
+      { All: false, 'remote plugin': true }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(1)
+    expect(pluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Charlie Brown',
+      })
+    )
+  })
+
+  it('should load remote plugin when integrations object contains plugin: false', async () => {
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {
+              name: 'Charlie Brown',
+            },
+          },
+        ],
+      },
+      { 'remote plugin': false }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(0)
+  })
+
   it('should skip remote plugins that arent callable functions', async () => {
-    const plugins = await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'remote plugin',
-          url: 'cdn/path/to/file.js',
-          libraryName: 'this wont resolve',
-          settings: {},
-        },
-      ],
-    })
+    const plugins = await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'this wont resolve',
+            settings: {},
+          },
+        ],
+      },
+      {}
+    )
 
     expect(pluginFactory).not.toHaveBeenCalled()
     expect(plugins).toHaveLength(0)
@@ -127,23 +207,26 @@ describe('Remote Loader', () => {
       return Promise.resolve(true)
     })
 
-    const plugins = await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'multiple plugins',
-          url: 'multiple-plugins.js',
-          libraryName: 'multiple-plugins',
-          settings: { foo: true },
-        },
-        {
-          name: 'single plugin',
-          url: 'single-plugin.js',
-          libraryName: 'single-plugin',
-          settings: { bar: false },
-        },
-      ],
-    })
+    const plugins = await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'multiple plugins',
+            url: 'multiple-plugins.js',
+            libraryName: 'multiple-plugins',
+            settings: { foo: true },
+          },
+          {
+            name: 'single plugin',
+            url: 'single-plugin.js',
+            libraryName: 'single-plugin',
+            settings: { bar: false },
+          },
+        ],
+      },
+      {}
+    )
 
     expect(plugins).toHaveLength(3)
     expect(plugins).toEqual(expect.arrayContaining([one, two, three]))
@@ -165,23 +248,26 @@ describe('Remote Loader', () => {
       return Promise.resolve(true)
     })
 
-    const plugins = await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'flaky plugin',
-          url: 'cdn/path/to/flaky.js',
-          libraryName: 'flaky',
-          settings: {},
-        },
-        {
-          name: 'async flaky plugin',
-          url: 'cdn/path/to/asyncFlaky.js',
-          libraryName: 'asyncFlaky',
-          settings: {},
-        },
-      ],
-    })
+    const plugins = await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'flaky plugin',
+            url: 'cdn/path/to/flaky.js',
+            libraryName: 'flaky',
+            settings: {},
+          },
+          {
+            name: 'async flaky plugin',
+            url: 'cdn/path/to/asyncFlaky.js',
+            libraryName: 'asyncFlaky',
+            settings: {},
+          },
+        ],
+      },
+      {}
+    )
 
     expect(pluginFactory).not.toHaveBeenCalled()
     expect(plugins).toHaveLength(0)
@@ -213,23 +299,26 @@ describe('Remote Loader', () => {
       return Promise.resolve(true)
     })
 
-    const plugins = await remoteLoader({
-      integrations: {},
-      remotePlugins: [
-        {
-          name: 'valid plugin',
-          url: 'valid',
-          libraryName: 'valid',
-          settings: { foo: true },
-        },
-        {
-          name: 'invalid plugin',
-          url: 'invalid',
-          libraryName: 'invalid',
-          settings: { bar: false },
-        },
-      ],
-    })
+    const plugins = await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'valid plugin',
+            url: 'valid',
+            libraryName: 'valid',
+            settings: { foo: true },
+          },
+          {
+            name: 'invalid plugin',
+            url: 'invalid',
+            libraryName: 'invalid',
+            settings: { bar: false },
+          },
+        ],
+      },
+      {}
+    )
 
     expect(plugins).toHaveLength(1)
     expect(plugins).toEqual(expect.arrayContaining([validPlugin]))

--- a/src/plugins/remote-loader/index.ts
+++ b/src/plugins/remote-loader/index.ts
@@ -1,3 +1,4 @@
+import type { Integrations } from '../../core/events/interfaces'
 import { LegacySettings } from '../../browser'
 import { JSONValue } from '../../core/events'
 import { Plugin } from '../../core/plugin'
@@ -42,13 +43,19 @@ function validate(pluginLike: unknown): pluginLike is Plugin[] {
 }
 
 export async function remoteLoader(
-  settings: LegacySettings
+  settings: LegacySettings,
+  integrations: Integrations
 ): Promise<Plugin[]> {
   const allPlugins: Plugin[] = []
   const cdn = window.analytics?._cdn ?? getCDN()
 
   const pluginPromises = (settings.remotePlugins ?? []).map(
     async (remotePlugin) => {
+      if (
+        (integrations.All === false && !integrations[remotePlugin.name]) ||
+        integrations[remotePlugin.name] === false
+      )
+        return
       try {
         await loadScript(
           remotePlugin.url.replace('https://cdn.segment.com', cdn)


### PR DESCRIPTION
This PR makes action destinations respect the same logic as legacy destinations in the integrations object

Testing completed locally with a source with multiple action destinations enabled. Setting All: false and Fullstory (Actions): true properly only loads the fullstory actions:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/2866515/156454971-2bb435f5-1607-48a8-8841-00eedb1eb765.png">
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/2866515/156455198-141b027b-ef0b-4568-b387-ca9253af571f.png">
