### PR TITLE
Fixes race condition where querystring params could be ignored

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -266,20 +266,20 @@ export class AnalyticsBrowser {
       plugins
     )
 
-    analytics.initialized = true
-    analytics.emit('initialize', settings, options)
-
-    if (options.initialPageview) {
-      analytics.page().catch(console.error)
-    }
-
     const search = window.location.search ?? ''
     const hash = window.location.hash ?? ''
 
     const term = search.length ? search : hash.replace(/(?=#).*(?=\?)/, '')
 
     if (term.includes('ajs_')) {
-      analytics.queryString(term).catch(console.error)
+      await analytics.queryString(term).catch(console.error)
+    }
+
+    analytics.initialized = true
+    analytics.emit('initialize', settings, options)
+
+    if (options.initialPageview) {
+      analytics.page().catch(console.error)
     }
 
     await flushBuffered(analytics)


### PR DESCRIPTION
This PR moves updated `AnalyticsBrowser.load()` to:
- Move the querystring API call prior to considering analytics.js as `initialized`
- Waits for `querystring()` to complete before considering analytics.js as `initialized`

Previously there was a race condition that would cause the `anonymousId` passed in via a querystring to be overridden if there were any calls made to `analytics` before it finished loading.

An easy way to demonstrate this is to make calls to analytics before loading it and (optionally) simulate network latency since the querystring API is fetched dynamically when loading analytics.js. This would cause analytics.js to generate a random anonymousId for itself for the events to use. In some cases, if the querystring API completed before the events hit the `Segment.io` plugin, analytics.js would have its anonymousId reset to match the event's anonymousId and override what was set by the querystring API.
