### PR TITLE
Create github release from tags after tags are pushed

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -17,6 +17,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name "buildkite-agent"
-          git config --global user.email "buildkite-agent@segment.com"
+          git config --global user.name "Segment Github"
+          git config --global user.email "github-actions@segment.com"
           bash scripts/create-release-from-tags.sh

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,22 @@
+# Creating the github release is the final step of the release.
+name: Create Github Release
+on:
+  push:
+    tags:
+      - "@segment/*"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Create Github Release From Tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "buildkite-agent"
+          git config --global user.email "buildkite-agent@segment.com"
+          bash scripts/create-release-from-tags.sh

--- a/scripts/create-release-from-tags.sh
+++ b/scripts/create-release-from-tags.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Create github release(s) for every tag of the current commit. Use the github cli.
+
+tags=$(git tag --points-at HEAD)
+
+for tag in "${tags[@]}"; do
+  gh release create "$tag"
+done


### PR DESCRIPTION
As the final automation step, automatically create a github release once tags are pushed (in the release step).

Github actions includes the gh CLI (pre-installed) by default.

This doesn't include logic to add "notes" ATM -- we can add some logic to pass the "notes property" and link to the changelog later. For now, we can manually edit the release after-the-fact.