### PR TITLE
Improved error message logging in console

### DIFF
--- a/.changeset/spotty-files-wave.md
+++ b/.changeset/spotty-files-wave.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Enhances console error logging when requests to settings api fail

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "25.9 KB"
+      "limit": "25.95 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -5,7 +5,6 @@ import { Context } from '../../core/context'
 import * as Factory from '../../test-helpers/factories'
 import { sleep } from '../../test-helpers/sleep'
 import { setGlobalCDNUrl } from '../../lib/parse-cdn'
-import { User } from '../../core/user'
 
 jest.mock('unfetch')
 
@@ -60,38 +59,19 @@ describe('Pre-initialization', () => {
       expect(trackSpy).toBeCalledTimes(1)
     })
 
-    test('"return types should not change over the lifecycle for async methods', async () => {
+    test('"return types should not change over the lifecycle for ordinary methods', async () => {
       const ajsBrowser = AnalyticsBrowser.load({ writeKey })
 
       const trackCtxPromise1 = ajsBrowser.track('foo', { name: 'john' })
       expect(trackCtxPromise1).toBeInstanceOf(Promise)
-      await ajsBrowser
+      const ctx1 = await trackCtxPromise1
+      expect(ctx1).toBeInstanceOf(Context)
 
       // loaded
       const trackCtxPromise2 = ajsBrowser.track('foo', { name: 'john' })
       expect(trackCtxPromise2).toBeInstanceOf(Promise)
-
-      expect(await trackCtxPromise1).toBeInstanceOf(Context)
-      expect(await trackCtxPromise2).toBeInstanceOf(Context)
-    })
-
-    test('return types should not change over lifecycle for sync methods', async () => {
-      const ajsBrowser = AnalyticsBrowser.load({ writeKey })
-      const user = ajsBrowser.user()
-      expect(user).toBeInstanceOf(Promise)
-      await ajsBrowser
-
-      // loaded
-      const user2 = ajsBrowser.user()
-      expect(user2).toBeInstanceOf(Promise)
-
-      expect(await user).toBeInstanceOf(User)
-      expect(await user2).toBeInstanceOf(User)
-    })
-
-    test('version should return version', async () => {
-      const ajsBrowser = AnalyticsBrowser.load({ writeKey })
-      expect(typeof ajsBrowser.VERSION).toBe('string')
+      const ctx2 = await trackCtxPromise2
+      expect(ctx2).toBeInstanceOf(Context)
     })
 
     test('If a user sends multiple events, all of those event gets flushed', async () => {

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -123,10 +123,11 @@ describe('Pre-initialization', () => {
         status: 403,
         statusText: 'Forbidden',
         json: undefined,
+        text: () => Promise.resolve('text'),
       }
       mockFetchSettingsErrorResponse(err)
       const consoleSpy = jest
-        .spyOn(console, 'warn')
+        .spyOn(console, 'error')
         .mockImplementationOnce(() => {})
       AnalyticsBrowser.load({ writeKey: 'abc' })
       await sleep(500)

--- a/packages/browser/src/browser/__tests__/csp-detection.test.ts
+++ b/packages/browser/src/browser/__tests__/csp-detection.test.ts
@@ -26,6 +26,8 @@ const cdnResponse: LegacySettings = {
 
 const fetchSettings = Promise.resolve({
   json: () => Promise.resolve(cdnResponse),
+  text: () => Promise.resolve('text'),
+  ok: true,
 })
 
 jest.mock('unfetch', () => {

--- a/packages/browser/src/browser/__tests__/csp-detection.test.ts
+++ b/packages/browser/src/browser/__tests__/csp-detection.test.ts
@@ -4,6 +4,7 @@ import { LegacySettings } from '..'
 import { onCSPError } from '../../lib/csp-detection'
 import { pWhile } from '../../lib/p-while'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
+import * as Factory from '../../test-helpers/factories'
 
 const cdnResponse: LegacySettings = {
   integrations: {
@@ -24,11 +25,7 @@ const cdnResponse: LegacySettings = {
   },
 }
 
-const fetchSettings = Promise.resolve({
-  json: () => Promise.resolve(cdnResponse),
-  text: () => Promise.resolve('text'),
-  ok: true,
-})
+const fetchSettings = Factory.createSuccess(cdnResponse)
 
 jest.mock('unfetch', () => {
   return jest.fn()

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -37,6 +37,8 @@ const fetchSettings = Promise.resolve({
     Promise.resolve({
       integrations: {},
     }),
+  text: () => Promise.resolve('text'),
+  ok: true,
 })
 
 jest.mock('unfetch', () => {
@@ -81,6 +83,7 @@ describe('standalone bundle', () => {
     const documentSpy = jest.spyOn(global, 'document', 'get')
 
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
 
     windowSpy.mockImplementation(() => {
       return jsd.window as unknown as Window & typeof globalThis

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -6,6 +6,7 @@ import { install, AnalyticsSnippet } from '../standalone-analytics'
 import unfetch from 'unfetch'
 import { PersistedPriorityQueue } from '../../lib/priority-queue/persisted'
 import { sleep } from '../../test-helpers/sleep'
+import * as Factory from '../../test-helpers/factories'
 
 const track = jest.fn()
 const identify = jest.fn()
@@ -32,14 +33,7 @@ jest.mock('@/core/analytics', () => ({
   }),
 }))
 
-const fetchSettings = Promise.resolve({
-  json: () =>
-    Promise.resolve({
-      integrations: {},
-    }),
-  text: () => Promise.resolve('text'),
-  ok: true,
-})
+const fetchSettings = Factory.createSuccess({ integrations: {} })
 
 jest.mock('unfetch', () => {
   return jest.fn()

--- a/packages/browser/src/browser/__tests__/standalone-errors.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-errors.test.ts
@@ -4,6 +4,7 @@ import { snippet } from '../../tester/__fixtures__/segment-snippet'
 import { pWhile } from '../../lib/p-while'
 import unfetch from 'unfetch'
 import { RemoteMetrics } from '../../core/stats/remote-metrics'
+import * as Factory from '../../test-helpers/factories'
 
 const cdnResponse: LegacySettings = {
   integrations: {
@@ -24,9 +25,7 @@ const cdnResponse: LegacySettings = {
   },
 }
 
-const fetchSettings = Promise.resolve({
-  json: () => Promise.resolve(cdnResponse),
-})
+const fetchSettings = Factory.createSuccess(cdnResponse)
 
 jest.mock('unfetch', () => {
   return jest.fn()

--- a/packages/browser/src/browser/__tests__/standalone.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone.test.ts
@@ -3,6 +3,7 @@ import unfetch from 'unfetch'
 import { LegacySettings } from '..'
 import { pWhile } from '../../lib/p-while'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
+import * as Factory from '../../test-helpers/factories'
 
 const cdnResponse: LegacySettings = {
   integrations: {
@@ -23,9 +24,7 @@ const cdnResponse: LegacySettings = {
   },
 }
 
-const fetchSettings = Promise.resolve({
-  json: () => Promise.resolve(cdnResponse),
-})
+const fetchSettings = Factory.createSuccess(cdnResponse)
 
 jest.mock('unfetch', () => {
   return jest.fn()

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -85,14 +85,14 @@ export function loadLegacySettings(
   return fetch(`${baseUrl}/v1/projects/${writeKey}/settings`)
     .then((res) => {
       if (!res.ok) {
-        return res.text().then((statusText) => {
-          throw { ...res, statusText }
+        return res.text().then((errorResponseMessage) => {
+          throw { ...res, errorResponseMessage }
         })
       }
       return res.json()
     })
     .catch((err) => {
-      console.error(err.statusText)
+      console.error(err.errorResponseMessage)
       throw err
     })
 }

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -83,9 +83,16 @@ export function loadLegacySettings(
   const baseUrl = cdnURL ?? getCDN()
 
   return fetch(`${baseUrl}/v1/projects/${writeKey}/settings`)
-    .then((res) => res.json())
+    .then((res) => {
+      if (!res.ok) {
+        return res.text().then((statusText) => {
+          throw { ...res, statusText }
+        })
+      }
+      return res.json()
+    })
     .catch((err) => {
-      console.warn('Failed to load settings', err)
+      console.error(err.statusText)
       throw err
     })
 }

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -86,13 +86,13 @@ export function loadLegacySettings(
     .then((res) => {
       if (!res.ok) {
         return res.text().then((errorResponseMessage) => {
-          throw { ...res, errorResponseMessage }
+          throw new Error(errorResponseMessage)
         })
       }
       return res.json()
     })
     .catch((err) => {
-      console.error(err.errorResponseMessage)
+      console.error(err.message)
       throw err
     })
 }

--- a/packages/browser/src/plugins/ajs-destination/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/ajs-destination/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import { Plan } from '../../../core/events'
 import { tsubMiddleware } from '../../routing-middleware'
 import { AMPLITUDE_WRITEKEY } from '../../../test-helpers/test-writekeys'
 import { PersistedPriorityQueue } from '../../../lib/priority-queue/persisted'
+import * as Factory from '../../../test-helpers/factories'
 
 const cdnResponse: LegacySettings = {
   integrations: {
@@ -66,9 +67,7 @@ const cdnResponse: LegacySettings = {
   },
 }
 
-const fetchSettings = Promise.resolve({
-  json: () => Promise.resolve(cdnResponse),
-})
+const fetchSettings = Factory.createSuccess(cdnResponse)
 
 jest.mock('unfetch', () => {
   return jest.fn()


### PR DESCRIPTION
Adds a console error with the error status text from the API explaining to users what went wrong with the `settings` call.

<img width="788" alt="Screen Shot 2022-08-03 at 12 57 19 PM" src="https://user-images.githubusercontent.com/10540173/183713872-551b9e02-5af4-45a4-9f11-e679cef4f340.png">
.