### PR TITLE
updates event-queue to only scheduleFlush when items exist in queue

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -772,9 +772,8 @@ describe('retries', () => {
       { retryQueue: false }
     )
 
-    expect(ajs.queue.queue).toStrictEqual(
-      new PersistedPriorityQueue(1, 'event-queue')
-    )
+    expect(ajs.queue.queue instanceof PersistedPriorityQueue).toBeTruthy()
+    expect(ajs.queue.queue.maxAttempts).toBe(1)
 
     await ajs.queue.register(
       Context.system(),

--- a/src/core/queue/event-queue.ts
+++ b/src/core/queue/event-queue.ts
@@ -1,6 +1,6 @@
 import { Analytics } from '../../analytics'
 import { groupBy } from '../../lib/group-by'
-import { PriorityQueue } from '../../lib/priority-queue'
+import { ON_REMOVE_FROM_FUTURE, PriorityQueue } from '../../lib/priority-queue'
 import { PersistedPriorityQueue } from '../../lib/priority-queue/persisted'
 import { isOnline } from '../connection'
 import { Context, ContextCancelation } from '../context'
@@ -25,7 +25,9 @@ export class EventQueue extends Emitter {
   constructor(priorityQueue?: PriorityQueue<Context>) {
     super()
     this.queue = priorityQueue ?? new PersistedPriorityQueue(4, 'event-queue')
-    this.scheduleFlush()
+    this.queue.on(ON_REMOVE_FROM_FUTURE, () => {
+      this.scheduleFlush(0)
+    })
   }
 
   async register(
@@ -140,8 +142,6 @@ export class EventQueue extends Emitter {
 
           if (this.queue.length) {
             this.scheduleFlush(0)
-          } else {
-            this.scheduleFlush(500)
           }
         }, 0)
       })


### PR DESCRIPTION
Fixes #402 

This PR changes the way the `EventQueue` class schedules flush calls. The main motivation for this change is to prevent `AnalyticsNode` from preventing the process from exiting due to a persistent `setTimeout` from `EventQueue's` polling.

## Current state

`EventQueue` starts polling it's queue via `scheduleFlush` as soon as it is instantiated. If there are no events in the queue, it will continue to poll every 500 ms. As mentioned above, this prevents a node.js process from exiting.

## What do these changes do?

These changes get rid of the persistent polling in `EventQueue`. Instead, `scheduleFlush` will only be called under the following conditions:
- `dispatch()` is called - same as currently
- After the `flush` invoked by `scheduleFlush` resolves, if the queue still has items - same as currently
- When a Context object transitions from a PriorityQueue's `future` array to `queue` array.
  - This is the part that replaces the need for persistent polling

### PriorityQueue.future

The PriorityQueue's `future` array holds events that failed to be sent initially, and are being retried with some backoff. 

Currently the `EventQueue` polls continuously to check if `priorityQueue.length > 0` to handle retried events getting re-enqueued. This PR changes how this is handled from being poll-based to push-based via listening for a new event emitted by the `PriorityQueue`. This should give a small performance benefit since now the flush will be scheduled immediately when an event is re-enqueued versus having to wait up to 500 ms for the poller to see it.