### PR TITLE
improve error message when sending metrics fails

### DIFF
--- a/.changeset/moody-rats-double.md
+++ b/.changeset/moody-rats-double.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Updates error message when sending metrics fails to indicate that metrics failed to send.

--- a/packages/browser/src/core/stats/__tests__/remote-metrics.test.ts
+++ b/packages/browser/src/core/stats/__tests__/remote-metrics.test.ts
@@ -118,7 +118,10 @@ describe('remote metrics', () => {
     remote.increment('analytics_js.banana', ['phone:1'])
     await remote.flush()
 
-    expect(errorSpy).toHaveBeenCalledWith(error)
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error sending segment performance metrics',
+      error
+    )
   })
 
   test('disables metrics reporting in case of errors', async () => {

--- a/packages/browser/src/core/stats/remote-metrics.ts
+++ b/packages/browser/src/core/stats/remote-metrics.ts
@@ -11,6 +11,10 @@ export interface MetricsOptions {
 
 type Metric = { type: 'Counter'; metric: string; value: number; tags: object }
 
+function logError(err: unknown): void {
+  console.error('Error sending segment performance metrics', err)
+}
+
 export class RemoteMetrics {
   private host: string
   private flushTimer: number
@@ -36,9 +40,7 @@ export class RemoteMetrics {
         }
 
         flushing = true
-        this.flush().catch((err) => {
-          console.error(err)
-        })
+        this.flush().catch(logError)
 
         flushing = false
 
@@ -90,7 +92,7 @@ export class RemoteMetrics {
     })
 
     if (metric.includes('error')) {
-      this.flush().catch((err) => console.error(err))
+      this.flush().catch(logError)
     }
   }
 
@@ -100,7 +102,7 @@ export class RemoteMetrics {
     }
 
     await this.send().catch((error) => {
-      console.error(error)
+      logError(error)
       this.sampleRate = 0
     })
   }


### PR DESCRIPTION
This PR updates the error message logged when sending client-side performance metrics to segment fails.
See https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/troubleshooting/#why-do-i-see-a-network-request-to-m for background info on client-side performance metrics.

These metrics do not impact customer event delivery, but can cause confusion when showing up on platforms like Sentry when an error occurs. This provides a way to filter out these messages by the new error message preceding the error.


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).