### PR TITLE
tweak tag push

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "husky install",
     "changeset": "changeset",
     "update-versions-and-changelogs": "changeset version && yarn version-run-all",
-    "release": "yarn prepare-run-all && changeset publish && git push --no-verify origin --tags && yarn postpublish-run-all",
+    "release": "yarn prepare-run-all && changeset publish && yarn postpublish-run-all && git push origin --tags --no-verify",
     "prepare-run-all": "yarn workspaces foreach -vpt --no-private run prepare",
     "postpublish-run-all": "yarn workspaces foreach -vpt --no-private run postpublish",
     "version-run-all": "yarn workspaces foreach -vpt --no-private run version",


### PR DESCRIPTION
I haven't been able to repro this successfully locally, it seems possible that there is an issue with the way that the tag creation step works in the [changeset code](https://github.com/changesets/changesets/blob/main/packages/cli/src/commands/publish/index.ts#L85) on buildkite, where the process executes before the tag creation finishes.

Creating and pushing tags on buildkite (without changeset publish) works fine in the [test buildkite repo I created](https://github.com/segmentio/analytics-publish-test).
