### PR TITLE
Add new buffered methods, improve types

### DIFF
--- a/.changeset/grumpy-oranges-stare.md
+++ b/.changeset/grumpy-oranges-stare.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Add 'screen', 'register', 'deregister', 'user' method and 'VERSION' property on AnalyticsBrowser. Allow buffering of 'screen', 'register', 'deregister' methods for snippet users.

--- a/examples/standalone-playground/pages/index-local-batched.html
+++ b/examples/standalone-playground/pages/index-local-batched.html
@@ -36,6 +36,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/examples/standalone-playground/pages/index-local-csp.html
+++ b/examples/standalone-playground/pages/index-local-csp.html
@@ -37,6 +37,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/examples/standalone-playground/pages/index-local-errors.html
+++ b/examples/standalone-playground/pages/index-local-errors.html
@@ -36,6 +36,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/examples/standalone-playground/pages/index-local-track-link.html
+++ b/examples/standalone-playground/pages/index-local-track-link.html
@@ -36,6 +36,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/examples/standalone-playground/pages/index-local.html
+++ b/examples/standalone-playground/pages/index-local.html
@@ -36,6 +36,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/examples/standalone-playground/pages/index-remote.html
+++ b/examples/standalone-playground/pages/index-remote.html
@@ -33,6 +33,9 @@
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.85 KB"
+      "limit": "25.87 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.87 KB"
+      "limit": "25.9 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/qa/__fixtures__/snippets.ts
+++ b/packages/browser/qa/__fixtures__/snippets.ts
@@ -13,6 +13,9 @@ export function next(writekey: string, obfuscate: boolean) {
           else {
             analytics.invoked = !0
             analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
               'trackSubmit',
               'trackClick',
               'trackLink',
@@ -84,6 +87,9 @@ export function classic(writekey: string) {
       else {
         analytics.invoked = !0
         analytics.methods = [
+          'screen',
+          'register',
+          'deregister',
           'trackSubmit',
           'trackClick',
           'trackLink',

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -3,7 +3,6 @@ import { Context } from '@/core/context'
 import { Plugin } from '@/core/plugin'
 import { JSDOM } from 'jsdom'
 import { Analytics } from '../../core/analytics'
-import { Group } from '../../core/user'
 import { LegacyDestination } from '../../plugins/ajs-destination'
 import { PersistedPriorityQueue } from '../../lib/priority-queue/persisted'
 // @ts-ignore loadLegacySettings mocked dependency is accused as unused
@@ -258,7 +257,7 @@ describe('Initialization', () => {
     )
 
     expect(ajs.user().options.persist).toBe(false)
-    expect((ajs.group() as Group).options.persist).toBe(false)
+    expect(ajs.group().options.persist).toBe(false)
   })
 
   it('fetch remote source settings by default', async () => {
@@ -536,11 +535,11 @@ describe('Group', () => {
       writeKey,
     })
 
-    const group = analytics.group() as Group
+    const group = analytics.group()
 
-    const ctx = (await analytics.group('coolKids', {
+    const ctx = await analytics.group('coolKids', {
       coolKids: true,
-    })) as Context
+    })
 
     expect(ctx.event.groupId).toEqual('coolKids')
     expect(ctx.event.traits).toEqual({ coolKids: true })

--- a/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
+++ b/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
@@ -2,6 +2,7 @@ import { Analytics } from '@/core/analytics'
 import { Context } from '@/core/context'
 import { AnalyticsBrowser } from '@/browser'
 import { assertNotAny, assertIs } from '@/test-helpers/type-assertions'
+import { Group } from '../../../core/user'
 
 /**
  * These are general typescript definition tests;
@@ -54,4 +55,16 @@ export default {
           assertIs<number | [Analytics, Context]>(response)
         })
     },
+
+  'Group should have the correct type': () => {
+    const ajs = AnalyticsBrowser.load({ writeKey: 'foo' })
+    {
+      const grpResult = ajs.group()
+      assertIs<Promise<Group>>(grpResult)
+    }
+    {
+      const grpResult = ajs.group('foo')
+      assertIs<Promise<Context>>(grpResult)
+    }
+  },
 }

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -10,11 +10,18 @@ import {
   UserParams,
 } from '../arguments-resolver'
 import type { FormArgs, LinkArgs } from '../auto-track'
-import { Callback, invokeCallback } from '../callback'
+import { invokeCallback } from '../callback'
 import { isOffline } from '../connection'
 import { Context } from '../context'
 import { Emitter } from '@segment/analytics-core'
-import { EventFactory, Integrations, Plan, SegmentEvent } from '../events'
+import {
+  Callback,
+  EventFactory,
+  Integrations,
+  Plan,
+  EventProperties,
+  SegmentEvent,
+} from '../events'
 import { Plugin } from '../plugin'
 import { EventQueue } from '../queue/event-queue'
 import { CookieOptions, Group, ID, User, UserOptions } from '../user'
@@ -30,6 +37,7 @@ import { version } from '../../generated/version'
 import { PriorityQueue } from '../../lib/priority-queue'
 import { getGlobal } from '../../lib/get-global'
 import { inspectorHost } from '../inspector'
+import { AnalyticsClassic, AnalyticsSnippetCore } from './interfaces'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'
@@ -69,7 +77,10 @@ export interface InitOptions {
   obfuscate?: boolean
 }
 
-export class Analytics extends Emitter {
+export class Analytics
+  extends Emitter
+  implements AnalyticsSnippetCore, AnalyticsClassic
+{
   protected settings: AnalyticsSettings
   private _user: User
   private _group: Group
@@ -127,7 +138,7 @@ export class Analytics extends Emitter {
 
     const segmentEvent = this.eventFactory.track(
       name,
-      data as SegmentEvent['properties'],
+      data as EventProperties,
       opts,
       this.integrations
     )
@@ -180,6 +191,8 @@ export class Analytics extends Emitter {
     })
   }
 
+  group(): Group
+  group(...args: UserParams): Promise<DispatchedEvent>
   group(...args: UserParams): Promise<DispatchedEvent> | Group {
     if (args.length === 0) {
       return this._group
@@ -503,58 +516,20 @@ export class Analytics extends Emitter {
     return integrations
   }
 
-  // analytics-classic stubs
-
-  log() {
+  /* analytics-classic stubs */
+  stub(this: never) {
     console.warn(deprecationWarning)
-    return
   }
-
-  addIntegrationMiddleware() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  listeners() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  addEventListener() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  removeAllListeners() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  removeListener() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  removeEventListener() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  hasListeners() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  // This function is only used to add GA and Appcue, but these are already being added to Integrations by AJSN
-  addIntegration() {
-    console.warn(deprecationWarning)
-    return
-  }
-
-  add() {
-    console.warn(deprecationWarning)
-    return
-  }
+  log = this.stub
+  addIntegrationMiddleware = this.stub
+  listeners = this.stub
+  addEventListener = this.stub
+  removeAllListeners = this.stub
+  removeListener = this.stub
+  removeEventListener = this.stub
+  hasListeners = this.stub
+  add = this.stub
+  addIntegration = this.stub
 
   // snippet function
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -77,6 +77,11 @@ export interface InitOptions {
   obfuscate?: boolean
 }
 
+/* analytics-classic stubs */
+function _stub(this: never) {
+  console.warn(deprecationWarning)
+}
+
 export class Analytics
   extends Emitter
   implements AnalyticsSnippetCore, AnalyticsClassic
@@ -516,20 +521,16 @@ export class Analytics
     return integrations
   }
 
-  /* analytics-classic stubs */
-  stub(this: never) {
-    console.warn(deprecationWarning)
-  }
-  log = this.stub
-  addIntegrationMiddleware = this.stub
-  listeners = this.stub
-  addEventListener = this.stub
-  removeAllListeners = this.stub
-  removeListener = this.stub
-  removeEventListener = this.stub
-  hasListeners = this.stub
-  add = this.stub
-  addIntegration = this.stub
+  log = _stub
+  addIntegrationMiddleware = _stub
+  listeners = _stub
+  addEventListener = _stub
+  removeAllListeners = _stub
+  removeListener = _stub
+  removeEventListener = _stub
+  hasListeners = _stub
+  add = _stub
+  addIntegration = _stub
 
   // snippet function
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/browser/src/core/analytics/interfaces.ts
+++ b/packages/browser/src/core/analytics/interfaces.ts
@@ -1,0 +1,106 @@
+import type { Analytics, AnalyticsSettings, InitOptions } from '.'
+import type { Plugin } from '../plugin'
+import type {
+  EventParams,
+  DispatchedEvent,
+  PageParams,
+  UserParams,
+  AliasParams,
+} from '../arguments-resolver'
+import type { Context } from '../context'
+import type { SegmentEvent } from '../events'
+import type { Group, User } from '../user'
+import type { LegacyIntegration } from '../../plugins/ajs-destination/types'
+
+// we can define a contract because:
+// - it gives us a neat place to put all our typedocs (they end up being inherited by the class that implements them).
+// - it makes it easy to reason about what's being shared between browser and node
+
+/**
+ * All of these methods are a no-op.
+ */
+/** @deprecated */
+interface AnalyticsClassicStubs {
+  /** @deprecated */
+  log(this: never): void
+  /** @deprecated */
+  addIntegrationMiddleware(this: never): void
+  /** @deprecated */
+  listeners(this: never): void
+  /** @deprecated */
+  addEventListener(this: never): void
+  /** @deprecated */
+  removeAllListeners(this: never): void
+  /** @deprecated */
+  removeListener(this: never): void
+  /** @deprecated */
+  removeEventListener(this: never): void
+  /** @deprecated */
+  hasListeners(this: never): void
+  /** @deprecated */
+  // This function is only used to add GA and Appcue, but these are already being added to Integrations by AJSN
+  addIntegration(this: never): void
+  /** @deprecated */
+  add(this: never): void
+}
+
+/** @deprecated */
+export interface AnalyticsClassic extends AnalyticsClassicStubs {
+  /** @deprecated */
+  initialize(
+    settings?: AnalyticsSettings,
+    options?: InitOptions
+  ): Promise<Analytics>
+
+  /** @deprecated */
+  noConflict(): Analytics
+
+  /** @deprecated */
+  normalize(msg: SegmentEvent): SegmentEvent
+
+  /** @deprecated */
+  readonly failedInitializations: string[]
+
+  /** @deprecated */
+  pageview(url: string): Promise<Analytics>
+
+  /**  @deprecated*/
+  readonly plugins: any
+
+  /** @deprecated */
+  readonly Integrations: Record<string, LegacyIntegration>
+}
+
+/**
+ * Interface implemented by the snippet ('Analytics')
+ */
+export interface AnalyticsSnippetCore {
+  track(...args: EventParams): Promise<DispatchedEvent>
+  page(...args: PageParams): Promise<DispatchedEvent>
+  identify(...args: UserParams): Promise<DispatchedEvent>
+  group(): Group
+  group(...args: UserParams): Promise<DispatchedEvent>
+  alias(...args: AliasParams): Promise<DispatchedEvent>
+  screen(...args: PageParams): Promise<DispatchedEvent>
+  register(...plugins: Plugin[]): Promise<Context>
+  deregister(...plugins: string[]): Promise<Context>
+  user(): User
+  readonly VERSION: string
+}
+
+/**
+ * Interface implemented by AnalyticsBrowser
+ */
+export interface AnalyticsBrowserCore {
+  track: AnalyticsSnippetCore['track']
+  page: AnalyticsSnippetCore['page']
+  identify: AnalyticsSnippetCore['identify']
+  group(): Promise<Group> // Browser always wraps things in a promise, so we can't share a common "Core" interface =(
+  group(...args: UserParams): Promise<DispatchedEvent>
+  alias: AnalyticsSnippetCore['alias']
+  screen: AnalyticsSnippetCore['screen']
+  register: AnalyticsSnippetCore['register']
+  deregister: AnalyticsSnippetCore['deregister']
+  user(): Promise<User>
+  readonly VERSION: AnalyticsSnippetCore['VERSION']
+}

--- a/packages/browser/src/core/analytics/interfaces.ts
+++ b/packages/browser/src/core/analytics/interfaces.ts
@@ -95,12 +95,12 @@ export interface AnalyticsBrowserCore {
   track: AnalyticsSnippetCore['track']
   page: AnalyticsSnippetCore['page']
   identify: AnalyticsSnippetCore['identify']
-  group(): Promise<Group> // Browser always wraps things in a promise, so we can't share a common "Core" interface =(
+  group(): Promise<Group> // Different than AnalyticsSnippetCore ^
   group(...args: UserParams): Promise<DispatchedEvent>
   alias: AnalyticsSnippetCore['alias']
   screen: AnalyticsSnippetCore['screen']
   register: AnalyticsSnippetCore['register']
   deregister: AnalyticsSnippetCore['deregister']
-  user(): Promise<User>
+  user(): Promise<User> // Different than AnalyticsSnippetCore ^
   readonly VERSION: AnalyticsSnippetCore['VERSION']
 }

--- a/packages/browser/src/core/arguments-resolver/__tests__/index.test.ts
+++ b/packages/browser/src/core/arguments-resolver/__tests__/index.test.ts
@@ -2,9 +2,9 @@ import {
   resolveArguments,
   resolvePageArguments,
   resolveUserArguments,
-  Callback,
   resolveAliasArguments,
 } from '../'
+import { Callback } from '../../events'
 import { User } from '../../user'
 
 const bananaPhone = {

--- a/packages/browser/src/core/auto-track.ts
+++ b/packages/browser/src/core/auto-track.ts
@@ -1,5 +1,5 @@
 import { Analytics } from './analytics'
-import { SegmentEvent, Options } from './events'
+import { EventProperties, Options } from './events'
 import { pTimeout } from './callback'
 
 declare global {
@@ -46,7 +46,7 @@ export function link(
   this: Analytics,
   links: Element | Array<Element> | JQueryShim | null,
   event: string | Function,
-  properties?: SegmentEvent['properties'] | Function,
+  properties?: EventProperties | Function,
   options?: Options
 ): Analytics {
   let elements: Array<Element> = []
@@ -110,7 +110,7 @@ export function form(
   this: Analytics,
   forms: HTMLFormElement | Array<HTMLFormElement> | null,
   event: string | Function,
-  properties?: SegmentEvent['properties'] | Function,
+  properties?: EventProperties | Function,
   options?: Options
 ): Analytics {
   // always arrays, handles jquery

--- a/packages/browser/src/core/buffer/index.ts
+++ b/packages/browser/src/core/buffer/index.ts
@@ -5,8 +5,7 @@ import { AnalyticsBrowserCore } from '../analytics/interfaces'
 import { version } from '../../generated/version'
 
 /**
- * The names of any Analytics instance methods that can be called pre-initialization.
- * These methods should exist statically on AnalyticsBrowser.
+ * The names of any AnalyticsBrowser methods that also exist on Analytics
  */
 export type PreInitMethodName =
   | 'screen'

--- a/packages/browser/src/core/buffer/index.ts
+++ b/packages/browser/src/core/buffer/index.ts
@@ -1,12 +1,18 @@
 import { Analytics } from '../analytics'
 import { Context } from '../context'
 import { isThenable } from '../../lib/is-thenable'
+import { AnalyticsBrowserCore } from '../analytics/interfaces'
+import { version } from '../../generated/version'
 
 /**
  * The names of any Analytics instance methods that can be called pre-initialization.
  * These methods should exist statically on AnalyticsBrowser.
  */
 export type PreInitMethodName =
+  | 'screen'
+  | 'register'
+  | 'deregister'
+  | 'user'
   | 'trackSubmit'
   | 'trackClick'
   | 'trackLink'
@@ -166,7 +172,9 @@ export type AnalyticsLoader = (
   preInitBuffer: PreInitMethodCallBuffer
 ) => Promise<[Analytics, Context]>
 
-export class AnalyticsBuffered implements PromiseLike<[Analytics, Context]> {
+export class AnalyticsBuffered
+  implements PromiseLike<[Analytics, Context]>, AnalyticsBrowserCore
+{
   instance?: Analytics
   ctx?: Context
   private _preInitBuffer = new PreInitMethodCallBuffer()
@@ -217,7 +225,7 @@ export class AnalyticsBuffered implements PromiseLike<[Analytics, Context]> {
   pageView = this._createMethod('pageview')
   identify = this._createMethod('identify')
   reset = this._createMethod('reset')
-  group = this._createMethod('group')
+  group = this._createMethod('group') as AnalyticsBrowserCore['group']
   track = this._createMethod('track')
   ready = this._createMethod('ready')
   alias = this._createMethod('alias')
@@ -229,6 +237,12 @@ export class AnalyticsBuffered implements PromiseLike<[Analytics, Context]> {
   addSourceMiddleware = this._createMethod('addSourceMiddleware')
   setAnonymousId = this._createMethod('setAnonymousId')
   addDestinationMiddleware = this._createMethod('addDestinationMiddleware')
+
+  screen = this._createMethod('screen')
+  register = this._createMethod('register')
+  deregister = this._createMethod('deregister')
+  user = this._createMethod('user')
+  readonly VERSION = version
 
   private _createMethod<T extends PreInitMethodName>(methodName: T) {
     return (

--- a/packages/browser/src/core/callback/index.ts
+++ b/packages/browser/src/core/callback/index.ts
@@ -1,5 +1,6 @@
 import { Context } from '../context'
 import { asPromise } from '../../lib/as-promise'
+import { Callback } from '../events/interfaces'
 
 export function pTimeout(
   cb: Promise<unknown>,
@@ -20,8 +21,6 @@ export function pTimeout(
 function sleep(timeoutInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutInMs))
 }
-
-export type Callback = (ctx: Context) => Promise<unknown> | unknown
 
 /**
  * @param delayTimeout - The amount of time in ms to wait before invoking the callback.

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -1,7 +1,13 @@
 import { v4 as uuid } from '@lukeed/uuid'
 import { dset } from 'dset'
 import { ID, User } from '../user'
-import { Options, Integrations, SegmentEvent } from './interfaces'
+import {
+  Options,
+  Integrations,
+  EventProperties,
+  Traits,
+  SegmentEvent,
+} from './interfaces'
 import md5 from 'spark-md5'
 
 export * from './interfaces'
@@ -15,7 +21,7 @@ export class EventFactory {
 
   track(
     event: string,
-    properties?: SegmentEvent['properties'],
+    properties?: EventProperties,
     options?: Options,
     globalIntegrations?: Integrations
   ): SegmentEvent {
@@ -32,7 +38,7 @@ export class EventFactory {
   page(
     category: string | null,
     page: string | null,
-    properties?: object,
+    properties?: EventProperties,
     options?: Options,
     globalIntegrations?: Integrations
   ): SegmentEvent {
@@ -62,7 +68,7 @@ export class EventFactory {
   screen(
     category: string | null,
     screen: string | null,
-    properties?: object,
+    properties?: EventProperties,
     options?: Options,
     globalIntegrations?: Integrations
   ): SegmentEvent {
@@ -89,7 +95,7 @@ export class EventFactory {
 
   identify(
     userId: ID,
-    traits?: SegmentEvent['traits'],
+    traits?: Traits,
     options?: Options,
     globalIntegrations?: Integrations
   ): SegmentEvent {
@@ -105,7 +111,7 @@ export class EventFactory {
 
   group(
     groupId: ID,
-    traits?: SegmentEvent['traits'],
+    traits?: Traits,
     options?: Options,
     globalIntegrations?: Integrations
   ): SegmentEvent {

--- a/packages/browser/src/core/events/interfaces.ts
+++ b/packages/browser/src/core/events/interfaces.ts
@@ -7,8 +7,6 @@ export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 export type JSONObject = { [member: string]: JSONValue }
 export type JSONArray = Array<JSONValue>
 
-// TODO: the change is that context is no longer "undefined". "Callback" was defined twice in this codebase previously, with that being the only difference.
-// Are there methods where the context object for Callback is undefined? If so, which ones?
 export type Callback = (ctx: Context) => Promise<unknown> | unknown
 
 export type Integrations = {

--- a/packages/browser/src/core/events/interfaces.ts
+++ b/packages/browser/src/core/events/interfaces.ts
@@ -1,3 +1,4 @@
+import { Context } from '../context'
 import { CompactMetric } from '../stats'
 import { ID } from '../user'
 
@@ -5,6 +6,10 @@ export type JSONPrimitive = string | number | boolean | null
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 export type JSONObject = { [member: string]: JSONValue }
 export type JSONArray = Array<JSONValue>
+
+// TODO: the change is that context is no longer "undefined". "Callback" was defined twice in this codebase previously, with that being the only difference.
+// Are there methods where the context object for Callback is undefined? If so, which ones?
+export type Callback = (ctx: Context) => Promise<unknown> | unknown
 
 export type Integrations = {
   All?: boolean
@@ -16,7 +21,7 @@ export type Options = {
   anonymousId?: ID
   timestamp?: Date | string
   context?: AnalyticsContext
-  traits?: object
+  traits?: Traits
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
@@ -97,6 +102,11 @@ interface AnalyticsContext {
   [key: string]: any
 }
 
+export type Traits = { [k: string]: JSONValue }
+export type EventProperties = {
+  [k: string]: JSONValue
+}
+
 export interface SegmentEvent {
   messageId?: string
 
@@ -106,13 +116,9 @@ export interface SegmentEvent {
   category?: string
   name?: string
 
-  properties?: object & {
-    [k: string]: JSONValue
-  }
+  properties?: EventProperties
 
-  traits?: object & {
-    [k: string]: JSONValue
-  }
+  traits?: Traits
 
   integrations?: Integrations
   context?: AnalyticsContext | Options

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from '@lukeed/uuid'
 import jar from 'js-cookie'
-import { SegmentEvent } from '../events'
+import { Traits } from '../events'
 import { tld } from './tld'
 import autoBind from '../../lib/bind-all'
 
@@ -222,7 +222,7 @@ export class User {
 
     this.mem = isDisabled ? new NullStorage() : new Store()
 
-    const legacyUser = this.cookies.get<{ id?: string; traits?: object }>(
+    const legacyUser = this.cookies.get<{ id?: string; traits?: Traits }>(
       defaults.cookie.oldKey
     )
     if (legacyUser) {
@@ -312,7 +312,7 @@ export class User {
     return this.chainGet(this.anonKey)
   }
 
-  traits = (traits?: object | null): SegmentEvent['traits'] => {
+  traits = (traits?: Traits | null): Traits | undefined => {
     if (this.options.disable) {
       return
     }
@@ -333,7 +333,7 @@ export class User {
     )
   }
 
-  identify(id?: ID, traits?: object): void {
+  identify(id?: ID, traits?: Traits): void {
     if (this.options.disable) {
       return
     }

--- a/packages/browser/src/plugins/validation/index.ts
+++ b/packages/browser/src/plugins/validation/index.ts
@@ -14,7 +14,9 @@ export function isFunction(obj: unknown): obj is Function {
   return typeof obj === 'function'
 }
 
-export function isPlainObject(obj: unknown): obj is object {
+export function isPlainObject(
+  obj: unknown
+): obj is Record<string | symbol | number, any> {
   return (
     Object.prototype.toString.call(obj).slice(8, -1).toLowerCase() === 'object'
   )

--- a/packages/browser/src/tester/__fixtures__/segment-snippet.ts
+++ b/packages/browser/src/tester/__fixtures__/segment-snippet.ts
@@ -8,6 +8,9 @@ export const snippet = (writeKey: string, load: boolean = true, extra = '') => `
     else {
       analytics.invoked = !0
       analytics.methods = [
+        'screen',
+        'register',
+        'deregister',
         'trackSubmit',
         'trackClick',
         'trackLink',


### PR DESCRIPTION


This PR:
- Adds 'screen', 'register', 'deregister', 'user' method and 'VERSION' property on AnalyticsBrowser.   🎸 
- Allows buffering of 'screen', 'register', 'deregister' methods for snippet users. 🎹 
- Improves typing -- e.g better names, add overloads 🎷 
> Outstanding todo: update the _actual_ UI snippet (the one that shows up on app.segment.com?) so that the copypasta from includes  'screen', 'register', and 'deregister' ⛑️ 

😢 Because of some differences in return types between AnalyticsBrowser and Analytics (AnalyticsBrowser always being async, while Analytics is inconsistent in that regard) the dream of a unified AnalyticsCore interface between Analytics and AnalyticsBrowser is on hold. 

It’s IMO advisable to not try to obsess over strict sharing of a public interfaces, as that common abstraction does not seem possible, and it can in addition become  hard to maintain either for the legacy behavior of one system or due to subtle differences between platforms. Ultimately, our API is just a bags of methods and we want to evolve and be nimble, and not hamstring ourselves.

We can continue to share models and types where appropriate.