### PR TITLE
Suspend event deliveries until middlewares are ready

### DIFF
--- a/.changeset/ten-lions-look.md
+++ b/.changeset/ten-lions-look.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Suspend event deliveries until middlewares are ready

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -41,7 +41,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.7 KB"
+      "limit": "25.85 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/inspector/__tests__/index.test.ts
+++ b/packages/browser/src/core/inspector/__tests__/index.test.ts
@@ -19,7 +19,6 @@ describe('Inspector interface', () => {
     const deliveryPromise = analytics.track('Test event').catch(() => {})
 
     expect(window.__SEGMENT_INSPECTOR__?.triggered).toHaveBeenCalledTimes(1)
-    expect(window.__SEGMENT_INSPECTOR__?.enriched).toHaveBeenCalledTimes(1)
 
     expect(window.__SEGMENT_INSPECTOR__?.triggered).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -33,6 +32,7 @@ describe('Inspector interface', () => {
 
     await deliveryPromise
 
+    expect(window.__SEGMENT_INSPECTOR__?.enriched).toHaveBeenCalledTimes(1)
     expect(window.__SEGMENT_INSPECTOR__?.delivered).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/browser/src/core/task/task-group.ts
+++ b/packages/browser/src/core/task/task-group.ts
@@ -1,0 +1,31 @@
+import { isThenable } from '../../lib/is-thenable'
+
+export type TaskGroup = {
+  done: () => Promise<void>
+  run: <Operation extends (...args: any[]) => any>(
+    op: Operation
+  ) => ReturnType<Operation>
+}
+
+export const createTaskGroup = (): TaskGroup => {
+  let taskCompletionPromise: Promise<void>
+  let resolvePromise: () => void
+  let count = 0
+
+  return {
+    done: () => taskCompletionPromise,
+    run: (op) => {
+      const returnValue = op()
+
+      if (isThenable(returnValue)) {
+        if (++count === 1) {
+          taskCompletionPromise = new Promise((res) => (resolvePromise = res))
+        }
+
+        returnValue.finally(() => --count === 0 && resolvePromise())
+      }
+
+      return returnValue
+    },
+  }
+}

--- a/packages/browser/src/lib/is-thenable.ts
+++ b/packages/browser/src/lib/is-thenable.ts
@@ -2,7 +2,7 @@
  *  Check if  thenable
  *  (instanceof Promise doesn't respect realms)
  */
-export const isThenable = (value: unknown): value is Promise<unknown> =>
+export const isThenable = (value: unknown): boolean =>
   typeof value === 'object' &&
   value !== null &&
   'then' in value &&

--- a/packages/browser/src/lib/is-thenable.ts
+++ b/packages/browser/src/lib/is-thenable.ts
@@ -2,7 +2,7 @@
  *  Check if  thenable
  *  (instanceof Promise doesn't respect realms)
  */
-export const isThenable = (value: unknown): boolean =>
+export const isThenable = (value: unknown): value is Promise<unknown> =>
   typeof value === 'object' &&
   value !== null &&
   'then' in value &&


### PR DESCRIPTION
This patch fixes an important issue where a middleware will miss out
on augmenting any events while it's being prepped up. Those events will
reach all the destinations as-is without going through the said
middleware.

With this patch, `addSourceMiddleware` is now classified as a critical
task, and thus will seize all event deliveries until all middlewares are
in an operational state. The suspension happens internally, and the
public API is unaffected.