### PR TITLE
add ability to disable user in Analytics constructor

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -32,7 +32,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.5 KB"
+      "limit": "25.52 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -155,11 +155,15 @@ export class EventFactory {
       options: {},
     }
 
-    if (this.user.id()) {
-      base.userId = this.user.id()
+    const user = this.user
+
+    if (user.id()) {
+      base.userId = user.id()
     }
 
-    base.anonymousId = this.user.anonymousId()
+    if (user.anonymousId()) {
+      base.anonymousId = user.anonymousId()
+    }
 
     return base
   }

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -230,6 +230,18 @@ describe('user', () => {
       })
     })
 
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be null', () => {
+        expect(user.id()).toBeNull()
+        expect(user.id('foo')).toBeNull()
+        expect(user.id()).toBeNull()
+      })
+    })
+
     describe('when cookies are enabled', () => {
       it('should get an id from the cookie', () => {
         jar.set(cookieKey, 'id')
@@ -413,6 +425,18 @@ describe('user', () => {
         assert.equal(store.get('ajs_anonymous_id'), null)
       })
     })
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be null', () => {
+        expect(user.anonymousId()).toBeNull()
+        expect(user.anonymousId('foo')).toBeNull()
+        expect(user.anonymousId()).toBeNull()
+      })
+    })
   })
 
   describe('#traits', () => {
@@ -459,6 +483,18 @@ describe('user', () => {
       user.traits({ trait: true })
       user = new User()
       expect(user.traits()).toEqual({ trait: true })
+    })
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        user = new User({ disable: true })
+      })
+
+      it('should always be undefined', () => {
+        expect(user.traits()).toBeUndefined()
+        expect(user.traits({})).toBeUndefined()
+        expect(user.traits()).toBeUndefined()
+      })
     })
   })
 
@@ -774,6 +810,25 @@ describe('group', () => {
     })
     expect(store.get(User.defaults.localStorage.key)).not.toEqual({
       coolkids: true,
+    })
+  })
+
+  describe('when disabled', () => {
+    let group: Group
+    beforeEach(() => {
+      group = new Group({ disable: true })
+    })
+
+    it('id should always be null', () => {
+      expect(group.id()).toBeNull()
+      expect(group.id('foo')).toBeNull()
+      expect(group.id()).toBeNull()
+    })
+
+    it('traits should always be undefined', () => {
+      expect(group.traits()).toBeUndefined()
+      expect(group.traits({})).toBeUndefined()
+      expect(group.traits()).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
This PR makes it possible to effectively disable `analytics.user()` by having all methods return either `null` or `undefined`. This is needed for the node.js version of analytics where assuming the app has a single user at a time will cause unintended issues.

This change is pulled from https://github.com/segmentio/analytics-next/pull/459. Now that we have a monorepo I wanted to separate this change from the purely node.js changes in #459.