### PR TITLE
enhance typechecking and remove tests from build

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -23,8 +23,8 @@
     "umd": "webpack",
     "build:dev": "yarn clean && yarn build-prep && yarn concurrently 'yarn umd' 'yarn pkg' 'yarn cjs'",
     "build:prod": "NODE_ENV=production yarn clean && yarn build-prep && yarn concurrently 'NODE_ENV=production yarn umd' 'NODE_ENV=production yarn pkg' 'NODE_ENV=production yarn cjs'",
-    "pkg": "tsc",
-    "cjs": "tsc -p tsconfig.cjs.json",
+    "pkg": "tsc -p tsconfig.build.json",
+    "cjs": "tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "clean": "rm -rf dist",
     "lint": "yarn constraints && tsc --noEmit && eslint '**/*.{js,jsx,ts,tsx}'",
     "test": "jest"

--- a/packages/browser/qa/__tests__/backwards-compatibility.test.ts
+++ b/packages/browser/qa/__tests__/backwards-compatibility.test.ts
@@ -134,8 +134,8 @@ describe('Backwards compatibility', () => {
       writeKey: TEST_WRITEKEY,
     })
 
-    const classic = result.classic.codeEvaluation
-    const next = result.next.codeEvaluation
+    const classic = result.classic.codeEvaluation as any
+    const next = result.next.codeEvaluation as any
 
     expect(next['track']).toEqual(classic['track'])
     expect(next['identify']).toEqual(classic['identify'])

--- a/packages/browser/qa/__tests__/destinations.test.ts
+++ b/packages/browser/qa/__tests__/destinations.test.ts
@@ -3,14 +3,21 @@ import { reportMetrics } from '../lib/benchmark'
 import { browser } from '../lib/browser'
 import { run } from '../lib/runner'
 import { server } from '../lib/server'
-
 jest.setTimeout(100000)
 
+if (!process.env.QA_SAMPLES) {
+  throw new Error('no process.env.QA_SAMPLES')
+}
 const samples = JSON.parse(process.env.QA_SAMPLES)
 
 let destinations = Object.keys(samples)
 if (process.env.DESTINATION) {
   destinations = [process.env.DESTINATION]
+}
+declare global {
+  interface URLSearchParams {
+    entries(): [string, string][]
+  }
 }
 
 jest.retryTimes(10)

--- a/packages/browser/qa/__tests__/smoke.test.ts
+++ b/packages/browser/qa/__tests__/smoke.test.ts
@@ -9,6 +9,9 @@ import { server } from '../lib/server'
 jest.setTimeout(100000)
 type RemovePromise<T> = T extends Promise<infer U> ? U : T
 
+if (!process.env.QA_SOURCES) {
+  throw new Error('no process.env.QA_SOURCES')
+}
 const samples = process.env.QA_SOURCES.split(',')
 
 function compareSchema(results: RemovePromise<ReturnType<typeof run>>) {

--- a/packages/browser/qa/lib/runner.ts
+++ b/packages/browser/qa/lib/runner.ts
@@ -9,6 +9,7 @@ type ComparisonParams = {
   serverURL: string
   writeKey: string
   script: string
+  key?: string | number | symbol,
 }
 
 export async function run(params: ComparisonParams) {

--- a/packages/browser/qa/lib/stats.ts
+++ b/packages/browser/qa/lib/stats.ts
@@ -1,14 +1,20 @@
-import { Analytics } from '../../src/analytics'
+import { Analytics } from '../../src/index'
 import { Context } from '../../src/core/context'
 import { AnalyticsNode } from '../../src/node'
 import ex from 'execa'
 
-let analytics: Analytics = undefined
+let analytics!: Analytics
+
 
 const getBranch = async () =>
   (await ex('git', ['branch', '--show-current'])).stdout
 
 async function client(): Promise<Analytics> {
+
+  if (!process.env.STATS_WRITEKEY) {
+    throw new Error('no process.env.STATS_WRITEKEY')
+  }
+
   if (analytics) {
     return analytics
   }

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/test-helpers/**", "**/tester/**"],
+  "compilerOptions": {
+    "outDir": "./dist/pkg"
+  }
+}

--- a/packages/browser/tsconfig.cjs.json
+++ b/packages/browser/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "./dist/cjs"
-  }
-}

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -8,13 +8,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "sourceMap": true,
-    "outDir": "dist/pkg",
     "lib": ["es2020", "DOM"],
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "exclude": ["node_modules", "dist"],
-  "include": ["src"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
     "skipLibCheck": true,
     "incremental": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": true
   }
 }


### PR DESCRIPTION
This fixes tests being included in our npm package.

### Before:
```
npm notice === Tarball Details ===
npm notice name:          @segment/analytics-next
npm notice package size:  1.1 MB
npm notice unpacked size: 4.5 MB
npm notice total files:   940
```
### After:
```
npm notice === Tarball Details ===
npm notice name:          @segment/analytics-next
npm notice package size:  873.7 kB
npm notice unpacked size: 2.8 MB
npm notice total files:   568
```

This _also_ creates a base tsconfig that include e2e tests, so type checking actually works on those files.
![image](https://user-images.githubusercontent.com/5115498/172263531-d6478bff-38d2-4a59-8406-de5fd3ef905a.png)

