### PR TITLE
[Bugfix] Do not allow the user method to change its return types over its lifecycle

### DIFF
--- a/.changeset/slimy-worms-fail.md
+++ b/.changeset/slimy-worms-fail.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Do not allow the "user" method to change its return types over its lifecycle. We should always return a promise for wrapped methods in AnalyticsBrowser, regardless if the underlying Analytics method is sync or async.

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -5,6 +5,7 @@ import { Context } from '../../core/context'
 import * as Factory from '../../test-helpers/factories'
 import { sleep } from '../../test-helpers/sleep'
 import { setGlobalCDNUrl } from '../../lib/parse-cdn'
+import { User } from '../../core/user'
 
 jest.mock('unfetch')
 
@@ -59,19 +60,38 @@ describe('Pre-initialization', () => {
       expect(trackSpy).toBeCalledTimes(1)
     })
 
-    test('"return types should not change over the lifecycle for ordinary methods', async () => {
+    test('"return types should not change over the lifecycle for async methods', async () => {
       const ajsBrowser = AnalyticsBrowser.load({ writeKey })
 
       const trackCtxPromise1 = ajsBrowser.track('foo', { name: 'john' })
       expect(trackCtxPromise1).toBeInstanceOf(Promise)
-      const ctx1 = await trackCtxPromise1
-      expect(ctx1).toBeInstanceOf(Context)
+      await ajsBrowser
 
       // loaded
       const trackCtxPromise2 = ajsBrowser.track('foo', { name: 'john' })
       expect(trackCtxPromise2).toBeInstanceOf(Promise)
-      const ctx2 = await trackCtxPromise2
-      expect(ctx2).toBeInstanceOf(Context)
+
+      expect(await trackCtxPromise1).toBeInstanceOf(Context)
+      expect(await trackCtxPromise2).toBeInstanceOf(Context)
+    })
+
+    test('return types should not change over lifecycle for sync methods', async () => {
+      const ajsBrowser = AnalyticsBrowser.load({ writeKey })
+      const user = ajsBrowser.user()
+      expect(user).toBeInstanceOf(Promise)
+      await ajsBrowser
+
+      // loaded
+      const user2 = ajsBrowser.user()
+      expect(user2).toBeInstanceOf(Promise)
+
+      expect(await user).toBeInstanceOf(User)
+      expect(await user2).toBeInstanceOf(User)
+    })
+
+    test('version should return version', async () => {
+      const ajsBrowser = AnalyticsBrowser.load({ writeKey })
+      expect(typeof ajsBrowser.VERSION).toBe('string')
     })
 
     test('If a user sends multiple events, all of those event gets flushed', async () => {

--- a/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
+++ b/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
@@ -2,7 +2,7 @@ import { Analytics } from '@/core/analytics'
 import { Context } from '@/core/context'
 import { AnalyticsBrowser } from '@/browser'
 import { assertNotAny, assertIs } from '@/test-helpers/type-assertions'
-import { Group } from '../../../core/user'
+import { Group, User } from '../../../core/user'
 
 /**
  * These are general typescript definition tests;
@@ -65,6 +65,13 @@ export default {
     {
       const grpResult = ajs.group('foo')
       assertIs<Promise<Context>>(grpResult)
+    }
+  },
+  'User should have the correct type': () => {
+    const ajs = AnalyticsBrowser.load({ writeKey: 'foo' })
+    {
+      const grpResult = ajs.user()
+      assertIs<Promise<User>>(grpResult)
     }
   },
 }

--- a/packages/browser/src/core/buffer/index.ts
+++ b/packages/browser/src/core/buffer/index.ts
@@ -248,7 +248,8 @@ export class AnalyticsBuffered
       ...args: Parameters<Analytics[T]>
     ): Promise<ReturnTypeUnwrap<Analytics[T]>> => {
       if (this.instance) {
-        return (this.instance[methodName] as Function)(...args)
+        const result = (this.instance[methodName] as Function)(...args)
+        return Promise.resolve(result)
       }
 
       return new Promise((resolve, reject) => {

--- a/packages/browser/src/test-helpers/type-assertions.ts
+++ b/packages/browser/src/test-helpers/type-assertions.ts
@@ -5,11 +5,7 @@ type NotUnknown<T> = unknown extends T ? never : T
 type NotTopType<T> = NotAny<T> & NotUnknown<T>
 
 // this is not meant to be run, just for type tests
-export function assertNotAny<T>(val: NotTopType<T>) {
-  console.log(val)
-}
+export function assertNotAny<T>(_val: NotTopType<T>) {}
 
 // this is not meant to be run, just for type tests
-export function assertIs<T extends SomeType, SomeType = any>(val: T) {
-  console.log(val)
-}
+export function assertIs<T extends SomeType, SomeType = any>(_val: T) {}


### PR DESCRIPTION
I discovered a bug in the recently added "user" method for analytics buffered. It's the only method that's both synchronous and non-chained, so the bug didn't reveal itself previously.

Do not allow the "user" method to change its return types over its lifecycle. We should always return a promise for wrapped methods in AnalyticsBrowser, regardless if the underlying Analytics method is sync or async.