### PR TITLE
minify class properties with underscore

### DIFF
--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -85,7 +85,12 @@ const config = {
         extractComments: false,
         terserOptions: {
           ecma: '2015',
-          mangle: true,
+          mangle: {
+            properties: {
+              /* minify class properties that start with underscore */
+              regex: /^_/
+            }
+          },
           compress: true,
           output: {
             comments: false,


### PR DESCRIPTION
We can be comfortable using private methods in classes as long as we prefix with _. 

I tested it, it successfully mangled _createChainableMethod and _createMethod