### PR TITLE
support secure cookie option for identity cookies

### DIFF
--- a/.changeset/dry-vans-worry.md
+++ b/.changeset/dry-vans-worry.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fixes an issue where the 'secure' cookie setting was not being applied correctly when specified.

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -513,6 +513,22 @@ describe('user', () => {
       expect(cookie['options'].domain).toBe('foo')
       expect(cookie['options'].secure).toBe(true)
       expect(cookie['options'].path).toBe('/test')
+      expect(cookie['options'].secure).toBe(true)
+    })
+
+    it('should pass options when creating cookie', () => {
+      const jarSpy = jest.spyOn(jar, 'set')
+      const cookie = new Cookie({ domain: 'foo', secure: true, path: '/test' })
+
+      cookie.set('foo', 'bar')
+
+      expect(jarSpy).toHaveBeenCalledWith('foo', 'bar', {
+        domain: 'foo',
+        expires: 365,
+        path: '/test',
+        sameSite: 'Lax',
+        secure: true,
+      })
     })
   })
 

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -92,6 +92,7 @@ export class Cookie extends Store {
       expires: this.options.maxage,
       domain: this.options.domain,
       path: this.options.path,
+      secure: this.options.secure,
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the `secure` cookie property wasn't being applied to cookies created by the `User` and `Group` classes. This meant it was always being ignore (effectively false)

[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).