### PR TITLE
Fixes the QA job

### DIFF
--- a/qa/__fixtures__/snippets.ts
+++ b/qa/__fixtures__/snippets.ts
@@ -72,8 +72,7 @@ export function next(writekey: string, obfuscate: boolean) {
 export function classic(writekey: string) {
   return `
   <html>
-  <head>
-  </head>
+  <head></head>
     <script>!(function () {
     var analytics = (window.analytics = window.analytics || [])
     if (!analytics.initialize)

--- a/qa/__fixtures__/snippets.ts
+++ b/qa/__fixtures__/snippets.ts
@@ -72,7 +72,8 @@ export function next(writekey: string, obfuscate: boolean) {
 export function classic(writekey: string) {
   return `
   <html>
-  <head></head>
+  <head>
+  </head>
     <script>!(function () {
     var analytics = (window.analytics = window.analytics || [])
     if (!analytics.initialize)

--- a/qa/lib/runner.ts
+++ b/qa/lib/runner.ts
@@ -95,6 +95,7 @@ export async function run(params: ComparisonParams) {
     // This forces every timestamp to look exactly the same
     await page.evaluate('Date.prototype.toJSON = () => "<date>";')
     await page.evaluate('Date.prototype.getTime = () => 1614653469;')
+    await page.evaluate('Object.freeze(Date.prototype);')
 
     await page.waitForLoadState('networkidle')
     await page.waitForFunction(`window.analytics.initialized === true`)


### PR DESCRIPTION
In our QA tests there was one source loading a destination in debug mode that was overwriting `Date.prototype.toJSON`. Unfortunately we want to overwrite `Date.prototype.toJSON` to return a simple string in our QA job so it's easier to compare the results from 2 browsers.

This change simply freezes the `Date.prototype` object after we modify so nothing else can.