### PR TITLE
tweak hoisting limits

### DIFF
--- a/examples/standalone-playground/package.json
+++ b/examples/standalone-playground/package.json
@@ -2,8 +2,7 @@
   "name": "standalone-playground",
   "private": true,
   "installConfig": {
-    "selfReferences": false,
-    "hoistingLimits": "dependencies"
+    "hoistingLimits": "workspaces"
   },
   "scripts": {
     "watch": "NODE_ENV=production yarn workspace @segment/analytics-next umd --watch",


### PR DESCRIPTION
This is just an OCD improvement as it doesn't really matter in this project. "workspaces" is a slightly better setting, as it creates a typical flat file structures

This workspace needs to limit hoisting to begin with to put the umd bundle inside the relative path of the http-server. 

https://yarnpkg.com/configuration/manifest#installConfig
