### PR TITLE
[bugfix] set event timestamp at event creation

### DIFF
--- a/packages/browser/src/core/events/__tests__/index.test.ts
+++ b/packages/browser/src/core/events/__tests__/index.test.ts
@@ -101,6 +101,11 @@ describe('Event Factory', () => {
       expect(track.messageId).toContain('ajs-next')
     })
 
+    test('adds a timestamp', () => {
+      const track = factory.track('Order Completed', shoes)
+      expect(track.timestamp).toBeInstanceOf(Date)
+    })
+
     test('adds a random message id even when random is mocked', () => {
       jest.useFakeTimers()
       jest.spyOn(uuid, 'v4').mockImplementation(() => 'abc-123')
@@ -331,6 +336,9 @@ describe('Event Factory', () => {
 
         expect(normalized.messageId?.length).toBeGreaterThanOrEqual(41) // 'ajs-next-md5(content + [UUID])'
         delete normalized.messageId
+
+        expect(normalized.timestamp).toBeInstanceOf(Date)
+        delete normalized.timestamp
 
         expect(normalized).toStrictEqual({
           integrations: { Segment: true },

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -221,6 +221,7 @@ export class EventFactory {
     const { options, ...rest } = event
 
     const body = {
+      timestamp: new Date(),
       ...rest,
       context,
       integrations: allIntegrations,

--- a/packages/browser/src/plugins/segmentio/__tests__/normalize.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/normalize.test.ts
@@ -79,6 +79,13 @@ describe('before loading', () => {
       assert(object.userId === 'user-id')
     })
 
+    it('should not replace the .timestamp', () => {
+      const timestamp = new Date()
+      object.timestamp = timestamp
+      normalize(analytics, object, options, {})
+      assert(object.timestamp === timestamp)
+    })
+
     it('should not replace the .userId', () => {
       analytics.user().id('user-id')
       object.userId = 'existing-id'

--- a/packages/browser/src/plugins/segmentio/normalize.ts
+++ b/packages/browser/src/plugins/segmentio/normalize.ts
@@ -161,7 +161,6 @@ export function normalize(
   json.userId = json.userId || user.id()
   json.anonymousId = user.anonymousId(anonId)
   json.sentAt = new Date()
-  json.timestamp = new Date()
 
   const failed = analytics.queue.failedInitializations || []
   if (failed.length > 0) {


### PR DESCRIPTION
This PR updates when the `timestamp` property of an event gets set. Currently for `AnalyticsBrowser`, it is set right before sending the event to Segment. This means it's almost exactly the same as the `sentAt` timestamp, and is updated every time we retry sending the event.

Instead it should reflect the time that the event occurred (i.e. when the event was created) and should be unchanged across retries. This is the behavior analytics.js (classic) exhibits.

This also puts us in accordance with the [spec for timestamps](https://segment.com/docs/connections/spec/common/#timestamps). Through some testing I found that the `timestamp` we set on the client-side becomes the `originalTimestamp` in the event after it hits the tracking api. The `timestamp` field then gets replaced by the `originalTimestamp` with clock-skew taken into account.

## Testing

I tested this in my own app and also added some tests to ensure `timestamp` is being added. We actually have many more tests that show `timestamp` is added to the event sent to the tracking API so I didn't have to write too many new ones :smile:
