### PR TITLE
add auto-update resolutions script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "yarn workspace with-next-js run dev",
     "postinstall": "husky install",
     "changeset": "changeset",
-    "update-versions-and-changelogs": "changeset version && yarn version-run-all",
+    "update-versions-and-changelogs": "changeset version && yarn version-run-all && bash scripts/update-lockfile.sh",
     "release": "yarn build:packages --force && changeset publish && yarn postpublish-run-all && git push origin --tags --no-verify",
     "postpublish-run-all": "yarn workspaces foreach -vpt --no-private run postpublish",
     "version-run-all": "yarn workspaces foreach -vpt --no-private run version",

--- a/scripts/update-lockfile.sh
+++ b/scripts/update-lockfile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Changesets does not support yarn, so if the resolutions change, we want to commit them as part of the version pipeline.
+echo "Checking if yarn.lock is up-to-date"
+yarn install
+if [[ -n $(git status --porcelain | grep yarn.lock) ]]; then
+  echo "Adding yarn.lock..."
+  git add yarn.lock
+  # The yarn.lock will be auto-commited by the changeset github action
+else
+  echo "No yarn.lock updates needed"
+fi


### PR DESCRIPTION
Ran into this issue of the yarn.lock needing to be updated during the `version` phase of the changeset action. 

One day: https://github.com/changesets/changesets/issues/432