### PR TITLE
[feature] Updates AnalyticsNode API

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.13 KB"
+      "limit": "25.15 KB"
     }
   ],
   "lint-staged": {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -249,7 +249,7 @@ describe('Initialization', () => {
     )
 
     expect(ajs.user().options.persist).toBe(false)
-    expect((ajs.group() as Group).options.persist).toBe(false)
+    expect(ajs.group().options.persist).toBe(false)
   })
 
   it('fetch remote source settings by default', async () => {

--- a/src/__tests__/node-integration.test.ts
+++ b/src/__tests__/node-integration.test.ts
@@ -1,19 +1,298 @@
-import { AnalyticsNode } from '../node'
+import { Analytics } from '../analytics'
+import { Plugin } from '../core/plugin'
+import { load } from '../node'
 
 const writeKey = 'foo'
+const TEST_FAILURE = 'Test failure'
 
-describe('Initialization', () => {
-  it('loads analytics-node-next plugin', async () => {
-    const [analytics] = await AnalyticsNode.load({
-      writeKey,
+const testPlugin: Plugin = {
+  isLoaded: jest.fn().mockReturnValue(true),
+  load: jest.fn().mockResolvedValue(undefined),
+  unload: jest.fn().mockResolvedValue(undefined),
+  name: 'Test Plugin',
+  type: 'destination',
+  version: '0.1.0',
+  alias: jest.fn((ctx) => Promise.resolve(ctx)),
+  group: jest.fn((ctx) => Promise.resolve(ctx)),
+  identify: jest.fn((ctx) => Promise.resolve(ctx)),
+  page: jest.fn((ctx) => Promise.resolve(ctx)),
+  screen: jest.fn((ctx) => Promise.resolve(ctx)),
+  track: jest.fn((ctx) => Promise.resolve(ctx)),
+}
+
+describe('AnalyticsNode', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Initialization', () => {
+    it('loads analytics-node-next plugin', async () => {
+      const [analytics] = await load({
+        writeKey,
+      })
+
+      expect((analytics as any as Analytics).queue.plugins.length).toBe(2)
+
+      const ajsNodeXt = (analytics as any as Analytics).queue.plugins.find(
+        (xt) => xt.name === 'analytics-node-next'
+      )
+      expect(ajsNodeXt).toBeDefined()
+      expect(ajsNodeXt?.isLoaded()).toBeTruthy()
+    })
+  })
+
+  describe('alias', () => {
+    it('generates alias events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const ctx = await analytics.alias('chris radek', 'chris')
+
+      expect(ctx.event.userId).toEqual('chris radek')
+      expect(ctx.event.previousId).toEqual('chris')
+      expect(ctx.event.anonymousId).toBeUndefined()
     })
 
-    expect(analytics.queue.plugins.length).toBe(2)
+    it('populates anonymousId if provided', async () => {
+      const [analytics] = await load({ writeKey })
 
-    const ajsNodeXt = analytics.queue.plugins.find(
-      (xt) => xt.name === 'analytics-node-next'
-    )
-    expect(ajsNodeXt).toBeDefined()
-    expect(ajsNodeXt?.isLoaded()).toBeTruthy()
+      const ctx = await analytics.alias('chris radek', 'chris', {
+        anonymousId: 'foo',
+      })
+
+      expect(ctx.event.userId).toEqual('chris radek')
+      expect(ctx.event.previousId).toEqual('chris')
+      expect(ctx.event.anonymousId).toEqual('foo')
+    })
+  })
+
+  describe('group', () => {
+    it('generates group events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const ctx = await analytics.group('coolKids', {
+        anonymousId: 'foo',
+      })
+
+      expect(ctx.event.groupId).toEqual('coolKids')
+      expect(ctx.event.traits).toBeUndefined()
+      expect(ctx.event.userId).toBeUndefined()
+      expect(ctx.event.anonymousId).toEqual('foo')
+    })
+
+    it('generates group events with traits', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const ctx = await analytics.group(
+        'coolKids',
+        { coolKids: true },
+        {
+          userId: 'foo',
+        }
+      )
+
+      expect(ctx.event.groupId).toEqual('coolKids')
+      expect(ctx.event.traits).toEqual({ coolKids: true })
+      expect(ctx.event.userId).toEqual('foo')
+      expect(ctx.event.anonymousId).toBeUndefined()
+    })
+
+    it('requires userId or anonymousId to be provided', async () => {
+      const [analytics] = await load({ writeKey })
+
+      try {
+        await analytics.group('coolKids', {} as any)
+        throw new Error(TEST_FAILURE)
+      } catch (err: any) {
+        expect(err.message).not.toEqual(TEST_FAILURE)
+      }
+    })
+
+    it('invocations are isolated', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const ctx1 = await analytics.group(
+        'coolKids',
+        { foo: 'foo' },
+        {
+          anonymousId: 'unknown',
+        }
+      )
+
+      const ctx2 = await analytics.group(
+        'coolKids',
+        { bar: 'bar' },
+        {
+          userId: 'me',
+        }
+      )
+
+      expect(ctx1.event.traits).toEqual({ foo: 'foo' })
+      expect(ctx1.event.anonymousId).toEqual('unknown')
+      expect(ctx1.event.userId).toBeUndefined()
+
+      expect(ctx2.event.traits).toEqual({ bar: 'bar' })
+      expect(ctx2.event.anonymousId).toBeUndefined()
+      expect(ctx2.event.userId).toEqual('me')
+    })
+  })
+
+  describe('identify', () => {
+    it('generates identify events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const ctx1 = await analytics.identify(
+        {
+          name: 'Chris Radek',
+        },
+        {
+          userId: 'user-id',
+        }
+      )
+
+      expect(ctx1.event.userId).toEqual('user-id')
+      expect(ctx1.event.anonymousId).toBeUndefined()
+      expect(ctx1.event.traits).toEqual({ name: 'Chris Radek' })
+
+      const ctx2 = await analytics.identify({
+        anonymousId: 'unknown',
+      })
+
+      expect(ctx2.event.userId).toBeUndefined
+      expect(ctx2.event.anonymousId).toEqual('unknown')
+      expect(ctx2.event.traits).toEqual({})
+    })
+  })
+
+  describe('page', () => {
+    it('generates page events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const category = 'Docs'
+      const name = 'How to write a test'
+
+      const ctx1 = await analytics.page(
+        category,
+        name,
+        {},
+        { anonymousId: 'unknown' }
+      )
+
+      expect(ctx1.event.type).toEqual('page')
+      expect(ctx1.event.name).toEqual(name)
+      expect(ctx1.event.anonymousId).toEqual('unknown')
+      expect(ctx1.event.userId).toBeUndefined()
+      expect(ctx1.event.properties).toEqual({ category })
+
+      const ctx2 = await analytics.page(
+        name,
+        { title: 'wip' },
+        { userId: 'user-id' }
+      )
+
+      expect(ctx2.event.type).toEqual('page')
+      expect(ctx2.event.name).toEqual(name)
+      expect(ctx2.event.anonymousId).toBeUndefined()
+      expect(ctx2.event.userId).toEqual('user-id')
+      expect(ctx2.event.properties).toEqual({ title: 'wip' })
+
+      const ctx3 = await analytics.page(
+        { title: 'invisible' },
+        { userId: 'user-id' }
+      )
+
+      expect(ctx3.event.type).toEqual('page')
+      expect(ctx3.event.name).toBeUndefined()
+      expect(ctx3.event.anonymousId).toBeUndefined()
+      expect(ctx3.event.userId).toEqual('user-id')
+      expect(ctx3.event.properties).toEqual({ title: 'invisible' })
+    })
+  })
+
+  describe('screen', () => {
+    it('generates screen events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const name = 'Home Screen'
+
+      const ctx1 = await analytics.screen(
+        name,
+        { title: 'wip' },
+        { userId: 'user-id' }
+      )
+
+      expect(ctx1.event.type).toEqual('screen')
+      expect(ctx1.event.name).toEqual(name)
+      expect(ctx1.event.anonymousId).toBeUndefined()
+      expect(ctx1.event.userId).toEqual('user-id')
+      expect(ctx1.event.properties).toEqual({ title: 'wip' })
+
+      const ctx2 = await analytics.screen(
+        { title: 'invisible' },
+        { userId: 'user-id' }
+      )
+
+      expect(ctx2.event.type).toEqual('screen')
+      expect(ctx2.event.name).toBeUndefined()
+      expect(ctx2.event.anonymousId).toBeUndefined()
+      expect(ctx2.event.userId).toEqual('user-id')
+      expect(ctx2.event.properties).toEqual({ title: 'invisible' })
+    })
+  })
+
+  describe('track', () => {
+    it('generates track events', async () => {
+      const [analytics] = await load({ writeKey })
+
+      const eventName = 'Test Event'
+
+      const ctx1 = await analytics.track(
+        eventName,
+        {},
+        {
+          anonymousId: 'unknown',
+          userId: 'known',
+        }
+      )
+
+      expect(ctx1.event.type).toEqual('track')
+      expect(ctx1.event.event).toEqual(eventName)
+      expect(ctx1.event.properties).toEqual({})
+      expect(ctx1.event.anonymousId).toEqual('unknown')
+      expect(ctx1.event.userId).toEqual('known')
+
+      const ctx2 = await analytics.track(
+        eventName,
+        { foo: 'bar' },
+        {
+          userId: 'known',
+        }
+      )
+
+      expect(ctx2.event.type).toEqual('track')
+      expect(ctx2.event.event).toEqual(eventName)
+      expect(ctx2.event.properties).toEqual({ foo: 'bar' })
+      expect(ctx2.event.anonymousId).toBeUndefined()
+      expect(ctx2.event.userId).toEqual('known')
+    })
+  })
+
+  describe('register', () => {
+    it('registers a plugin', async () => {
+      const [analytics] = await load({ writeKey })
+
+      await analytics.register(testPlugin)
+
+      expect(testPlugin.load).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('deregister', () => {
+    it('deregisters a plugin given its name', async () => {
+      const [analytics] = await load({ writeKey })
+      await analytics.register(testPlugin)
+
+      await analytics.deregister(testPlugin.name)
+      expect(testPlugin.unload).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -163,8 +163,8 @@ export class Analytics extends Emitter {
 
     this._user.identify(id, _traits)
     const segmentEvent = this.eventFactory.identify(
-      this._user.id(),
-      this._user.traits(),
+      this._user.id() ?? id,
+      this._user.traits() ?? (_traits as ReturnType<User['traits']>),
       options,
       this.integrations
     )
@@ -180,7 +180,9 @@ export class Analytics extends Emitter {
     })
   }
 
-  group(...args: UserParams): Promise<DispatchedEvent> | Group {
+  group(): Group
+  group(...args: UserParams): Promise<DispatchedEvent>
+  group(...args: UserParams | undefined[]): Promise<DispatchedEvent> | Group {
     if (args.length === 0) {
       return this._group
     }
@@ -190,8 +192,9 @@ export class Analytics extends Emitter {
     )
 
     this._group.identify(id, _traits)
-    const groupId = this._group.id()
-    const groupTraits = this._group.traits()
+    const groupId = this._group.id() ?? id
+    const groupTraits =
+      this._group.traits() ?? (_traits as ReturnType<Group['traits']>)
 
     const segmentEvent = this.eventFactory.group(
       groupId,

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -155,11 +155,15 @@ export class EventFactory {
       options: {},
     }
 
-    if (this.user.id()) {
-      base.userId = this.user.id()
+    const user = this.user
+
+    if (user.id()) {
+      base.userId = user.id()
     }
 
-    base.anonymousId = this.user.anonymousId()
+    if (user.anonymousId()) {
+      base.anonymousId = user.anonymousId()
+    }
 
     return base
   }

--- a/src/core/user/__tests__/index.test.ts
+++ b/src/core/user/__tests__/index.test.ts
@@ -230,6 +230,18 @@ describe('user', () => {
       })
     })
 
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be null', () => {
+        expect(user.id()).toBeNull()
+        expect(user.id('foo')).toBeNull()
+        expect(user.id()).toBeNull()
+      })
+    })
+
     describe('when cookies are enabled', () => {
       it('should get an id from the cookie', () => {
         jar.set(cookieKey, 'id')
@@ -413,6 +425,18 @@ describe('user', () => {
         assert.equal(store.get('ajs_anonymous_id'), null)
       })
     })
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be null', () => {
+        expect(user.anonymousId()).toBeNull()
+        expect(user.anonymousId('foo')).toBeNull()
+        expect(user.anonymousId()).toBeNull()
+      })
+    })
   })
 
   describe('#traits', () => {
@@ -459,6 +483,18 @@ describe('user', () => {
       user.traits({ trait: true })
       user = new User()
       expect(user.traits()).toEqual({ trait: true })
+    })
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be undefined', () => {
+        expect(user.traits()).toBeUndefined()
+        expect(user.traits({})).toBeUndefined()
+        expect(user.traits()).toBeUndefined()
+      })
     })
   })
 
@@ -771,6 +807,25 @@ describe('group', () => {
     })
     expect(store.get(User.defaults.localStorage.key)).not.toEqual({
       coolkids: true,
+    })
+  })
+
+  describe('when disabled', () => {
+    let group: Group
+    beforeEach(() => {
+      group = new Group({ disable: true })
+    })
+
+    it('id should always be null', () => {
+      expect(group.id()).toBeNull()
+      expect(group.id('foo')).toBeNull()
+      expect(group.id()).toBeNull()
+    })
+
+    it('traits should always be undefined', () => {
+      expect(group.traits()).toBeUndefined()
+      expect(group.traits({})).toBeUndefined()
+      expect(group.traits()).toBeUndefined()
     })
   })
 

--- a/src/core/user/index.ts
+++ b/src/core/user/index.ts
@@ -243,7 +243,7 @@ export class User {
 
   id = (id?: ID): ID => {
     if (this.options.disable) {
-      return
+      return null
     }
 
     const prevId = this.chainGet(this.idKey)
@@ -275,7 +275,7 @@ export class User {
 
   anonymousId = (id?: ID): ID => {
     if (this.options.disable) {
-      return
+      return null
     }
 
     if (id === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './analytics'
 export * from './browser'
-export * from './node'
+export * as AnalyticsNode from './node'
 
 export * from './core/context'
 export * from './core/events'

--- a/src/node.ts
+++ b/src/node.ts
@@ -5,11 +5,184 @@ import { analyticsNode } from './plugins/analytics-node'
 import { Plugin } from './core/plugin'
 import { EventQueue } from './core/queue/event-queue'
 import { PriorityQueue } from './lib/priority-queue'
+import { Options } from './core/events/interfaces'
+import { Callback, DispatchedEvent } from './core/arguments-resolver'
+import { Emitter } from './core/emitter'
+
+export type Identity =
+  | { userId: string; anonymousId?: string }
+  | { userId?: string; anonymousId: string }
+
+export type NodeOptions = Options & Identity
+
+export interface AnalyticsNodeJs extends Emitter {
+  /**
+   * Combines two unassociated user identities.
+   * @param userId - The new user id you want to associate with the user.
+   * @param previousId - The previous id that the user was recognized by.
+   * @param options
+   * @param callback
+   */
+  alias(
+    userId: string,
+    previousId: string,
+    options?: Options,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Associates an identified user with a collective.
+   * @param groupId - The group id to associate with the provided user.
+   * @param options - A dictionary of options including the user id.
+   * @param callback
+   */
+  group(
+    groupId: string,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+  /**
+   * Associates an identified user with a collective.
+   * @param groupId - The group id to associate with the provided user.
+   * @param traits - A dictionary of traits for the group.
+   * @param options - A dictionary of options including the user id.
+   * @param callback
+   */
+  group(
+    groupId: string,
+    traits: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Record traits about a user.
+   * Includes a unique userId and/or anonymousId and any optional traits you know about them.
+   * @param traits
+   * @param options
+   * @param callback
+   */
+  identify(
+    traits: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Records page views on your website, along with optional extra information
+   * about the page viewed by the user.
+   * @param properties
+   * @param options
+   * @param callback
+   */
+  page(
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+  /**
+   * Records page views on your website, along with optional extra information
+   * about the page viewed by the user.
+   * @param name - The name of the page.
+   * @param properties - A dictionary of properties of the page.
+   * @param options
+   * @param callback
+   */
+  page(
+    name: string,
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+  /**
+   * Records page views on your website, along with optional extra information
+   * about the page viewed by the user.
+   * @param category - The category of the page.
+   * Useful for cases like ecommerce where many pages might live under a single category.
+   * @param name - The name of the page.
+   * @param properties - A dictionary of properties of the page.
+   * @param options
+   * @param callback
+   */
+  page(
+    category: string,
+    name: string,
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Records screen views on your app, along with optional extra information
+   * about the screen viewed by the user.
+   * @param properties
+   * @param options
+   * @param callback
+   */
+  screen(
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+  /**
+   * Records screen views on your app, along with optional extra information
+   * about the screen viewed by the user.
+   * @param name - The name of the screen.
+   * @param properties
+   * @param options
+   * @param callback
+   */
+  screen(
+    name: string,
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Records actions your users perform.
+   * @param event - The name of the event you're tracking.
+   * @param options
+   * @param callback
+   */
+  track(
+    event: string,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+  /**
+   * Records actions your users perform.
+   * @param event - The name of the event you're tracking.
+   * @param properties - A dictionary of properties for the event.
+   * @param options
+   * @param callback
+   */
+  track(
+    event: string,
+    properties: object,
+    options: NodeOptions,
+    callback?: Callback
+  ): Promise<DispatchedEvent>
+
+  /**
+   * Registers one or more plugins to augment Analytics functionality.
+   * @param plugins
+   */
+  register(...plugins: Plugin[]): Promise<Context>
+
+  /**
+   * Deregisters one or more plugins based on their names.
+   * @param pluginNames - The names of one or more plugins to deregister.
+   */
+  deregister(...pluginNames: string[]): Promise<Context>
+
+  get VERSION(): string
+}
 
 export class AnalyticsNode {
   static async load(settings: {
     writeKey: string
-  }): Promise<[Analytics, Context]> {
+  }): Promise<[AnalyticsNodeJs, Context]> {
     const cookieOptions = {
       persist: false,
     }

--- a/src/plugins/analytics-node/__tests__/index.test.ts
+++ b/src/plugins/analytics-node/__tests__/index.test.ts
@@ -1,19 +1,18 @@
 const fetcher = jest.fn()
 jest.mock('node-fetch', () => fetcher)
 
-import { Analytics } from '../../../analytics'
-import { AnalyticsNode } from '../../../node'
+import { load, AnalyticsNodeJs } from '../../../node'
 
 const myDate = new Date('2016')
 const _Date = Date
 
 describe('Analytics Node', () => {
-  let ajs: Analytics
+  let ajs: AnalyticsNodeJs
 
   beforeEach(async () => {
     jest.resetAllMocks()
 
-    const [analytics] = await AnalyticsNode.load({
+    const [analytics] = await load({
       writeKey: 'abc123',
     })
 
@@ -29,7 +28,17 @@ describe('Analytics Node', () => {
 
   describe('AJS', () => {
     test('fireEvent instantiates the right event types', async () => {
-      await ajs.track('track')
+      try {
+        await ajs.track(
+          'track',
+          {},
+          {
+            anonymousId: 'foo',
+          }
+        )
+      } catch (err) {
+        console.log(err)
+      }
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/track',
         expect.anything()
@@ -41,25 +50,31 @@ describe('Analytics Node', () => {
         expect.anything()
       )
 
-      await ajs.page('page')
+      await ajs.page(
+        'page',
+        {},
+        {
+          anonymousId: 'foo',
+        }
+      )
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/page',
         expect.anything()
       )
 
-      await ajs.group('group')
+      await ajs.group('group', {}, { anonymousId: 'foo' })
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/group',
         expect.anything()
       )
 
-      await ajs.alias('alias')
+      await ajs.alias('alias', 'previous')
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/alias',
         expect.anything()
       )
 
-      await ajs.screen('screen')
+      await ajs.screen('screen', {}, { anonymousId: 'foo' })
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/screen',
         expect.anything()

--- a/src/plugins/analytics-node/__tests__/index.test.ts
+++ b/src/plugins/analytics-node/__tests__/index.test.ts
@@ -28,17 +28,13 @@ describe('Analytics Node', () => {
 
   describe('AJS', () => {
     test('fireEvent instantiates the right event types', async () => {
-      try {
-        await ajs.track(
-          'track',
-          {},
-          {
-            anonymousId: 'foo',
-          }
-        )
-      } catch (err) {
-        console.log(err)
-      }
+      await ajs.track(
+        'track',
+        {},
+        {
+          anonymousId: 'foo',
+        }
+      )
       expect(fetcher).toHaveBeenCalledWith(
         'https://api.segment.io/v1/track',
         expect.anything()

--- a/src/plugins/validation/index.ts
+++ b/src/plugins/validation/index.ts
@@ -21,8 +21,7 @@ export function isPlainObject(obj: unknown): obj is object {
 }
 
 function hasUser(event: SegmentEvent): boolean {
-  const id =
-    event.userId ?? event.anonymousId ?? event.groupId ?? event.previousId
+  const id = event.userId ?? event.anonymousId
   return isString(id)
 }
 


### PR DESCRIPTION
This change is part of the effort to improve using analytics in node.js. The goal is that this library should be able to replace the `analytics-node` library.

This PR focuses on 2 aspects:
1. Defines a node.js-specific analytics interface that represents the APIs available in node.js
2. Updates the `Analytics` class so that it can function without maintaining user/group state.

## Node.js interface

The `AnalyticsNodeJs` interface exposes the analytics API that works in node.js. If we continued exporting `Analytics` from `AnalyticsNode.load()` directly then we'd have 2 issues:

1. Many APIs are either only supported in the browser (e.g. `trackLink`) or were included for backwards compatibility with analytics.js classic and have been deprecated (e.g. `use`).
2. Analytics assumes that 1 user/group is being used at a time.

This change addresses both these points by only exposing the APIs that work in node.js and enforcing that either a `userId` or `anonymousId` is provided in each operation that generates an event.

## Analytics sans users

The `Analytics` class assumed that there would always be a single user (anonymous and/or known) at a time and would automatically keep track of the user details so our customers wouldn't have to. This causes an issue when using `Analytics` to a server environment because it's common to be handling multiple users concurrently.

The simplest way I found to handle this was to support disabling the `User` and `Group` objects so that they didn't store any state. This didn't require changing any method signatures. I thought of some alternatives such as:
- creating a `UserLike`/`GroupLike` interface to pass to Analytics instead of classes so we can pass in a no-op implementation in node.js
- Subclassing `User`/`Group` with `NullUser` and `NullGroup`
The 1st ended up leading to broader API changes that would leak into the browser usage unless we did our own type casting.
The 2nd option is safe but caused some extra work to be done in the constructor.

## Notes
I've set this PR to target the feature-node-uplift branch. Since we are changing the API for the node.js `Analytics`, this is technically a breaking change and we should do a major version bump when we decide to ship this. I don't want to block releasing from the main branch while this work is ongoing.