### PR TITLE
Pre-init API tweak for Typescript users

### DIFF
--- a/src/__tests__/typedef-tests/analytics-browser.ts
+++ b/src/__tests__/typedef-tests/analytics-browser.ts
@@ -1,5 +1,4 @@
 import { Analytics } from '@/analytics'
-import { AnalyticsBuffered } from '@/core/buffer'
 import { Context } from '@/core/context'
 import { AnalyticsBrowser } from '@/browser'
 import { assertNotAny, assertIs } from '@/test-helpers/type-assertions'
@@ -9,19 +8,16 @@ import { assertNotAny, assertIs } from '@/test-helpers/type-assertions'
  * They aren't meant to be run by anything but the typescript compiler.
  */
 export default {
-  'Analytics should return AnalyticsBuffered': () => {
+  'AnalyticsBrowser should return the correct type': () => {
     const result = AnalyticsBrowser.load({ writeKey: 'abc' })
     assertNotAny(result)
-    assertIs<AnalyticsBuffered>(result)
+    assertIs<AnalyticsBrowser>(result)
   },
-  'AnalyticsBuffered should return Promise<[Analytics, Context]> if awaited on.':
+  'AnalyticsBrowser should return the correct type if awaited on.':
     async () => {
-      // @ts-expect-error
-      await new AnalyticsBuffered(() => null)
-
-      const [analytics, context] = await new AnalyticsBuffered(
-        () => undefined as unknown as Promise<[Analytics, Context]>
-      )
+      const [analytics, context] = await AnalyticsBrowser.load({
+        writeKey: 'foo',
+      })
 
       assertNotAny(analytics)
       assertIs<Analytics>(analytics)
@@ -30,9 +26,7 @@ export default {
       assertIs<Context>(context)
     },
   'Promise API should work': () => {
-    void new AnalyticsBuffered(
-      () => undefined as unknown as Promise<[Analytics, Context]>
-    )
+    void AnalyticsBrowser.load({ writeKey: 'foo' })
       .then(([analytics, context]) => {
         assertNotAny(analytics)
         assertIs<Analytics>(analytics)
@@ -50,9 +44,7 @@ export default {
   },
   'If catch is before "then" in the middleware chain, .then should take into account the catch clause':
     () => {
-      void new AnalyticsBuffered(
-        () => undefined as unknown as Promise<[Analytics, Context]>
-      )
+      void AnalyticsBrowser.load({ writeKey: 'foo' })
         .catch((err: string) => {
           assertIs<string>(err)
           return 123

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -271,11 +271,25 @@ async function loadAnalytics(
   return [analytics, ctx]
 }
 
+/**
+ * The public browser interface for this package.
+ * Use AnalyticsBrowser.load to create an instance.
+ */
 export class AnalyticsBrowser extends AnalyticsBuffered {
   private constructor(loader: AnalyticsLoader) {
     super(loader)
   }
 
+  /**
+   * Instantiates an object exposing Analytics methods.
+   *
+   * ```ts
+   * const ajs = AnalyticsBrowser.load({ writeKey: '<YOUR_WRITE_KEY>' })
+   *
+   * ajs.track("foo")
+   * ...
+   * ```
+   */
   static load(
     settings: AnalyticsBrowserSettings,
     options: InitOptions = {}

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -18,6 +18,7 @@ import {
   PreInitMethodCallBuffer,
   flushAnalyticsCallsInNewTask,
   flushAddSourceMiddleware,
+  AnalyticsLoader,
   flushSetAnonymousID,
   flushOn,
 } from './core/buffer'
@@ -270,12 +271,16 @@ async function loadAnalytics(
   return [analytics, ctx]
 }
 
-export class AnalyticsBrowser {
+export class AnalyticsBrowser extends AnalyticsBuffered {
+  private constructor(loader: AnalyticsLoader) {
+    super(loader)
+  }
+
   static load(
     settings: AnalyticsBrowserSettings,
     options: InitOptions = {}
-  ): AnalyticsBuffered {
-    return new AnalyticsBuffered((preInitBuffer) =>
+  ): AnalyticsBrowser {
+    return new this((preInitBuffer) =>
       loadAnalytics(settings, options, preInitBuffer)
     )
   }

--- a/src/core/buffer/index.ts
+++ b/src/core/buffer/index.ts
@@ -166,7 +166,7 @@ export async function callAnalyticsMethod<T extends PreInitMethodName>(
   }
 }
 
-type AnalyticsLoader = (
+export type AnalyticsLoader = (
   preInitBuffer: PreInitMethodCallBuffer
 ) => Promise<[Analytics, Context]>
 


### PR DESCRIPTION
A nice API tweak for Typescript users that occurred to me over the weekend that slightly reduces the public API surface area. We don't need to expose the AnalyticsBuffer class; it's can just be an implementation detail.

 (assuming a user who want to wrap our library)…

```ts
import { AnalyticsBrowser } from '@segment/analytics-next' // no need to know about  AnalyticsBuffered 

const loadAnalytics = (writeKey: string): AnalyticsBrowser => {
   return AnalyticsBrowser.load({ writeKey })
}

```