### PR TITLE
Dont throw on mutex failure

### DIFF
--- a/packages/browser/src/lib/priority-queue/persisted.ts
+++ b/packages/browser/src/lib/priority-queue/persisted.ts
@@ -81,7 +81,7 @@ function mutex(key: string, onUnlock: Function, attempt = 0): void {
       mutex(key, onUnlock, attempt + 1)
     }, lockTimeout)
   } else {
-    throw new Error('Unable to retrieve lock')
+    console.error('Unable to retrieve lock')
   }
 }
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉

Please add a description of your PR, including the what and why

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.

--->

Make sure we're just logging the error instead of throwing, especially since if the error is thrown in the setTimeout call it won't be catchable