### PR TITLE
Allow SegmentEvent and Traits objects to contain undefined / optional key-values

### DIFF
--- a/.changeset/eleven-apes-attack.md
+++ b/.changeset/eleven-apes-attack.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Loosen SegmentEvent and Traits typescript interface (Fixes [#570](https://github.com/segmentio/analytics-next/issues/570)).

--- a/packages/browser/qa/__tests__/smoke.test.ts
+++ b/packages/browser/qa/__tests__/smoke.test.ts
@@ -1,6 +1,6 @@
 import flat from 'flat'
 import { difference, intersection, uniq, without } from 'lodash'
-import { JSONValue } from '../../src/core/events'
+import { JSONObject } from '../../src/core/events'
 import { browser } from '../lib/browser'
 import { run } from '../lib/runner'
 import { objectSchema } from '../lib/schema'
@@ -69,14 +69,14 @@ function compareSchema(results: RemovePromise<ReturnType<typeof run>>) {
       'integrations'
     )
 
-    expect((req.data as Record<string, JSONValue>).integrations).toEqual(
+    expect((req.data as JSONObject).integrations).toEqual(
       expect.objectContaining(
-        (classic.data as Record<string, JSONValue>).integrations
+        (classic.data as JSONObject).integrations
       )
     )
 
-    const flatNext = flat(req.data) as Record<string, JSONValue>
-    const flatClassic = flat(classic.data) as Record<string, JSONValue>
+    const flatNext = flat(req.data) as JSONObject
+    const flatClassic = flat(classic.data) as JSONObject
 
     intersectionKeys.forEach((key) => {
       const comparison = {

--- a/packages/browser/src/core/events/interfaces.ts
+++ b/packages/browser/src/core/events/interfaces.ts
@@ -5,7 +5,16 @@ import { ID } from '../user'
 export type JSONPrimitive = string | number | boolean | null
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 export type JSONObject = { [member: string]: JSONValue }
-export type JSONArray = Array<JSONValue>
+export type JSONArray = JSONValue[]
+
+/**
+ *  A JSON object that allows undefined key/values which will be completely removed during serialization.
+ */
+export type JSONObjectLoose = {
+  [member: string]: JSONValueLoose | undefined
+}
+
+export type JSONValueLoose = JSONPrimitive | JSONObjectLoose | JSONValueLoose[]
 
 export type Callback = (ctx: Context) => Promise<unknown> | unknown
 
@@ -100,10 +109,8 @@ interface AnalyticsContext {
   [key: string]: any
 }
 
-export type Traits = { [k: string]: JSONValue }
-export type EventProperties = {
-  [k: string]: JSONValue
-}
+export type Traits = JSONObjectLoose
+export type EventProperties = JSONObjectLoose
 
 export interface SegmentEvent {
   messageId?: string

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -1,9 +1,4 @@
-import {
-  Integrations,
-  JSONObject,
-  JSONValue,
-  SegmentEvent,
-} from '@/core/events'
+import { Integrations, JSONObject, SegmentEvent } from '@/core/events'
 import { Alias, Facade, Group, Identify, Page, Track } from '@segment/facade'
 import { Analytics, InitOptions } from '../../core/analytics'
 import { LegacySettings } from '../../browser'
@@ -65,7 +60,7 @@ async function flushQueue(
 export class LegacyDestination implements Plugin {
   name: string
   version: string
-  settings: Record<string, JSONValue>
+  settings: JSONObject
   options: InitOptions = {}
   type: Plugin['type'] = 'destination'
   middleware: DestinationMiddlewareFunction[] = []
@@ -83,7 +78,7 @@ export class LegacyDestination implements Plugin {
   constructor(
     name: string,
     version: string,
-    settings: Record<string, JSONValue> = {},
+    settings: JSONObject = {},
     options: InitOptions
   ) {
     this.name = name

--- a/packages/browser/src/plugins/schema-filter/index.ts
+++ b/packages/browser/src/plugins/schema-filter/index.ts
@@ -31,7 +31,7 @@ function disabledActionDestinations(
   return (settings.remotePlugins ?? []).reduce((acc, p) => {
     if (p.settings['subscriptions']) {
       if (disabledRemotePlugins.includes(p.name)) {
-        // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONValue
+        // @ts-expect-error element implicitly has an 'any' type because p.settings is a JSONObject
         p.settings['subscriptions'].forEach(
           // @ts-expect-error parameter 'sub' implicitly has an 'any' type
           (sub) => (acc[`${p.name} ${sub.partnerAction}`] = false)


### PR DESCRIPTION
Addresses [#570](https://github.com/segmentio/analytics-next/issues/570)