### PR TITLE
Removing unnecessary import on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ More React Examples:
 1. create composable file `segment.ts` with factory ref analytics:
 
 ```ts
-import { Analytics, AnalyticsBrowser } from '@segment/analytics-next'
+import { AnalyticsBrowser } from '@segment/analytics-next'
 
 export const analytics = AnalyticsBrowser.load({
   writeKey: '<YOUR_WRITE_KEY>',


### PR DESCRIPTION
## Overview 

There was an unused import on the readme in an example, this pr seeks to remove it and make the doc more clear