### PR TITLE
[bugfix] Honor Integration["Segment.io"]: false to API calls

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -352,6 +352,37 @@ describe('Dispatch', () => {
     expect(segmentSpy).not.toHaveBeenCalled()
   })
 
+  it('does dispatch events to Segment.io when All is false', async () => {
+    const [ajs] = await AnalyticsBrowser.load({
+      writeKey,
+      plugins: [amplitude, googleAnalytics],
+    })
+
+    const segmentio = ajs.queue.plugins.find((p) => p.name === 'Segment.io')
+    expect(segmentio).toBeDefined()
+
+    const ampSpy = jest.spyOn(amplitude, 'track')
+    const gaSpy = jest.spyOn(googleAnalytics, 'track')
+    const segmentSpy = jest.spyOn(segmentio!, 'track')
+
+    const boo = await ajs.track(
+      'Boo!',
+      {
+        total: 25,
+        userId: '👻',
+      },
+      {
+        integrations: {
+          All: false,
+        },
+      }
+    )
+
+    expect(gaSpy).not.toHaveBeenCalled()
+    expect(ampSpy).not.toHaveBeenCalled()
+    expect(segmentSpy).toHaveBeenCalledWith(boo)
+  })
+
   it('enriches events before dispatching', async () => {
     const [ajs] = await AnalyticsBrowser.load({
       writeKey,

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -303,8 +303,12 @@ describe('Dispatch', () => {
       plugins: [amplitude, googleAnalytics],
     })
 
+    const segmentio = ajs.queue.plugins.find((p) => p.name === 'Segment.io')
+    expect(segmentio).toBeDefined()
+
     const ampSpy = jest.spyOn(amplitude, 'track')
     const gaSpy = jest.spyOn(googleAnalytics, 'track')
+    const segmentSpy = jest.spyOn(segmentio!, 'track')
 
     const boo = await ajs.track('Boo!', {
       total: 25,
@@ -313,6 +317,7 @@ describe('Dispatch', () => {
 
     expect(ampSpy).toHaveBeenCalledWith(boo)
     expect(gaSpy).toHaveBeenCalledWith(boo)
+    expect(segmentSpy).toHaveBeenCalledWith(boo)
   })
 
   it('does not dispatch events to destinations on deny list', async () => {
@@ -321,8 +326,12 @@ describe('Dispatch', () => {
       plugins: [amplitude, googleAnalytics],
     })
 
+    const segmentio = ajs.queue.plugins.find((p) => p.name === 'Segment.io')
+    expect(segmentio).toBeDefined()
+
     const ampSpy = jest.spyOn(amplitude, 'track')
     const gaSpy = jest.spyOn(googleAnalytics, 'track')
+    const segmentSpy = jest.spyOn(segmentio!, 'track')
 
     const boo = await ajs.track(
       'Boo!',
@@ -333,12 +342,14 @@ describe('Dispatch', () => {
       {
         integrations: {
           Amplitude: false,
+          'Segment.io': false,
         },
       }
     )
 
     expect(gaSpy).toHaveBeenCalledWith(boo)
     expect(ampSpy).not.toHaveBeenCalled()
+    expect(segmentSpy).not.toHaveBeenCalled()
   })
 
   it('enriches events before dispatching', async () => {

--- a/src/core/queue/__tests__/event-queue.test.ts
+++ b/src/core/queue/__tests__/event-queue.test.ts
@@ -333,16 +333,27 @@ describe('Flushing', () => {
       },
     }
 
+    const segmentio = {
+      ...testPlugin,
+      name: 'Segment.io',
+      type: 'after' as const,
+      track: (ctx: Context): Promise<Context> | Context => {
+        return Promise.resolve(ctx)
+      },
+    }
+
     test('does not delivery to destinations on denyList', async () => {
       const eq = new EventQueue()
 
       jest.spyOn(amplitude, 'track')
       jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
         integrations: {
           Mixpanel: false,
+          'Segment.io': false,
         },
       }
 
@@ -350,6 +361,7 @@ describe('Flushing', () => {
 
       await eq.register(Context.system(), amplitude, ajs)
       await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -361,13 +373,15 @@ describe('Flushing', () => {
 
       expect(mixPanel.track).not.toHaveBeenCalled()
       expect(amplitude.track).toHaveBeenCalled()
+      expect(segmentio.track).not.toHaveBeenCalled()
     })
 
-    test('does not deliver to any destination if All: false ', async () => {
+    test('does not deliver to any destination except Segment.io if All: false ', async () => {
       const eq = new EventQueue()
 
       jest.spyOn(amplitude, 'track')
       jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
@@ -380,6 +394,7 @@ describe('Flushing', () => {
 
       await eq.register(Context.system(), amplitude, ajs)
       await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -390,6 +405,7 @@ describe('Flushing', () => {
 
       expect(mixPanel.track).not.toHaveBeenCalled()
       expect(amplitude.track).not.toHaveBeenCalled()
+      expect(segmentio.track).toHaveBeenCalled()
     })
 
     test('does not deliver when All: false and destination is also explicitly false', async () => {
@@ -397,12 +413,14 @@ describe('Flushing', () => {
 
       jest.spyOn(amplitude, 'track')
       jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
         integrations: {
           All: false,
           Amplitude: false,
+          'Segment.io': false,
         },
       }
 
@@ -410,6 +428,7 @@ describe('Flushing', () => {
 
       await eq.register(Context.system(), amplitude, ajs)
       await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -420,6 +439,7 @@ describe('Flushing', () => {
 
       expect(mixPanel.track).not.toHaveBeenCalled()
       expect(amplitude.track).not.toHaveBeenCalled()
+      expect(segmentio.track).not.toHaveBeenCalled()
     })
 
     test('delivers to destinations if All: false but the destination is allowed', async () => {
@@ -427,6 +447,41 @@ describe('Flushing', () => {
 
       jest.spyOn(amplitude, 'track')
       jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
+
+      const evt = {
+        type: 'track' as const,
+        integrations: {
+          All: false,
+          Amplitude: true,
+          'Segment.io': true,
+        },
+      }
+
+      const ctx = new Context(evt)
+
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
+
+      eq.dispatch(ctx)
+
+      expect(eq.queue.length).toBe(1)
+      const flushed = await flushAll(eq)
+
+      expect(flushed).toEqual([ctx])
+
+      expect(mixPanel.track).not.toHaveBeenCalled()
+      expect(amplitude.track).toHaveBeenCalled()
+      expect(segmentio.track).toHaveBeenCalled()
+    })
+
+    test('delivers to Segment.io if All: false but Segment.io is not specified', async () => {
+      const eq = new EventQueue()
+
+      jest.spyOn(amplitude, 'track')
+      jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
@@ -440,6 +495,7 @@ describe('Flushing', () => {
 
       await eq.register(Context.system(), amplitude, ajs)
       await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -450,12 +506,14 @@ describe('Flushing', () => {
 
       expect(mixPanel.track).not.toHaveBeenCalled()
       expect(amplitude.track).toHaveBeenCalled()
+      expect(segmentio.track).toHaveBeenCalled()
     })
 
     test('delivers to destinations that exist as an object', async () => {
       const eq = new EventQueue()
 
       jest.spyOn(amplitude, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
@@ -464,12 +522,14 @@ describe('Flushing', () => {
           Amplitude: {
             amplitudeKey: 'foo',
           },
+          'Segment.io': {},
         },
       }
 
       const ctx = new Context(evt)
 
       await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -479,6 +539,7 @@ describe('Flushing', () => {
       expect(flushed).toEqual([ctx])
 
       expect(amplitude.track).toHaveBeenCalled()
+      expect(segmentio.track).toHaveBeenCalled()
     })
 
     test('respect deny lists generated by other plugin', async () => {
@@ -486,32 +547,39 @@ describe('Flushing', () => {
 
       jest.spyOn(amplitude, 'track')
       jest.spyOn(mixPanel, 'track')
+      jest.spyOn(segmentio, 'track')
 
       const evt = {
         type: 'track' as const,
         integrations: {
           Amplitude: true,
           MixPanel: true,
+          'Segment.io': true,
         },
       }
 
       const ctx = new Context(evt)
       await eq.register(Context.system(), amplitude, ajs)
       await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
       await eq.dispatch(ctx)
 
-      const skipAmplitude: MiddlewareFunction = ({ payload, next }) => {
+      const skipAmplitudeAndSegment: MiddlewareFunction = ({
+        payload,
+        next,
+      }) => {
         if (!payload.obj.integrations) {
           payload.obj.integrations = {}
         }
 
         payload.obj.integrations['Amplitude'] = false
+        payload.obj.integrations['Segment.io'] = false
         next(payload)
       }
 
       await eq.register(
         Context.system(),
-        sourceMiddlewarePlugin(skipAmplitude, {}),
+        sourceMiddlewarePlugin(skipAmplitudeAndSegment, {}),
         ajs
       )
 
@@ -519,6 +587,7 @@ describe('Flushing', () => {
 
       expect(mixPanel.track).toHaveBeenCalledTimes(2)
       expect(amplitude.track).toHaveBeenCalledTimes(1)
+      expect(segmentio.track).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/core/queue/event-queue.ts
+++ b/src/core/queue/event-queue.ts
@@ -213,7 +213,8 @@ export class EventQueue extends Emitter {
   private availableExtensions(denyList: Integrations): PluginsByType {
     const available = this.plugins.filter(
       (p) =>
-        p.type !== 'destination' || (denyList[p.name] ?? denyList.All) !== false
+        (p.type !== 'destination' && p.name !== 'Segment.io') ||
+        (denyList[p.name] ?? denyList.All) !== false
     )
 
     const {

--- a/src/core/queue/event-queue.ts
+++ b/src/core/queue/event-queue.ts
@@ -211,11 +211,18 @@ export class EventQueue extends Emitter {
   }
 
   private availableExtensions(denyList: Integrations): PluginsByType {
-    const available = this.plugins.filter(
-      (p) =>
-        (p.type !== 'destination' && p.name !== 'Segment.io') ||
-        (denyList[p.name] ?? denyList.All) !== false
-    )
+    const available = this.plugins.filter((p) => {
+      // Only filter out destination plugins or the Segment.io plugin
+      if (p.type !== 'destination' && p.name !== 'Segment.io') {
+        return true
+      }
+
+      // Explicit integration option takes precedence, `All: false` does not apply to Segment.io
+      return (
+        denyList[p.name] ??
+        (p.name === 'Segment.io' ? true : denyList.All) !== false
+      )
+    })
 
     const {
       before = [],


### PR DESCRIPTION
### What is this change:
This PR updates the plugin filtering logic to support denying the `Segment.io` plugin when `{Integrations: {"Segment.io": false}}` is passed to API calls (e.g. track/identify/etc).

### Why this change is needed:
Prior to this update, setting the `Segment.io` integration to false was only honored when passed to `analytics.load()`. All other destinations can already be disabled via the `integrations` object passed to API calls. This meant users explicitly trying to disable `Segment.io` for individual API calls were still seeing events sent to Segment.

### Difference compared to `analytics.load()` behavior
Passing `{ integrations: { All: false } }` to `analytics.load()` will cause events to __not__ be sent to Segment.

For individual event API calls (e.g. track/identify/etc), `Segment.io` has to be explicitly set to `false` in order to prevent events from being sent to Segment.

Behavior before this PR:
| A.JS Call | { Integrations: { All: false } } | { Integrations: { 'Segment.io': false } } |
| --- | --- | --- |
|analytics.load() | Not sent | Not sent |
| analytics.track() | Sent | Sent |

Behavior with this PR:
| A.JS Call | { Integrations: { All: false } } | { Integrations: { 'Segment.io': false } } |
| --- | --- | --- |
|analytics.load() | Not sent | Not sent |
| analytics.track() | Sent | Not sent |

### Risks

With this change, any code that currently passes `{ integrations: { 'Segment.io': false } }` to an event-generating API call will stop sending those events to Segment. This seems reasonable to treat as a bugfix since the user is explicitly disabling Segment in this case.

Passing only `{ integrations: { All: false } }` will __NOT__ prevent events from being sent to Segment. While this means the behavior of `All: false` differs between `analytics.load()` and event-generating methods, I don't think it's worth the risk of unintentionally disabling `Segment.io` if users are currently relying on the (incorrect) behavior where `All: false` only disables destination plugins.