### PR TITLE
[bugfix] ignore invalid URLs with TLD lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.8 KB"
+      "limit": "25.82 KB"
     }
   ],
   "lint-staged": {

--- a/src/core/__tests__/auto-track.test.ts
+++ b/src/core/__tests__/auto-track.test.ts
@@ -125,7 +125,7 @@ describe('track helpers', () => {
       expect(mockTrack).toHaveBeenCalled()
     })
 
-    it.only('should still navigate even if the track call fails', async () => {
+    it('should still navigate even if the track call fails', async () => {
       mockTrack.mockClear()
 
       let rejected = false
@@ -183,7 +183,7 @@ describe('track helpers', () => {
       await analytics.trackLink(link, 'event', { property: true })
       link.click()
 
-      expect(mockTrack).toBeCalledWith('event', { property: true })
+      expect(mockTrack).toBeCalledWith('event', { property: true }, {})
     })
 
     it('should accept an event function', async () => {
@@ -193,7 +193,7 @@ describe('track helpers', () => {
       await analytics.trackLink(link, event, { foo: 'bar' })
       link.click()
 
-      expect(mockTrack).toBeCalledWith('A', { foo: 'bar' })
+      expect(mockTrack).toBeCalledWith('A', { foo: 'bar' }, {})
     })
 
     it('should accept a properties function', async () => {
@@ -203,7 +203,7 @@ describe('track helpers', () => {
       await analytics.trackLink(link, 'event', properties)
       link.click()
 
-      expect(mockTrack).toBeCalledWith('event', { type: 'A' })
+      expect(mockTrack).toBeCalledWith('event', { type: 'A' }, {})
     })
 
     it('should load an href on click', async () => {
@@ -349,7 +349,7 @@ describe('track helpers', () => {
     it('should send an event and properties', async () => {
       await analytics.trackForm(form, 'event', { property: true })
       submit.click()
-      expect(mockTrack).toBeCalledWith('event', { property: true })
+      expect(mockTrack).toBeCalledWith('event', { property: true }, {})
     })
 
     it('should accept an event function', async () => {
@@ -358,7 +358,7 @@ describe('track helpers', () => {
       }
       await analytics.trackForm(form, event, { foo: 'bar' })
       submit.click()
-      expect(mockTrack).toBeCalledWith('event', { foo: 'bar' })
+      expect(mockTrack).toBeCalledWith('event', { foo: 'bar' }, {})
     })
 
     it('should accept a properties function', async () => {
@@ -367,7 +367,7 @@ describe('track helpers', () => {
       }
       await analytics.trackForm(form, 'event', properties)
       submit.click()
-      expect(mockTrack).toBeCalledWith('event', { property: true })
+      expect(mockTrack).toBeCalledWith('event', { property: true }, {})
     })
 
     it('should call submit after a timeout', async (done) => {

--- a/src/core/user/__tests__/tld.test.ts
+++ b/src/core/user/__tests__/tld.test.ts
@@ -22,18 +22,15 @@ describe('topDomain', function () {
   })
 
   it('should match the following urls', function () {
-    assert.strictEqual(tld(new URL('http://www.google.com')), 'google.com')
+    assert.strictEqual(tld('http://www.google.com'), 'google.com')
     assert.strictEqual(
-      tld(new URL('http://gist.github.com/calvinfo/some_file')),
+      tld('http://gist.github.com/calvinfo/some_file'),
       'github.com'
     )
-    assert.strictEqual(tld(new URL('http://localhost:3000')), undefined)
-    assert.strictEqual(
-      tld(new URL('https://google.com:443/stuff')),
-      'google.com'
-    )
-    assert.strictEqual(tld(new URL('http://dev:3000')), undefined)
-    assert.strictEqual(tld(new URL('http://app.jut.io')), 'jut.io')
-    assert.strictEqual(tld(new URL('http://app.segment.io')), 'segment.io')
+    assert.strictEqual(tld('http://localhost:3000'), undefined)
+    assert.strictEqual(tld('https://google.com:443/stuff'), 'google.com')
+    assert.strictEqual(tld('http://dev:3000'), undefined)
+    assert.strictEqual(tld('http://app.jut.io'), 'jut.io')
+    assert.strictEqual(tld('http://app.segment.io'), 'segment.io')
   })
 })

--- a/src/core/user/index.ts
+++ b/src/core/user/index.ts
@@ -66,7 +66,7 @@ export class Cookie extends Store {
   static get defaults(): CookieOptions {
     return {
       maxage: ONE_YEAR,
-      domain: tld(new URL(window.location.href)),
+      domain: tld(window.location.href),
       path: '/',
       sameSite: 'Lax',
     }

--- a/src/core/user/tld.ts
+++ b/src/core/user/tld.ts
@@ -31,8 +31,19 @@ function levels(url: URL): string[] {
   return levels
 }
 
-export function tld(url: URL): string | undefined {
-  const lvls = levels(url)
+function parseUrl(url: string): URL | undefined {
+  try {
+    return new URL(url)
+  } catch {
+    return
+  }
+}
+
+export function tld(url: string): string | undefined {
+  const parsedUrl = parseUrl(url)
+  if (!parsedUrl) return
+
+  const lvls = levels(parsedUrl)
 
   // Lookup the real top level one.
   for (let i = 0; i < lvls.length; ++i) {

--- a/src/plugins/segmentio/normalize.ts
+++ b/src/plugins/segmentio/normalize.ts
@@ -14,7 +14,7 @@ function getCookieOptions(): CookieAttributes {
     return cookieOptions
   }
 
-  const domain = tld(new URL(window.location.href))
+  const domain = tld(window.location.href)
   cookieOptions = {
     expires: 31536000000, // 1 year
     secure: false,


### PR DESCRIPTION
Turns out we had an `it.only` in the auto-track tests so most of those tests weren't being ran. Many of the tests were failing. This PR re-enables the auto-track tests and makes the `tld` check more resilient by parsing URLs internally.

Discovered as part of #478