### PR TITLE
update playground with idiomatic next instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ const App = () => {
   )
 ```
 
-For another example,
-There is a [React example repo](https://github.com/segmentio/react-example/) which outlines using the [Segment snippet](https://github.com/segmentio/react-example/tree/main/src/examples/analytics-quick-start) and using the [Segment npm package](https://github.com/segmentio/react-example/tree/main/src/examples/analytics-package).
+More React Examples:
+
+- Our [playground](example/pages/_app.tsx) (written in NextJS) -- this can be run with `make dev`.
+- Complex [React example repo](https://github.com/segmentio/react-example/) which outlines using the [Segment snippet](https://github.com/segmentio/react-example/tree/main/src/examples/analytics-quick-start) and using the [Segment npm package](https://github.com/segmentio/react-example/tree/main/src/examples/analytics-package).
 
 ### using `Vite` with `Vue 3`
 

--- a/example/context/analytics.tsx
+++ b/example/context/analytics.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { AnalyticsBrowser } from '../../'
+import { useWriteKey } from '../utils/hooks/useConfig'
 
 const AnalyticsContext = React.createContext<AnalyticsBrowser>(undefined)
 
-export const AnalyticsProvider: React.FC<{ writeKey: string }> = ({
-  children,
-  writeKey,
-}) => {
+export const AnalyticsProvider: React.FC<{
+  writeKey: string
+  CDNUrl?: string
+}> = ({ children, writeKey, CDNUrl }) => {
   const analytics = React.useMemo(
-    () => AnalyticsBrowser.load({ writeKey }),
-    [writeKey]
+    () => AnalyticsBrowser.load({ writeKey, CDNUrl }),
+    [writeKey, CDNUrl]
   )
   return (
     <AnalyticsContext.Provider value={analytics}>
@@ -19,3 +20,8 @@ export const AnalyticsProvider: React.FC<{ writeKey: string }> = ({
 }
 
 export const useAnalytics = () => React.useContext(AnalyticsContext)
+
+export const AnalyticsProviderWithConfig = ({ children }) => {
+  const [key] = useWriteKey()
+  return <AnalyticsProvider writeKey={key}> {children}</AnalyticsProvider>
+}

--- a/example/pages/_app.js
+++ b/example/pages/_app.js
@@ -1,8 +1,0 @@
-import '../styles/globals.css'
-import '../styles/dracula/dracula-ui.css'
-import '../styles/dracula/prism.css'
-import '../styles/logs-table.css'
-
-export default function ExampleApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
-}

--- a/example/pages/_app.tsx
+++ b/example/pages/_app.tsx
@@ -1,0 +1,17 @@
+import '../styles/globals.css'
+import '../styles/dracula/dracula-ui.css'
+import '../styles/dracula/prism.css'
+import '../styles/logs-table.css'
+
+import { AnalyticsProvider } from '../context/analytics'
+import { useWriteKey, useCDNUrl } from '../utils/hooks/useConfig'
+
+export default function ExampleApp({ Component, pageProps }) {
+  const [writeKey] = useWriteKey()
+  const [CDNUrl] = useCDNUrl()
+  return (
+    <AnalyticsProvider writeKey={writeKey} CDNUrl={CDNUrl}>
+      <Component {...pageProps} />
+    </AnalyticsProvider>
+  )
+}

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -7,16 +7,10 @@ import JSONTree from 'react-json-tree'
 import faker from 'faker'
 import { shuffle } from 'lodash'
 import Table from 'rc-table'
-import { useLocalStorage } from '../utils/hooks/useLocalStorage'
 import { useDidMountEffect } from '../utils/hooks/useDidMountEffect'
-
-import {
-  AnalyticsBrowserSettings,
-  AnalyticsBrowser,
-  Analytics,
-  Context,
-} from '../../'
-import { useWriteKey } from '../utils/hooks/useWritekey'
+import { useAnalytics } from '../context/analytics'
+import { AnalyticsBrowserSettings, Analytics, Context } from '../../'
+import { useCDNUrl, useWriteKey } from '../utils/hooks/useConfig'
 
 const jsontheme = {
   scheme: 'tomorrow',
@@ -46,10 +40,8 @@ export default function Home(): React.ReactElement {
   >(undefined)
   const [analyticsReady, setAnalyticsReady] = useState<boolean>(false)
   const [writeKey, setWriteKey] = useWriteKey()
-  const [url, setURL] = useLocalStorage(
-    'segment_playground_cdn_url',
-    'https://cdn.segment.com'
-  )
+  const [url, setURL] = useCDNUrl()
+  const analyticsBrowser = useAnalytics()
 
   useDidMountEffect(() => {
     fetchAnalytics()
@@ -83,10 +75,7 @@ export default function Home(): React.ReactElement {
 
   async function fetchAnalytics() {
     try {
-      const [response, ctx] = await AnalyticsBrowser.load({
-        ...settings,
-        writeKey,
-      })
+      const [response, ctx] = await analyticsBrowser
       setCtx(ctx)
       setAnalytics(response)
       setAnalyticsReady(true)

--- a/example/pages/vanilla/index.tsx
+++ b/example/pages/vanilla/index.tsx
@@ -1,13 +1,9 @@
 import Link from 'next/link'
-import { AnalyticsBrowser } from '../../../'
-
-export const analytics = AnalyticsBrowser.load({
-  writeKey: process.env.NEXT_PUBLIC_WRITEKEY,
-})
-
-analytics.then(() => console.log('loaded!'))
+import React from 'react'
+import { useAnalytics } from '../../context/analytics'
 
 const Vanilla: React.FC = () => {
+  const analytics = useAnalytics()
   analytics.identify('hello').then((res) => console.log('identified!', res))
   return (
     <div>

--- a/example/pages/vanilla/other-page.tsx
+++ b/example/pages/vanilla/other-page.tsx
@@ -1,11 +1,9 @@
 import Link from 'next/link'
 import React, { useEffect } from 'react'
-import { analytics } from '.'
+import { useAnalytics } from '../../context/analytics'
 
 const OtherPage: React.FC = () => {
-  useEffect(() => {
-    analytics.identify('hello').then((res) => console.log('identified!', res))
-  }, [])
+  const analytics = useAnalytics()
   return (
     <div>
       <input

--- a/example/pages/with-context/index.tsx
+++ b/example/pages/with-context/index.tsx
@@ -1,20 +1,10 @@
-import { AnalyticsProvider, useAnalytics } from '../../context/analytics'
-import { useWriteKey } from '../../utils/hooks/useWritekey'
+import { useAnalytics } from '../../context/analytics'
 
-const App = () => {
+export default () => {
   const analytics = useAnalytics()
   return (
     <button onClick={() => analytics.track('hello world').then(console.log)}>
       Track!
     </button>
-  )
-}
-
-export default () => {
-  const [writeKey] = useWriteKey()
-  return (
-    <AnalyticsProvider writeKey={writeKey}>
-      <App />
-    </AnalyticsProvider>
   )
 }

--- a/example/utils/hooks/useConfig.ts
+++ b/example/utils/hooks/useConfig.ts
@@ -4,3 +4,8 @@ export const useWriteKey = () => useLocalStorage(
   'segment_playground_write_key',
   process.env.NEXT_PUBLIC_WRITEKEY
 )
+export const useCDNUrl = () =>  useLocalStorage(
+  'segment_playground_cdn_url',
+  'https://cdn.segment.com'
+)
+


### PR DESCRIPTION
This PR makes the example page reflect best practices (i.e. single load instantiation,  SSR-ready).

The canonical example for how our app should be used should be colocated with our code, so it's important that they are mantained, and that we can point to. 

(side note: yep, the playground is not a "one-size-fits-all",  but we can have a full directory for independent examples once we move to a more typical monorepo setup).