### PR TITLE
add cdnSettings field to AnalyticsBrowserSettings

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -53,6 +53,15 @@ export interface LegacySettings {
   remotePlugins?: RemotePlugin[]
 }
 
+export interface AnalyticsBrowserSettings extends AnalyticsSettings {
+  /**
+   * The settings for the Segment Source.
+   * If provided, `AnalyticsBrowser` will not fetch remote settings
+   * for the source.
+   */
+  cdnSettings?: LegacySettings & Record<string, unknown>
+}
+
 export function loadLegacySettings(writeKey: string): Promise<LegacySettings> {
   const cdn = window.analytics?._cdn ?? getCDN()
   return fetch(`${cdn}/v1/projects/${writeKey}/settings`)
@@ -215,10 +224,11 @@ async function registerPlugins(
 
 export class AnalyticsBrowser {
   static async load(
-    settings: AnalyticsSettings,
+    settings: AnalyticsBrowserSettings,
     options: InitOptions = {}
   ): Promise<[Analytics, Context]> {
-    const legacySettings = await loadLegacySettings(settings.writeKey)
+    const legacySettings =
+      settings.cdnSettings ?? (await loadLegacySettings(settings.writeKey))
 
     const retryQueue: boolean =
       legacySettings.integrations['Segment.io']?.retryQueue ?? true


### PR DESCRIPTION
This resolves #304 by allowing users to pass Source settings directly to `analytics.load()` via the `cdnSettings` field in `AnalyticsBrowserSettings`.

When `cdnSettings` are passed in, a.js will __not__ hit the CDN to retrieve Source settings.

