### PR TITLE
[bugfix] integration overrides now work with action destinations

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.7 KB"
+      "limit": "25.8 KB"
     }
   ],
   "lint-staged": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -162,6 +162,7 @@ async function registerPlugins(
   const remotePlugins = await remoteLoader(
     legacySettings,
     analytics.integrations,
+    mergedSettings,
     options.obfuscate
   ).catch(() => [])
 

--- a/src/lib/merged-options.ts
+++ b/src/lib/merged-options.ts
@@ -1,4 +1,4 @@
-import { Options } from '@/core/events/interfaces'
+import { JSONObject, Options } from '@/core/events/interfaces'
 import { LegacySettings } from '../browser'
 
 /**
@@ -13,7 +13,7 @@ import { LegacySettings } from '../browser'
 export function mergedOptions(
   settings: LegacySettings,
   options: Options
-): Record<string, object> {
+): Record<string, JSONObject> {
   const optionOverrides = Object.entries(options.integrations ?? {}).reduce(
     (overrides, [integration, options]) => {
       if (typeof options === 'object') {
@@ -28,7 +28,7 @@ export function mergedOptions(
         [integration]: {},
       }
     },
-    {} as Record<string, object>
+    {} as Record<string, JSONObject>
   )
 
   return Object.entries(settings.integrations).reduce(
@@ -41,6 +41,6 @@ export function mergedOptions(
         },
       }
     },
-    {} as Record<string, object>
+    {} as Record<string, JSONObject>
   )
 }

--- a/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/src/plugins/remote-loader/__tests__/index.test.ts
@@ -1,5 +1,7 @@
 import * as loader from '../../../lib/load-script'
 import { remoteLoader } from '..'
+import { AnalyticsBrowser } from '../../../browser'
+import { InitOptions } from '../../../analytics'
 
 const pluginFactory = jest.fn()
 
@@ -30,6 +32,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -49,6 +52,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {},
       true
     )
@@ -73,6 +77,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -94,6 +99,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -120,7 +126,8 @@ describe('Remote Loader', () => {
           },
         ],
       },
-      { All: false }
+      { All: false },
+      {}
     )
 
     expect(pluginFactory).toHaveBeenCalledTimes(0)
@@ -141,7 +148,8 @@ describe('Remote Loader', () => {
           },
         ],
       },
-      { All: false, 'remote plugin': true }
+      { All: false, 'remote plugin': true },
+      {}
     )
 
     expect(pluginFactory).toHaveBeenCalledTimes(1)
@@ -167,7 +175,8 @@ describe('Remote Loader', () => {
           },
         ],
       },
-      { 'remote plugin': false }
+      { 'remote plugin': false },
+      {}
     )
 
     expect(pluginFactory).toHaveBeenCalledTimes(0)
@@ -186,6 +195,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -247,6 +257,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -288,6 +299,7 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
@@ -339,11 +351,105 @@ describe('Remote Loader', () => {
           },
         ],
       },
+      {},
       {}
     )
 
     expect(plugins).toHaveLength(1)
     expect(plugins).toEqual(expect.arrayContaining([validPlugin]))
     expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts settings overrides from merged integrations', async () => {
+    const cdnSettings = {
+      integrations: {
+        remotePlugin: {
+          name: 'Charlie Brown',
+          version: '1.0',
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'remotePlugin',
+          libraryName: 'testPlugin',
+          url: 'cdn/path/to/file.js',
+          settings: {
+            name: 'Charlie Brown',
+            version: '1.0',
+            subscriptions: [],
+          },
+        },
+      ],
+    }
+
+    const userOverrides = {
+      remotePlugin: {
+        name: 'Chris Radek',
+      },
+    }
+
+    await remoteLoader(cdnSettings, userOverrides, {
+      remotePlugin: {
+        ...cdnSettings.integrations.remotePlugin,
+        ...userOverrides.remotePlugin,
+      },
+    })
+
+    expect(pluginFactory).toHaveBeenCalledTimes(1)
+    expect(pluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Chris Radek',
+        version: '1.0',
+        subscriptions: [],
+      })
+    )
+  })
+
+  it('accepts settings overrides from options (AnalyticsBrowser)', async () => {
+    const cdnSettings = {
+      integrations: {
+        remotePlugin: {
+          name: 'Charlie Brown',
+          version: '1.0',
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'remotePlugin',
+          libraryName: 'testPlugin',
+          url: 'cdn/path/to/file.js',
+          settings: {
+            name: 'Charlie Brown',
+            version: '1.0',
+            subscriptions: [],
+          },
+        },
+      ],
+    }
+
+    const initOptions: InitOptions = {
+      integrations: {
+        remotePlugin: {
+          name: 'Chris Radek',
+        },
+      },
+    }
+
+    await AnalyticsBrowser.load(
+      {
+        writeKey: 'key',
+        cdnSettings,
+      },
+      initOptions
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(1)
+    expect(pluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Chris Radek',
+        version: '1.0',
+        subscriptions: [],
+      })
+    )
   })
 })

--- a/src/plugins/schema-filter/index.ts
+++ b/src/plugins/schema-filter/index.ts
@@ -29,7 +29,6 @@ function disabledActionDestinations(
   })
 
   return (settings.remotePlugins ?? []).reduce((acc, p) => {
-    // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONValue
     if (p.settings['subscriptions']) {
       if (disabledRemotePlugins.includes(p.name)) {
         // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONValue

--- a/src/plugins/segmentio/index.ts
+++ b/src/plugins/segmentio/index.ts
@@ -12,7 +12,7 @@ import standard from './fetch-dispatcher'
 import { normalize } from './normalize'
 import { scheduleFlush } from './schedule-flush'
 
-export interface SegmentioSettings {
+export type SegmentioSettings = {
   apiKey: string
   apiHost?: string
   protocol?: 'http' | 'https'


### PR DESCRIPTION
This PR updates how we resolve `integrations` passed to `analytics.load()` so that they now apply towards action destinations. Prior to this change they only applied to classic destinations.

The gist is now we merge the remote plugin settings from the CDN with the integration settings/overrides the user provides, whereas previously we were using the settings exclusively.