### PR TITLE
Add support for segment inspector

### DIFF
--- a/.changeset/khaki-frogs-look.md
+++ b/.changeset/khaki-frogs-look.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Add support for Segment Inspector Chrome extension

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.6 KB"
+      "limit": "25.7 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -59,6 +59,7 @@
     "unfetch": "^4.1.0"
   },
   "devDependencies": {
+    "@segment/inspector-core": "^1.0.0",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@types/flat": "^5.0.1",
     "@types/fs-extra": "^9.0.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.7 KB"
+      "limit": "25.8 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -29,6 +29,7 @@ import type {
 import { version } from '../../generated/version'
 import { PriorityQueue } from '../../lib/priority-queue'
 import { getGlobal } from '../../lib/get-global'
+import { inspectorHost } from '../inspector'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'
@@ -113,6 +114,13 @@ export class Analytics extends Emitter {
     this.eventFactory = new EventFactory(this._user)
     this.integrations = options?.integrations ?? {}
     this.options = options ?? {}
+
+    inspectorHost.start({
+      user: {
+        id: this.user().id() || null,
+        traits: this.user().traits(),
+      },
+    })
 
     autoBind(this)
   }
@@ -320,6 +328,13 @@ export class Analytics extends Emitter {
     callback?: Callback
   ): Promise<DispatchedEvent> {
     const ctx = new Context(event)
+
+    inspectorHost.trace({
+      stage: 'triggered',
+      id: ctx.id,
+      event: event as any,
+      timestamp: new Date().toISOString(),
+    })
 
     if (isOffline() && !this.options.retryQueue) {
       return ctx

--- a/packages/browser/src/core/inspector/__tests__/index.test.ts
+++ b/packages/browser/src/core/inspector/__tests__/index.test.ts
@@ -1,0 +1,67 @@
+import { Analytics } from '../../analytics'
+
+let analytics: Analytics
+
+describe('Inspector interface', () => {
+  beforeEach(() => {
+    ;(window as any)['__SEGMENT_INSPECTOR__'] = {
+      start: jest.fn(),
+      trace: jest.fn(),
+    }
+
+    analytics = new Analytics({
+      writeKey: 'abc',
+    })
+  })
+
+  it('accepts and starts up an inspector client trying to connect', () => {
+    expect(
+      (window as any)['__SEGMENT_INSPECTOR__'].start
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies the connected inspector client about each event API call and delivery', async () => {
+    expect(
+      (window as any)['__SEGMENT_INSPECTOR__'].trace
+    ).not.toHaveBeenCalled()
+
+    const timestampMatcher = expect.stringMatching(
+      /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+    )
+    const deliveryPromise = analytics.track('Test event').catch(() => {})
+
+    // expect 2 calls, triggered report, followed enriched report
+    expect(
+      (window as any)['__SEGMENT_INSPECTOR__'].trace
+    ).toHaveBeenCalledTimes(2)
+
+    expect((window as any)['__SEGMENT_INSPECTOR__'].trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'triggered',
+        timestamp: timestampMatcher,
+        event: expect.objectContaining({
+          event: 'Test event',
+          type: 'track',
+        }),
+      })
+    )
+
+    await deliveryPromise
+
+    // triggered -> enriched -> delivered
+    expect(
+      (window as any)['__SEGMENT_INSPECTOR__'].trace
+    ).toHaveBeenCalledTimes(3)
+
+    expect((window as any)['__SEGMENT_INSPECTOR__'].trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'delivered',
+        timestamp: timestampMatcher,
+        event: expect.objectContaining({
+          event: 'Test event',
+          type: 'track',
+        }),
+      })
+    )
+  })
+})

--- a/packages/browser/src/core/inspector/__tests__/index.test.ts
+++ b/packages/browser/src/core/inspector/__tests__/index.test.ts
@@ -4,7 +4,7 @@ let analytics: Analytics
 
 describe('Inspector interface', () => {
   beforeEach(() => {
-    ;(window as any)['__SEGMENT_INSPECTOR__'] = {
+    window.__SEGMENT_INSPECTOR__ = {
       start: jest.fn(),
       trace: jest.fn(),
     }
@@ -15,15 +15,11 @@ describe('Inspector interface', () => {
   })
 
   it('accepts and starts up an inspector client trying to connect', () => {
-    expect(
-      (window as any)['__SEGMENT_INSPECTOR__'].start
-    ).toHaveBeenCalledTimes(1)
+    expect(window.__SEGMENT_INSPECTOR__?.start).toHaveBeenCalledTimes(1)
   })
 
   it('notifies the connected inspector client about each event API call and delivery', async () => {
-    expect(
-      (window as any)['__SEGMENT_INSPECTOR__'].trace
-    ).not.toHaveBeenCalled()
+    expect(window.__SEGMENT_INSPECTOR__?.trace).not.toHaveBeenCalled()
 
     const timestampMatcher = expect.stringMatching(
       /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
@@ -31,11 +27,9 @@ describe('Inspector interface', () => {
     const deliveryPromise = analytics.track('Test event').catch(() => {})
 
     // expect 2 calls, triggered report, followed enriched report
-    expect(
-      (window as any)['__SEGMENT_INSPECTOR__'].trace
-    ).toHaveBeenCalledTimes(2)
+    expect(window.__SEGMENT_INSPECTOR__?.trace).toHaveBeenCalledTimes(2)
 
-    expect((window as any)['__SEGMENT_INSPECTOR__'].trace).toHaveBeenCalledWith(
+    expect(window.__SEGMENT_INSPECTOR__?.trace).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: 'triggered',
         timestamp: timestampMatcher,
@@ -49,11 +43,9 @@ describe('Inspector interface', () => {
     await deliveryPromise
 
     // triggered -> enriched -> delivered
-    expect(
-      (window as any)['__SEGMENT_INSPECTOR__'].trace
-    ).toHaveBeenCalledTimes(3)
+    expect(window.__SEGMENT_INSPECTOR__?.trace).toHaveBeenCalledTimes(3)
 
-    expect((window as any)['__SEGMENT_INSPECTOR__'].trace).toHaveBeenCalledWith(
+    expect(window.__SEGMENT_INSPECTOR__?.trace).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: 'delivered',
         timestamp: timestampMatcher,

--- a/packages/browser/src/core/inspector/index.ts
+++ b/packages/browser/src/core/inspector/index.ts
@@ -1,0 +1,9 @@
+import { Inspector } from 'segment-inspector-core'
+
+// FIXME: Replace this with `globalThis` to support all environments
+const env = typeof window !== 'undefined' ? window : null
+
+export const inspectorHost: Inspector = {
+  start: (...args) => (env as any)?.['__SEGMENT_INSPECTOR__']?.start(...args),
+  trace: (...args) => (env as any)?.['__SEGMENT_INSPECTOR__']?.trace(...args),
+}

--- a/packages/browser/src/core/inspector/index.ts
+++ b/packages/browser/src/core/inspector/index.ts
@@ -1,4 +1,5 @@
 import type { Inspector } from '@segment/inspector-core'
+import { getGlobal } from '../../lib/get-global'
 
 declare global {
   interface Window {
@@ -6,8 +7,7 @@ declare global {
   }
 }
 
-// FIXME: Replace this with `globalThis` to support all environments
-const env = typeof window !== 'undefined' ? window : null
+const env = getGlobal()
 
 export const inspectorHost: Inspector = {
   start: (...args) => (env as any)?.['__SEGMENT_INSPECTOR__']?.start(...args),

--- a/packages/browser/src/core/inspector/index.ts
+++ b/packages/browser/src/core/inspector/index.ts
@@ -1,4 +1,10 @@
-import { Inspector } from 'segment-inspector-core'
+import type { Inspector } from '@segment/inspector-core'
+
+declare global {
+  interface Window {
+    __SEGMENT_INSPECTOR__?: Inspector
+  }
+}
 
 // FIXME: Replace this with `globalThis` to support all environments
 const env = typeof window !== 'undefined' ? window : null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,7 @@ __metadata:
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics.js-video-plugins": ^0.2.1
     "@segment/facade": ^3.4.9
+    "@segment/inspector-core": ^1.0.0
     "@segment/tsub": ^0.1.12
     "@size-limit/preset-big-lib": ^7.0.8
     "@types/flat": ^5.0.1
@@ -1567,6 +1568,13 @@ __metadata:
     new-date: ^1.0.3
     obj-case: 0.2.1
   checksum: c6e139fd16464a1adb204bc13b958c95c96e5fa82c7281a4e71be4589b1a50a1d072f41d2bd8533c5fe1891e5a124af8c856ce26c493a0c5f548dff80c5ce572
+  languageName: node
+  linkType: hard
+
+"@segment/inspector-core@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@segment/inspector-core@npm:1.0.0"
+  checksum: 4c04303301f54cab9fe8d0502fe0a755ad21206b8917ebbfb5edb8be5888cd7ed4dc948cf34e52b957863de44f9152551d78571ba12c00106f573fdb2136f4ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This patch adds the interface that allows inspector clients to connect
and monitor all Segment activity happening on the page. This API is not
related to the events API (over Emitter interface) by design, as both of
these API's serve a very distinct purpose and will be developed at their
own pace without breaking each other's behaviour. End-users of the library
are not advised to use this interface in their production code and should
continue to rely on the existing events API.


<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

Please add a description of your PR, including the what and why

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.

--->