### PR TITLE
feat: change api to be functional

### DIFF
--- a/example/pages/iframe/index.tsx
+++ b/example/pages/iframe/index.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { TEST_WRITEKEY } from '../../../src/__tests__/test-writekeys'
 
-import {
-  AnalyticsSettings,
-  AnalyticsBrowser,
-  Analytics,
-} from '../../../dist/pkg'
+import { AnalyticsSettings, loadBrowser, Analytics } from '../../../dist/pkg'
 
 const settings: AnalyticsSettings = {
   writeKey: TEST_WRITEKEY,
@@ -17,7 +13,7 @@ export default function Iframe(): React.ReactElement {
   const [writeKey] = useState<string>(settings.writeKey)
 
   async function fetchAnalytics() {
-    const [response] = await AnalyticsBrowser.load({
+    const [response] = await loadBrowser({
       ...settings,
       writeKey,
     })

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import Head from 'next/head'
 import Editor from 'react-simple-code-editor'
 import { highlight, languages } from 'prismjs/components/prism-core'
@@ -8,7 +8,7 @@ import faker from 'faker'
 import { shuffle } from 'lodash'
 import Table from 'rc-table'
 
-import { AnalyticsSettings, AnalyticsBrowser, Analytics, Context } from '../../'
+import { AnalyticsSettings, loadBrowser, Analytics, Context } from '../../'
 
 const jsontheme = {
   scheme: 'tomorrow',
@@ -66,7 +66,7 @@ export default function Home(): React.ReactElement {
   const [ctx, setCtx] = React.useState<Context>()
 
   async function fetchAnalytics() {
-    const [response, ctx] = await AnalyticsBrowser.load({
+    const [response, ctx] = await loadBrowser({
       ...settings,
       writeKey,
     })

--- a/qa/lib/stats.ts
+++ b/qa/lib/stats.ts
@@ -1,6 +1,6 @@
 import { Analytics } from '../../src/analytics'
 import { Context } from '../../src/core/context'
-import { AnalyticsNode } from '../../src/node'
+import { loadNode } from '../../src/node'
 import ex from 'execa'
 
 let analytics: Analytics = undefined
@@ -13,7 +13,7 @@ async function client(): Promise<Analytics> {
     return analytics
   }
 
-  const [nodeAnalytics] = await AnalyticsNode.load({
+  const [nodeAnalytics] = await loadNode({
     writeKey: process.env.STATS_WRITEKEY,
   })
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -6,7 +6,7 @@ import { Group } from '../core/user'
 import { LegacyDestination } from '../plugins/ajs-destination'
 import { PersistedPriorityQueue } from '../lib/priority-queue/persisted'
 // @ts-ignore loadLegacySettings mocked dependency is accused as unused
-import { AnalyticsBrowser, loadLegacySettings } from '../browser'
+import { loadBrowser, loadLegacySettings } from '../browser'
 // @ts-ignore isOffline mocked dependency is accused as unused
 import { isOffline } from '../core/connection'
 import * as SegmentPlugin from '../plugins/segmentio'
@@ -72,7 +72,7 @@ describe('Initialization', () => {
   })
 
   it('loads plugins', async () => {
-    await AnalyticsBrowser.load({
+    await loadBrowser({
       writeKey,
       plugins: [xt],
     })
@@ -100,7 +100,7 @@ describe('Initialization', () => {
     }
 
     jest.spyOn(lazyPlugin, 'load')
-    await AnalyticsBrowser.load({ writeKey, plugins: [lazyPlugin] })
+    await loadBrowser({ writeKey, plugins: [lazyPlugin] })
 
     expect(lazyPlugin.load).toHaveBeenCalled()
     expect(onLoad).not.toHaveBeenCalled()
@@ -141,7 +141,7 @@ describe('Initialization', () => {
 
     jest.spyOn(lazyPlugin1, 'load')
     jest.spyOn(lazyPlugin2, 'load')
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [lazyPlugin1, lazyPlugin2, xt],
     })
@@ -164,7 +164,7 @@ describe('Initialization', () => {
     const mockPage = jest.fn().mockImplementation(() => Promise.resolve())
     Analytics.prototype.page = mockPage
 
-    await AnalyticsBrowser.load({ writeKey }, { initialPageview: true })
+    await loadBrowser({ writeKey }, { initialPageview: true })
 
     expect(mockPage).toHaveBeenCalled()
   })
@@ -173,7 +173,7 @@ describe('Initialization', () => {
     jest.mock('../analytics')
     const mockPage = jest.fn()
     Analytics.prototype.page = mockPage
-    await AnalyticsBrowser.load({ writeKey }, { initialPageview: false })
+    await loadBrowser({ writeKey }, { initialPageview: false })
     expect(mockPage).not.toHaveBeenCalled()
   })
 
@@ -184,7 +184,7 @@ describe('Initialization', () => {
       const options: { integrations: { [key: string]: boolean } } = {
         integrations: { All: false },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(settings, options)
+      const analyticsResponse = await loadBrowser(settings, options)
 
       const segmentio = analyticsResponse[0].queue.plugins.find(
         (p) => p.name === 'Segment.io'
@@ -197,7 +197,7 @@ describe('Initialization', () => {
       const options: { integrations?: { [key: string]: boolean } } = {
         integrations: { 'Segment.io': false },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(settings, options)
+      const analyticsResponse = await loadBrowser(settings, options)
 
       const segmentio = analyticsResponse[0].queue.plugins.find(
         (p) => p.name === 'Segment.io'
@@ -210,7 +210,7 @@ describe('Initialization', () => {
       const options: { integrations: { [key: string]: boolean } } = {
         integrations: { All: false, 'Segment.io': true },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(settings, options)
+      const analyticsResponse = await loadBrowser(settings, options)
 
       const segmentio = analyticsResponse[0].queue.plugins.find(
         (p) => p.name === 'Segment.io'
@@ -223,7 +223,7 @@ describe('Initialization', () => {
       const options: { integrations: { [key: string]: boolean } } = {
         integrations: { 'Segment.io': true },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(settings, options)
+      const analyticsResponse = await loadBrowser(settings, options)
 
       const segmentio = analyticsResponse[0].queue.plugins.find(
         (p) => p.name === 'Segment.io'
@@ -236,7 +236,7 @@ describe('Initialization', () => {
       const options: { integrations?: { [key: string]: boolean } } = {
         integrations: undefined,
       }
-      const analyticsResponse = await AnalyticsBrowser.load(settings, options)
+      const analyticsResponse = await loadBrowser(settings, options)
 
       const segmentio = analyticsResponse[0].queue.plugins.find(
         (p) => p.name === 'Segment.io'
@@ -252,7 +252,7 @@ describe('Initialization', () => {
           'Segment.io': false,
         },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(
+      const analyticsResponse = await loadBrowser(
         { ...settings, plugins: [xt] },
         options
       )
@@ -277,7 +277,7 @@ describe('Initialization', () => {
           'Segment.io': false,
         },
       }
-      const analyticsResponse = await AnalyticsBrowser.load(
+      const analyticsResponse = await loadBrowser(
         { ...settings, plugins: [xt] },
         options
       )
@@ -298,7 +298,7 @@ describe('Initialization', () => {
 
 describe('Dispatch', () => {
   it('dispatches events to destinations', async () => {
-    const [ajs] = await AnalyticsBrowser.load({
+    const [ajs] = await loadBrowser({
       writeKey,
       plugins: [amplitude, googleAnalytics],
     })
@@ -316,7 +316,7 @@ describe('Dispatch', () => {
   })
 
   it('does not dispatch events to destinations on deny list', async () => {
-    const [ajs] = await AnalyticsBrowser.load({
+    const [ajs] = await loadBrowser({
       writeKey,
       plugins: [amplitude, googleAnalytics],
     })
@@ -342,7 +342,7 @@ describe('Dispatch', () => {
   })
 
   it('enriches events before dispatching', async () => {
-    const [ajs] = await AnalyticsBrowser.load({
+    const [ajs] = await loadBrowser({
       writeKey,
       plugins: [enrichBilling, amplitude, googleAnalytics],
     })
@@ -360,7 +360,7 @@ describe('Dispatch', () => {
   })
 
   it('collects metrics for every event', async () => {
-    const [ajs] = await AnalyticsBrowser.load({
+    const [ajs] = await loadBrowser({
       writeKey,
       plugins: [amplitude],
     })
@@ -388,7 +388,7 @@ describe('Dispatch', () => {
 
 describe('Group', () => {
   it('manages Group state', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
 
@@ -408,7 +408,7 @@ describe('Group', () => {
 
 describe('Alias', () => {
   it('generates alias events', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude],
     })
@@ -425,7 +425,7 @@ describe('Alias', () => {
 
   it('falls back to userID in cookies if no id passed', async () => {
     jar.set('ajs_user_id', 'dan')
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude],
     })
@@ -453,7 +453,7 @@ describe('pageview', () => {
 
 describe('setAnonymousId', () => {
   it('calling setAnonymousId will set a new anonymousId and returns it', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude],
     })
@@ -471,7 +471,7 @@ describe('setAnonymousId', () => {
 
 describe('addSourceMiddleware', () => {
   it('supports registering source middlewares', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
 
@@ -522,7 +522,7 @@ describe('addDestinationMiddleware', () => {
   })
 
   it('supports registering destination middlewares', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
 
@@ -567,7 +567,7 @@ describe('addDestinationMiddleware', () => {
 
 describe('use', () => {
   it('registers a legacyPlugin', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
 
@@ -580,7 +580,7 @@ describe('use', () => {
 
 describe('timeout', () => {
   it('has a default timeout value', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
     //@ts-ignore
@@ -588,7 +588,7 @@ describe('timeout', () => {
   })
 
   it('can set a timeout value', async () => {
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
     })
     analytics.timeout(50)
@@ -632,7 +632,7 @@ describe('deregister', () => {
     )
     xt.unload = unload
 
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [xt],
     })
@@ -651,7 +651,7 @@ describe('deregister', () => {
       {}
     )
 
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude],
     })
@@ -690,7 +690,7 @@ describe('retries', () => {
   })
 
   it('does not retry errored events if retryQueue setting is set to false', async () => {
-    const [ajs] = await AnalyticsBrowser.load(
+    const [ajs] = await loadBrowser(
       { writeKey: TEST_WRITEKEY },
       { retryQueue: false }
     )
@@ -726,7 +726,7 @@ describe('retries', () => {
   })
 
   it('does not queue up events when offline if retryQueue setting is set to false', async () => {
-    const [ajs] = await AnalyticsBrowser.load({ writeKey })
+    const [ajs] = await loadBrowser({ writeKey })
 
     await ajs.queue.register(
       Context.system(),
@@ -752,7 +752,7 @@ describe('Segment.io overrides', () => {
   it('allows for overriding Segment.io settings', async () => {
     jest.spyOn(SegmentPlugin, 'segmentio')
 
-    await AnalyticsBrowser.load(
+    await loadBrowser(
       { writeKey },
       {
         integrations: {
@@ -814,7 +814,7 @@ describe('.Integrations', () => {
 
     const ga = new LegacyDestination('Google-Analytics', 'latest', {}, {})
 
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude, ga],
     })
@@ -842,7 +842,7 @@ describe('.Integrations', () => {
     const ga = new LegacyDestination('Google-Analytics', 'latest', {}, {})
     const customerIO = new LegacyDestination('Customer.io', 'latest', {}, {})
 
-    const [analytics] = await AnalyticsBrowser.load({
+    const [analytics] = await loadBrowser({
       writeKey,
       plugins: [amplitude, ga, customerIO],
     })

--- a/src/__tests__/node-integration.test.ts
+++ b/src/__tests__/node-integration.test.ts
@@ -1,10 +1,10 @@
-import { AnalyticsNode } from '../node'
+import { loadNode } from '../node'
 
 const writeKey = 'foo'
 
 describe('Initialization', () => {
   it('loads analytics-node-next plugin', async () => {
-    const [analytics] = await AnalyticsNode.load({
+    const [analytics] = await loadNode({
       writeKey,
     })
 

--- a/src/__tests__/query-string.integration.test.ts
+++ b/src/__tests__/query-string.integration.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom'
 import { Analytics } from '../analytics'
 // @ts-ignore loadLegacySettings mocked dependency is accused as unused
-import { AnalyticsBrowser } from '../browser'
+import { loadBrowser } from '../browser'
 import { TEST_WRITEKEY } from './test-writekeys'
 
 const writeKey = TEST_WRITEKEY
@@ -46,7 +46,7 @@ describe('queryString', () => {
       url: 'https://localhost/?ajs_id=123',
     })
 
-    await AnalyticsBrowser.load({ writeKey })
+    await loadBrowser({ writeKey })
     expect(mockQueryString).toHaveBeenCalledWith('?ajs_id=123')
   })
 
@@ -61,14 +61,14 @@ describe('queryString', () => {
       url: 'https://localhost/#/?ajs_id=123',
     })
 
-    await AnalyticsBrowser.load({ writeKey })
+    await loadBrowser({ writeKey })
     expect(mockQueryString).toHaveBeenCalledWith('?ajs_id=123')
 
     jsd.reconfigure({
       url: 'https://localhost/#about?ajs_id=123',
     })
 
-    await AnalyticsBrowser.load({ writeKey })
+    await loadBrowser({ writeKey })
     expect(mockQueryString).toHaveBeenCalledWith('?ajs_id=123')
   })
 
@@ -83,7 +83,7 @@ describe('queryString', () => {
       url: 'https://localhost/#about?ajs_id=123',
     })
 
-    await AnalyticsBrowser.load({ writeKey })
+    await loadBrowser({ writeKey })
     expect(mockQueryString).toHaveBeenCalledWith('?ajs_id=123')
   })
 })

--- a/src/__tests__/standalone-analytics.test.ts
+++ b/src/__tests__/standalone-analytics.test.ts
@@ -1,5 +1,6 @@
 import jsdom, { JSDOM } from 'jsdom'
-import { AnalyticsBrowser, loadLegacySettings } from '../browser'
+import { loadLegacySettings } from '../browser'
+import * as AnalyticsBrowser from '../browser'
 import { snippet } from '../tester/__fixtures__/segment-snippet'
 import { install } from '../standalone-analytics'
 import { mocked } from 'ts-jest/utils'
@@ -102,7 +103,7 @@ describe('standalone bundle', () => {
     }
 
     const spy = jest
-      .spyOn(AnalyticsBrowser, 'standalone')
+      .spyOn(AnalyticsBrowser, 'standaloneBrowser')
       .mockResolvedValueOnce((fakeAjs as unknown) as Analytics)
 
     await install()
@@ -117,7 +118,7 @@ describe('standalone bundle', () => {
       },
     }
     const spy = jest
-      .spyOn(AnalyticsBrowser, 'standalone')
+      .spyOn(AnalyticsBrowser, 'standaloneBrowser')
       .mockResolvedValueOnce((fakeAjs as unknown) as Analytics)
 
     await install()

--- a/src/__tests__/standalone-errors.test.ts
+++ b/src/__tests__/standalone-errors.test.ts
@@ -1,5 +1,6 @@
 import jsdom, { JSDOM } from 'jsdom'
-import { AnalyticsBrowser, LegacySettings } from '../browser'
+import { LegacySettings } from '../browser'
+import * as AnalyticsBrowser from '../browser'
 import { snippet } from '../tester/__fixtures__/segment-snippet'
 import { pWhile } from '../lib/p-while'
 import { mocked } from 'ts-jest/utils'
@@ -100,7 +101,7 @@ describe('standalone bundle', () => {
       })
 
     jest
-      .spyOn(AnalyticsBrowser, 'standalone')
+      .spyOn(AnalyticsBrowser, 'standaloneBrowser')
       .mockRejectedValueOnce(new Error('Ohhh nooo'))
 
     await import('../standalone')

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,4 @@
-import { AnalyticsBrowser } from './browser'
+import { loadBrowser } from './browser'
 import {
   AliasParams,
   DispatchedEvent,
@@ -427,7 +427,7 @@ export class Analytics extends Emitter {
   ): Promise<Analytics> {
     console.warn(deprecationWarning)
     if (settings) {
-      await AnalyticsBrowser.load(settings, options)
+      await loadBrowser(settings, options)
     }
     this.options = options || {}
     return this

--- a/src/node.ts
+++ b/src/node.ts
@@ -6,31 +6,26 @@ import { Plugin } from './core/plugin'
 import { EventQueue } from './core/queue/event-queue'
 import { PriorityQueue } from './lib/priority-queue'
 
-export class AnalyticsNode {
-  static async load(settings: {
-    writeKey: string
-  }): Promise<[Analytics, Context]> {
-    const cookieOptions = {
-      persist: false,
-    }
-
-    const queue = new EventQueue(new PriorityQueue(3, []))
-    const options = { user: cookieOptions, group: cookieOptions }
-    const analytics = new Analytics(settings, options, queue)
-
-    const nodeSettings = {
-      writeKey: settings.writeKey,
-      name: 'analytics-node-next',
-      type: 'after' as Plugin['type'],
-      version: 'latest',
-    }
-
-    const ctx = await analytics.register(
-      validation,
-      analyticsNode(nodeSettings)
-    )
-    analytics.emit('initialize', settings, cookieOptions ?? {})
-
-    return [analytics, ctx]
+export async function loadNode(settings: {
+  writeKey: string
+}): Promise<[Analytics, Context]> {
+  const cookieOptions = {
+    persist: false,
   }
+
+  const queue = new EventQueue(new PriorityQueue(3, []))
+  const options = { user: cookieOptions, group: cookieOptions }
+  const analytics = new Analytics(settings, options, queue)
+
+  const nodeSettings = {
+    writeKey: settings.writeKey,
+    name: 'analytics-node-next',
+    type: 'after' as Plugin['type'],
+    version: 'latest',
+  }
+
+  const ctx = await analytics.register(validation, analyticsNode(nodeSettings))
+  analytics.emit('initialize', settings, cookieOptions ?? {})
+
+  return [analytics, ctx]
 }

--- a/src/plugins/analytics-node/__tests__/index.test.ts
+++ b/src/plugins/analytics-node/__tests__/index.test.ts
@@ -2,7 +2,7 @@ const fetcher = jest.fn()
 jest.mock('node-fetch', () => fetcher)
 
 import { Analytics } from '../../../analytics'
-import { AnalyticsNode } from '../../../node'
+import { loadNode } from '../../../node'
 
 const myDate = new Date('2016')
 const _Date = Date
@@ -13,7 +13,7 @@ describe('Analytics Node', () => {
   beforeEach(async () => {
     jest.resetAllMocks()
 
-    const [analytics] = await AnalyticsNode.load({
+    const [analytics] = await loadNode({
       writeKey: 'abc123',
     })
 

--- a/src/plugins/remote-loader/__tests__/integration.test.ts
+++ b/src/plugins/remote-loader/__tests__/integration.test.ts
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils'
 import { JSDOM } from 'jsdom'
-import { AnalyticsBrowser, LegacySettings } from '../../../browser'
+import { LegacySettings, loadBrowser } from '../../../browser'
 
 jest.mock('unfetch', () => {
   return jest.fn()
@@ -65,7 +65,7 @@ describe.skip('Remote Plugin Integration', () => {
   })
 
   it('loads remote plugins', async () => {
-    await AnalyticsBrowser.load({
+    await loadBrowser({
       writeKey: 'test-write-key',
     })
 

--- a/src/standalone-analytics.ts
+++ b/src/standalone-analytics.ts
@@ -1,5 +1,5 @@
 import { Analytics, InitOptions } from './analytics'
-import { AnalyticsBrowser } from './browser'
+import { standaloneBrowser } from './browser'
 import { embeddedWriteKey } from './lib/embedded-write-key'
 
 type FunctionsOf<T> = {
@@ -70,10 +70,9 @@ export function install(): Promise<void> {
     return Promise.resolve()
   }
 
-  return AnalyticsBrowser.standalone(
-    writeKey,
-    window.analytics?._loadOptions ?? {}
-  ).then((an) => {
-    window.analytics = an as StandaloneAnalytics
-  })
+  return standaloneBrowser(writeKey, window.analytics?._loadOptions ?? {}).then(
+    (an) => {
+      window.analytics = an as StandaloneAnalytics
+    }
+  )
 }


### PR DESCRIPTION
Hey there, I noticed that the classes introduced define all the functions as `static`. Such a thing is a sign of code smell since it is leveraging the `class` (object) as a bag of functionalities which you can always achieve with `import * as AnalyticsBrowser` in ESM.

Removing such class definition and exposing the functions will give a cleaner, simple, and most important minifying code that will be shorter since you don't need the full class name.

#### Downside

Exposing everything from the root is suboptimal (reasons why I had to rename the functions), ideally, you would add two more exposed modules or as many runtime environments. For example:

```ts
import * as AnalyticsBrowser from '@segment/analytics-next/browser'
import * as AnalyticsNode from '@segment/analytics-next/node'
```

#### Follow up

I can fix the exporting, just wanna showcase what I meant rather than go back and forward on it.

Also fix the integration side, since such a file would probably create an object that mimics the previous behavior. Friendly when people don't import the script as part of their app.