### PR TITLE
update @segment/facade to 3.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics.js-video-plugins": "^0.2.1",
-    "@segment/facade": "3.4.8",
+    "@segment/facade": "^3.4.9",
     "@segment/tsub": "^0.1.10",
     "dset": "^3.0.0",
     "js-cookie": "^2.2.1",


### PR DESCRIPTION
Fixes #420 by updating `@segment/facade` to the latest version.

Also updated our package.json to pin to the major version of `@segment/facade` instead of the specific version so we don't have to release a new version of analytics-next in the future to get facade updates.
