### PR TITLE
fix eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "turbo run test",
     "lint": "yarn constraints && turbo run lint",
     "build": "turbo run build",
+    "build:packages": "turbo run build:packages",
     "dev": "yarn browser exec make dev",
     "postinstall": "husky install",
     "changeset": "changeset",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,7 +35,7 @@
     "pkg": "yarn tsc -p tsconfig.build.json",
     "cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "clean": "rm -rf dist",
-    "lint": "yarn tsc --noEmit && yarn eslint '**/*.{js,jsx,ts,tsx}'",
+    "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "test": "yarn jest"
   },
   "size-limit": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "yarn jest",
-    "lint": "yarn concurrently 'yarn:eslint' 'yarn:tsc --noEmit'",
+    "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build:esm": "yarn tsc -p tsconfig.build.json",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "yarn jest",
-    "lint": "yarn concurrently 'yarn:eslint' 'yarn:tsc --noEmit'",
+    "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "build:esm": "yarn tsc -p tsconfig.build.json --outDir ./dist/esm --module esnext",

--- a/turbo.json
+++ b/turbo.json
@@ -5,14 +5,23 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]
     },
+    "build:packages": {
+      "dependsOn": [
+        "@segment/analytics-next#build",
+        "@segment/analytics-node#build",
+        "@segment/analytics-core#build"
+      ],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "dependsOn": ["build"],
       "outputs": [],
       "inputs": ["src/**", "test*/**"]
     },
     "lint": {
+      "dependsOn": ["build:packages"],
       "outputs": [],
-      "inputs": ["**/*.ts?x", "**/*.js", "**/*.json"]
+      "inputs": ["**/*.ts", "**/*.tsx", "**/*.js"]
     }
   }
 }


### PR DESCRIPTION
- I improved the lint command so it doesn't require building examples
- I realized that the generic repo eslint command was missing the "."