### PR TITLE
Downgrade normalize_url to a non-vuln version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.05 KB"
+      "limit": "25.13 KB"
     }
   ],
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9103,9 +9103,9 @@ normalize-url@2.0.1:
     sort-keys "^2.0.0"
 
 normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
+  integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
 normalize-url@^6.0.1:
   version "6.1.0"


### PR DESCRIPTION
[More info](https://snyk.io/vuln/npm:normalize-url)