### PR TITLE
refactor tsconfig -- make consistent

### DIFF
--- a/.changeset/tidy-chairs-whisper.md
+++ b/.changeset/tidy-chairs-whisper.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-core': patch
+---
+
+Fix "failed to parse source map" in analytics-core ([#420](https://github.com/segmentio/analytics-next/issues/420))

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "./dist/cjs/index.js",
   "module": "./dist/pkg/index.js",
-  "types": "./dist/pkg/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "browser": {
     "./dist/cjs/node": "./dist/cjs/node/node.browser.js",
     "./dist/cjs/node.js": "./dist/cjs/node/node.browser.js",
@@ -17,8 +17,7 @@
     "./dist/pkg/node.js": "./dist/pkg/node/node.browser.js"
   },
   "files": [
-    "dist/",
-    "src/"
+    "dist/"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -17,7 +17,10 @@
     "./dist/pkg/node.js": "./dist/pkg/node/node.browser.js"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "src/",
+    "!**/__tests__/**",
+    "!**/tester/**"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -3,6 +3,15 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/test-helpers/**", "**/tester/**"],
   "compilerOptions": {
-    "outDir": "./dist/pkg"
+    "incremental": false,
+    "outDir": "./dist/pkg",
+    "importHelpers": true,
+    // publish sourceMaps
+    "sourceMap": true,
+    // publish declarationMaps (enable go-to-definition in IDE)
+    "declarationMap": true,
+    // add type declarations to "types" folder
+    "declaration": true,
+    "declarationDir": "./dist/types"
   }
 }

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "importHelpers": true,
     "module": "esnext",
     "target": "ES5",
-    "declaration": true,
     "moduleResolution": "node",
+    "importHelpers": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "lib": ["es2020", "DOM"],

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -63,6 +63,7 @@ const config = {
           {
             loader: 'ts-loader',
             options: {
+              configFile: 'tsconfig.build.json',
               transpileOnly: true,
             },
           },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "src/",
+    "!**/__tests__/**"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,5 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/__tests__/**", "**/*.test.*"]
+  "exclude": ["**/__tests__/**", "**/*.test.*"],
+  "compilerOptions": {
+    "incremental": false,
+    "outDir": "./dist/esm",
+    "importHelpers": true,
+    // publish sourceMaps
+    "sourceMap": true,
+    // publish declarationMaps (enable go-to-definition in IDE)
+    "declarationMap": true,
+    // add type declarations to "types" folder
+    "declaration": true,
+    "declarationDir": "./dist/types"
+  }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,19 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "importHelpers": true,
     "module": "esnext",
-    "lib": ["es2020"],
     "target": "ES5",
-    "outDir": "./dist/esm", // TODO: move to base tsconfig
     "moduleResolution": "node",
-    // publish sourceMaps
-    "sourceMap": true, // TODO: move to base tsconfig
-    // publish declarationMaps (enable go-to-definition in IDE)
-    "declarationMap": true, // TODO: move to base tsconfig
-    // add type declarations to "types" folder
-    "declaration": true, // TODO: move to base tsconfig
-    "declarationDir": "./dist/types" // TODO: move to base tsconfig (once browser is refactored)
-  },
-  "exclude": ["node_modules", "dist"]
+    "lib": ["es2020"]
+  }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,7 +10,9 @@
     "import": "./dist/esm/index.js"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "src/",
+    "!**/__tests__/**"
   ],
   "engines": {
     "node": ">=12"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
-    "build:esm": "yarn tsc -p tsconfig.build.json --outDir ./dist/esm --module esnext",
+    "build:esm": "yarn tsc -p tsconfig.build.json",
     "watch": "yarn concurrently 'yarn:build:cjs --watch' 'yarn:build:esm --watch'",
     "watch:test": "yarn test --watch",
     "tsc": "yarn run -T tsc",

--- a/packages/node/tsconfig.build.json
+++ b/packages/node/tsconfig.build.json
@@ -3,6 +3,15 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "incremental": false /* do not include .tsbuildinfo in prod build */
+    "incremental": false,
+    "outDir": "./dist/esm",
+    "importHelpers": true,
+    // publish sourceMaps
+    "sourceMap": true,
+    // publish declarationMaps (enable go-to-definition in IDE)
+    "declarationMap": true,
+    // add type declarations to "types" folder
+    "declaration": true,
+    "declarationDir": "./dist/types"
   }
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,20 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    // https://www.npmjs.com/package/@tsconfig/node12
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
-    "module": "commonjs",
-    "target": "es2019",
+    "module": "esnext",
+    "target": "ES5",
     "moduleResolution": "node",
-    "outDir": "./dist",
-    "baseUrl": "./src",
-    // publish sourceMaps
-    "sourceMap": true,
-    // publish declarationMaps (enable go-to-definition in IDE)
-    "declarationMap": true,
-    // add type declarations to "types" folder
-    "declaration": true,
-    "declarationDir": "./dist/types"
-  },
-  "exclude": ["node_modules", "dist"]
+    "lib": ["es2020"] // TODO: https://www.npmjs.com/package/@tsconfig/node12?
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,6 @@
     "skipLibCheck": true,
     "incremental": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "baseUrl": "./src",
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "noUnusedParameters": true
   }
 }


### PR DESCRIPTION
- Browser:
   -  generate a `types` folder in `browser`, similar to the rest of the packages
     - reference tsconfig.build.json in webpack, which is the correct tsconfig to reference.
     - no longer include the `src` folder (reduces package size significantly, and it's much more common not to include src. does not affect any debugging within the monorepo, and if really needed, can always "add folder to workspace" for external sources.)
     
 - make tsconfig and tsconfig.build.json consistent across packages -- tsconfig.build.json will be a build configuration; therefore, it has an `outDir` and `typesDir` and be responsible for specifics around generating the `dist` folder. `tsconfig.json` is a base tsconfig and should contains information around the overall environment (e.g. target, libs), with enough info run lint / jest / etc correctly without building a dist folder or generating declarations.
