### PR TITLE
fixes qa ci job by making integrations checking more resilient

### DIFF
--- a/qa/__tests__/smoke.test.ts
+++ b/qa/__tests__/smoke.test.ts
@@ -59,7 +59,17 @@ function compareSchema(results: RemovePromise<ReturnType<typeof run>>) {
       'properties.url',
 
       'messageId',
-      'anonymousId'
+      'anonymousId',
+
+      // We do an integrations specific check below since 'next'
+      // may have action-destinations that 'classic' does not
+      'integrations'
+    )
+
+    expect((req.data as Record<string, JSONValue>).integrations).toEqual(
+      expect.objectContaining(
+        (classic.data as Record<string, JSONValue>).integrations
+      )
     )
 
     const flatNext = flat(req.data) as Record<string, JSONValue>

--- a/qa/lib/schema.ts
+++ b/qa/lib/schema.ts
@@ -10,19 +10,41 @@ declare global {
   }
 }
 
+function injectAncestorKeys(keys: string[]): string[] {
+  const allKeys = new Set(keys)
+  for (const key of keys) {
+    const parts = key.split('.')
+    if (parts.length === 1) continue
+
+    do {
+      // remove the last item from the parts
+      parts.pop()
+      const newKey = parts.join('.')
+      if (newKey) {
+        allKeys.add(newKey)
+      }
+    } while (parts.length)
+  }
+
+  return Array.from(allKeys)
+}
+
 export const objectSchema = (obj: object | string) => {
   let parsed = obj
   if (typeof obj === 'string') {
     parsed = JSON.parse(obj)
   }
 
-  return Object.keys(flat(parsed))
+  const flattenedKeys = Object.keys(flat(parsed))
+  const allKeys = injectAncestorKeys(flattenedKeys)
+
+  return allKeys.sort()
 }
 
 expect.extend({
   toContainSchema(got: object, expected: object) {
-    const gotSchema = objectSchema(got).sort()
-    const expectedSchema = objectSchema(expected).sort()
+    const gotSchema = objectSchema(got)
+    const expectedSchema = objectSchema(expected)
     const missing = difference(expectedSchema, gotSchema)
 
     const message = () =>


### PR DESCRIPTION
QA job was failing again. The main cause was due to how we check the event's `integrations` object between classic and next. `analytics-next` can include action-destinations which classic doesn't, so we're seeing 1-2 sources where `integrations` contains more data with `next` due to these destinations than `classic`.

Since `next` should contain everything `classic` has, I made the `integrations` check ensure that `next` has __at least_ the same properties as `classic`.
