### PR TITLE
Load obfuscated destinations

### DIFF
--- a/qa/__tests__/destinations.test.ts
+++ b/qa/__tests__/destinations.test.ts
@@ -44,11 +44,13 @@ describe('Destination Tests', () => {
     const writeKey = samples[key][0]
 
     const [url, chrome] = await Promise.all([server(), browser()])
+
     const results = await run({
       browser: chrome,
       script: code,
       serverURL: url,
       writeKey,
+      key,
     })
 
     const classicReqs = results.classic.networkRequests

--- a/qa/lib/runner.ts
+++ b/qa/lib/runner.ts
@@ -85,6 +85,8 @@ export async function run(params: ComparisonParams) {
       '&wk=' +
       source
 
+    console.log(url)
+
     await page.goto(url)
 
     // This forces every timestamp to look exactly the same

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -52,6 +52,7 @@ export interface InitOptions {
   integrations?: Integrations
   plan?: Plan
   retryQueue?: boolean
+  obfuscate?: boolean
 }
 
 export class Analytics extends Emitter {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -199,7 +199,11 @@ async function registerPlugins(
     await import(
       /* webpackChunkName: "remoteMiddleware" */ './plugins/remote-middleware'
     ).then(async ({ remoteMiddlewares }) => {
-      const middleware = await remoteMiddlewares(ctx, legacySettings)
+      const middleware = await remoteMiddlewares(
+        ctx,
+        legacySettings,
+        options.obfuscate
+      )
       const promises = middleware.map((mdw) =>
         analytics.addSourceMiddleware(mdw)
       )

--- a/src/plugins/ajs-destination/index.ts
+++ b/src/plugins/ajs-destination/index.ts
@@ -115,14 +115,13 @@ export class LegacyDestination implements Plugin {
       return
     }
 
-    // Figure out how to consume options.obfuscate or settings.obfuscate here
-
     this.integration = await loadIntegration(
       ctx,
       analyticsInstance,
       this.name,
       this.version,
-      this.settings
+      this.settings,
+      this.options.obfuscate
     )
 
     this.onReady = new Promise((resolve) => {
@@ -161,7 +160,7 @@ export class LegacyDestination implements Plugin {
   }
 
   unload(_ctx: Context, _analyticsInstance: Analytics): Promise<void> {
-    return unloadIntegration(this.name, this.version)
+    return unloadIntegration(this.name, this.version, this.options.obfuscate)
   }
 
   addMiddleware(...fn: DestinationMiddlewareFunction[]): void {

--- a/src/plugins/ajs-destination/index.ts
+++ b/src/plugins/ajs-destination/index.ts
@@ -115,6 +115,8 @@ export class LegacyDestination implements Plugin {
       return
     }
 
+    // Figure out how to consume options.obfuscate or settings.obfuscate here
+
     this.integration = await loadIntegration(
       ctx,
       analyticsInstance,
@@ -353,7 +355,6 @@ export async function ajsDestinations(
       if ((!deviceMode && name !== 'Segment.io') || name === 'Iterable') {
         return
       }
-
       const version = resolveVersion(integrationSettings)
       const destination = new LegacyDestination(
         name,

--- a/src/plugins/ajs-destination/loader.ts
+++ b/src/plugins/ajs-destination/loader.ts
@@ -13,7 +13,7 @@ function normalizeName(name: string): string {
   return name.toLowerCase().replace('.', '').replace(/\s+/g, '-')
 }
 
-function obfuscatePathName(pathName: string, obfuscate = false): string {
+function obfuscatePathName(pathName: string, obfuscate = false): string | void {
   return obfuscate ? btoa(pathName).replace(/=/g, '') : undefined
 }
 

--- a/src/plugins/ajs-destination/loader.ts
+++ b/src/plugins/ajs-destination/loader.ts
@@ -33,14 +33,17 @@ export async function loadIntegration(
   analyticsInstance: Analytics,
   name: string,
   version: string,
-  settings?: { [key: string]: any }
+  settings?: { [key: string]: any },
+  obfuscate?: boolean
 ): Promise<LegacyIntegration> {
   const pathName = normalizeName(name)
   let obfuscatedPathName = ''
-  if (settings?.obfuscate) {
+  if (obfuscate) {
     obfuscatedPathName = btoa(pathName).replace(/=/g, '')
   }
-  const fullPath = `https://cdn.segment.build/next-integrations/integrations-2.0/integrations/b3B0aW1pemVseQ/${version}/b3B0aW1pemVseQ.dynamic.js.gz`
+  const fullPath = `${path}/integrations/${
+    obfuscate ? obfuscatedPathName : pathName
+  }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`
 
   try {
     await loadScript(fullPath)
@@ -80,12 +83,19 @@ export async function loadIntegration(
 
 export async function unloadIntegration(
   name: string,
-  version: string
+  version: string,
+  obfuscate?: boolean
 ): Promise<void> {
   const pathName = normalizeName(name)
-  return unloadScript(
-    `${path}/integrations/${pathName}/${version}/${pathName}.dynamic.js.gz`
-  )
+  let obfuscatedPathName = ''
+  if (obfuscate) {
+    obfuscatedPathName = btoa(pathName).replace(/=/g, '')
+  }
+  const fullPath = `${path}/integrations/${
+    obfuscate ? obfuscatedPathName : pathName
+  }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`
+
+  return unloadScript(fullPath)
 }
 
 export function resolveVersion(

--- a/src/plugins/ajs-destination/loader.ts
+++ b/src/plugins/ajs-destination/loader.ts
@@ -14,7 +14,7 @@ function normalizeName(name: string): string {
 }
 
 function obfuscatePathName(pathName: string, obfuscate = false): string {
-  return obfuscate ? btoa(pathName).replace(/=/g, '') : ''
+  return obfuscate ? btoa(pathName).replace(/=/g, '') : undefined
 }
 
 function recordLoadMetrics(fullPath: string, ctx: Context, name: string): void {
@@ -44,8 +44,8 @@ export async function loadIntegration(
   const obfuscatedPathName = obfuscatePathName(pathName, obfuscate)
 
   const fullPath = `${path}/integrations/${
-    obfuscate ? obfuscatedPathName : pathName
-  }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`
+    obfuscatedPathName ?? pathName
+  }/${version}/${obfuscatedPathName ?? pathName}.dynamic.js.gz`
 
   try {
     await loadScript(fullPath)
@@ -92,8 +92,8 @@ export async function unloadIntegration(
   const obfuscatedPathName = obfuscatePathName(name, obfuscate)
 
   const fullPath = `${path}/integrations/${
-    obfuscate ? obfuscatedPathName : pathName
-  }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`
+    obfuscatedPathName ?? pathName
+  }/${version}/${obfuscatedPathName ?? pathName}.dynamic.js.gz`
 
   return unloadScript(fullPath)
 }

--- a/src/plugins/ajs-destination/loader.ts
+++ b/src/plugins/ajs-destination/loader.ts
@@ -33,10 +33,14 @@ export async function loadIntegration(
   analyticsInstance: Analytics,
   name: string,
   version: string,
-  settings?: object
+  settings?: { [key: string]: any }
 ): Promise<LegacyIntegration> {
   const pathName = normalizeName(name)
-  const fullPath = `${path}/integrations/${pathName}/${version}/${pathName}.dynamic.js.gz`
+  let obfuscatedPathName = ''
+  if (settings?.obfuscate) {
+    obfuscatedPathName = btoa(pathName).replace(/=/g, '')
+  }
+  const fullPath = `https://cdn.segment.build/next-integrations/integrations-2.0/integrations/b3B0aW1pemVseQ/${version}/b3B0aW1pemVseQ.dynamic.js.gz`
 
   try {
     await loadScript(fullPath)

--- a/src/plugins/ajs-destination/loader.ts
+++ b/src/plugins/ajs-destination/loader.ts
@@ -13,6 +13,10 @@ function normalizeName(name: string): string {
   return name.toLowerCase().replace('.', '').replace(/\s+/g, '-')
 }
 
+function obfuscatePathName(pathName: string, obfuscate = false): string {
+  return obfuscate ? btoa(pathName).replace(/=/g, '') : ''
+}
+
 function recordLoadMetrics(fullPath: string, ctx: Context, name: string): void {
   try {
     const [metric] =
@@ -37,10 +41,8 @@ export async function loadIntegration(
   obfuscate?: boolean
 ): Promise<LegacyIntegration> {
   const pathName = normalizeName(name)
-  let obfuscatedPathName = ''
-  if (obfuscate) {
-    obfuscatedPathName = btoa(pathName).replace(/=/g, '')
-  }
+  const obfuscatedPathName = obfuscatePathName(pathName, obfuscate)
+
   const fullPath = `${path}/integrations/${
     obfuscate ? obfuscatedPathName : pathName
   }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`
@@ -87,10 +89,8 @@ export async function unloadIntegration(
   obfuscate?: boolean
 ): Promise<void> {
   const pathName = normalizeName(name)
-  let obfuscatedPathName = ''
-  if (obfuscate) {
-    obfuscatedPathName = btoa(pathName).replace(/=/g, '')
-  }
+  const obfuscatedPathName = obfuscatePathName(name, obfuscate)
+
   const fullPath = `${path}/integrations/${
     obfuscate ? obfuscatedPathName : pathName
   }/${version}/${obfuscate ? obfuscatedPathName : pathName}.dynamic.js.gz`

--- a/src/plugins/remote-middleware/index.ts
+++ b/src/plugins/remote-middleware/index.ts
@@ -10,7 +10,8 @@ const path = cdn + '/next-integrations'
 
 export async function remoteMiddlewares(
   ctx: Context,
-  settings: LegacySettings
+  settings: LegacySettings,
+  obfuscate?: boolean
 ): Promise<MiddlewareFunction[]> {
   if (isServer()) {
     return []
@@ -23,7 +24,11 @@ export async function remoteMiddlewares(
 
   const scripts = names.map(async (name) => {
     const nonNamespaced = name.replace('@segment/', '')
-    const fullPath = `${path}/middleware/${nonNamespaced}/latest/${nonNamespaced}.js.gz`
+    let bundleName = nonNamespaced
+    if (obfuscate) {
+      bundleName = btoa(nonNamespaced).replace(/=/g, '')
+    }
+    const fullPath = `${path}/middleware/${bundleName}/latest/${bundleName}.js.gz`
 
     try {
       await loadScript(fullPath)


### PR DESCRIPTION
In tandem with https://github.com/segmentio/analytics.js-integrations/pull/665, this will enable bundle obfuscation to be served to our customers who opt in. There's no strict timing on when one or the other needs to be merged as we have not yet provided documentation on how to use this feature.

The idea here is that consumers can pass `obfuscate: true` to the second argument of `analytics.load`, and we will fetch the obfuscated bundle files for the users.

Originally I thought I would need to translate the obfuscated file names using `atob`, but it turns out we pull in from workspace settings where those destinations are already in plain text in order to kick off other loading processes and setup, so that work was not needed.

Tested by pointing the paths for integrations and middleware to the staging bucket where I uploaded the obfuscated paths, where I was able to successfully load the obfuscated bundles.