### PR TITLE
fix spelling: persistance -> persistence

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -216,13 +216,13 @@ describe('Initialization', () => {
     expect(mockPage).not.toHaveBeenCalled()
   })
 
-  it('does not use a persisted queue when disableClientPersistance is true', async () => {
+  it('does not use a persisted queue when disableClientPersistence is true', async () => {
     const [ajs] = await AnalyticsBrowser.load(
       {
         writeKey,
       },
       {
-        disableClientPersistance: true,
+        disableClientPersistence: true,
       }
     )
 
@@ -238,13 +238,13 @@ describe('Initialization', () => {
     expect(ajs.queue.queue instanceof PersistedPriorityQueue).toBe(true)
   })
 
-  it('disables identity persistance when disableClientPersistance is true', async () => {
+  it('disables identity persistance when disableClientPersistence is true', async () => {
     const [ajs] = await AnalyticsBrowser.load(
       {
         writeKey,
       },
       {
-        disableClientPersistance: true,
+        disableClientPersistence: true,
       }
     )
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -58,7 +58,7 @@ export interface InitOptions {
    * Defaults to `false`.
    *
    */
-  disableClientPersistance?: boolean
+  disableClientPersistence?: boolean
   initialPageview?: boolean
   cookie?: CookieOptions
   user?: UserOptions
@@ -90,7 +90,7 @@ export class Analytics extends Emitter {
   ) {
     super()
     const cookieOptions = options?.cookie
-    const disablePersistance = options?.disableClientPersistance ?? false
+    const disablePersistance = options?.disableClientPersistence ?? false
     this.settings = settings
     this.settings.timeout = this.settings.timeout ?? 300
     this.queue =

--- a/src/plugins/ajs-destination/__tests__/index.test.ts
+++ b/src/plugins/ajs-destination/__tests__/index.test.ts
@@ -288,7 +288,7 @@ describe('settings', () => {
 })
 
 describe('options', () => {
-  it('#disableClientPersistance affects underlying queue', () => {
+  it('#disableClientPersistence affects underlying queue', () => {
     const defaultDestWithPersistance = new LegacyDestination(
       'LocalStorageUser',
       'latest',
@@ -299,13 +299,13 @@ describe('options', () => {
       'LocalStorageUserToo',
       'latest',
       {},
-      { disableClientPersistance: false }
+      { disableClientPersistence: false }
     )
     const destWithoutPersistance = new LegacyDestination(
       'MemoryUser',
       'latest',
       {},
-      { disableClientPersistance: true }
+      { disableClientPersistence: true }
     )
 
     expect(

--- a/src/plugins/ajs-destination/index.ts
+++ b/src/plugins/ajs-destination/index.ts
@@ -97,7 +97,7 @@ export class LegacyDestination implements Plugin {
     }
 
     this.options = options
-    this.buffer = options.disableClientPersistance
+    this.buffer = options.disableClientPersistence
       ? new PriorityQueue(4, [])
       : new PersistedPriorityQueue(4, `dest-${name}`)
 

--- a/src/plugins/segmentio/__tests__/normalize.test.ts
+++ b/src/plugins/segmentio/__tests__/normalize.test.ts
@@ -305,7 +305,7 @@ describe('before loading', () => {
       const setCookieSpy = spyOn(cookie, 'set').and.callThrough()
       analytics = new Analytics(
         { writeKey: options.apiKey },
-        { disableClientPersistance: true }
+        { disableClientPersistence: true }
       )
 
       normalize(analytics, object, options, {})

--- a/src/plugins/segmentio/__tests__/retries.test.ts
+++ b/src/plugins/segmentio/__tests__/retries.test.ts
@@ -20,9 +20,8 @@ describe('Segment.io retries', () => {
   let queue: (PersistedPriorityQueue | PriorityQueue<Context>) & {
     __type?: QueueType
   }
-
-  ;[false, true].forEach((disableClientPersistance) => {
-    describe(`disableClientPersistance: ${disableClientPersistance}`, () => {
+  ;[false, true].forEach((disableClientPersistence) => {
+    describe(`disableClientPersistence: ${disableClientPersistence}`, () => {
       beforeEach(async () => {
         jest.resetAllMocks()
         jest.restoreAllMocks()
@@ -33,15 +32,15 @@ describe('Segment.io retries', () => {
         options = { apiKey: 'foo' }
         analytics = new Analytics(
           { writeKey: options.apiKey },
-          { retryQueue: true, disableClientPersistance }
+          { retryQueue: true, disableClientPersistence }
         )
 
-        queue = disableClientPersistance
+        queue = disableClientPersistence
           ? new PriorityQueue(3, [])
           : new PersistedPriorityQueue(3, `test-Segment.io`)
 
-        queue['__type'] = disableClientPersistance ? 'priority' : 'persisted'
-        if (disableClientPersistance) {
+        queue['__type'] = disableClientPersistence ? 'priority' : 'persisted'
+        if (disableClientPersistence) {
           // @ts-expect-error reassign import
           PriorityQueue = jest.fn().mockImplementation(() => queue)
         } else {
@@ -66,7 +65,7 @@ describe('Segment.io retries', () => {
         expect(ctx.attempts).toBe(1)
         expect(isOffline).toHaveBeenCalledTimes(2)
         expect(queue.__type).toBe<QueueType>(
-          disableClientPersistance ? 'priority' : 'persisted'
+          disableClientPersistence ? 'priority' : 'persisted'
         )
       })
     })

--- a/src/plugins/segmentio/index.ts
+++ b/src/plugins/segmentio/index.ts
@@ -49,7 +49,7 @@ export function segmentio(
   settings?: SegmentioSettings,
   integrations?: LegacySettings['integrations']
 ): Plugin {
-  const buffer = analytics.options.disableClientPersistance
+  const buffer = analytics.options.disableClientPersistence
     ? new PriorityQueue<Context>(analytics.queue.queue.maxAttempts, [])
     : new PersistedPriorityQueue(
         analytics.queue.queue.maxAttempts,

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -156,7 +156,7 @@ export function normalize(
     ctx.campaign = utm(query)
   }
 
-  referrerId(query, ctx, analytics.options.disableClientPersistance ?? false)
+  referrerId(query, ctx, analytics.options.disableClientPersistence ?? false)
 
   json.userId = json.userId || user.id()
   json.anonymousId = user.anonymousId(anonId)


### PR DESCRIPTION
Fixes a misspelling of a yet-unreleased property:

```diff
- disableClientPersistance
+ disableClientPersistence
```