### PR TITLE
add seperate types to node build

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     "require": "./dist/cjs/index.js",
     "import": "./dist/esm/index.js"
@@ -21,7 +21,7 @@
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "build:esm": "yarn tsc -p tsconfig.build.json --outDir ./dist/esm --module esnext",
-    "watch:build": "yarn concurrently 'yarn:build:cjs --watch --sourceMap' 'yarn:build:esm --watch --sourceMap'",
+    "watch:build": "yarn concurrently 'yarn:build:cjs --watch' 'yarn:build:esm --watch'",
     "watch:test": "yarn test --watch",
     "prepare": "echo 'Prepare script...\n' && yarn build",
     "tsc": "yarn run -T tsc",

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -7,7 +7,14 @@
     "target": "es2019",
     "moduleResolution": "node",
     "outDir": "./dist",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    // publish sourceMaps
+    "sourceMap": true,
+    // publish declarationMaps (enable go-to-definition in IDE)
+    "declarationMap": true,
+    // add type declarations to "types" folder
+    "declaration": true,
+    "declarationDir": "./dist/types"
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
1. add separate types folder (not specific to any module format).
2. publish source maps (similar to browser) -- common in popular packages like sentry, commercetools, etc.
3. publish declaration maps (enable go-to-definition) -- fairly common (e.g. react-hook-form)