### PR TITLE
Fix memory leak

### DIFF
--- a/packages/core/src/priority-queue/__tests__/backoff.test.ts
+++ b/packages/core/src/priority-queue/__tests__/backoff.test.ts
@@ -1,4 +1,4 @@
-import { backoff } from '../backoff'
+import { backoff, calculateMaxTotalRetryTime } from '../backoff'
 
 describe('backoff', () => {
   it('increases with the number of attempts', () => {
@@ -19,5 +19,19 @@ describe('backoff', () => {
     const f3 = backoff({ attempt: 2, factor: 3 })
 
     expect(f3).toBeGreaterThan(f2)
+  })
+
+  it('accepts an optional multiplier', () => {
+    expect(backoff({ attempt: 2, rand: 1 })).toBe(4000)
+  })
+
+  it('works with a rand of 0', () => {
+    expect(backoff({ attempt: 2, rand: 0 })).toBe(2000)
+  })
+})
+
+describe('calculateMaxBackoff', () => {
+  it('gets the max backoff', () => {
+    expect(calculateMaxTotalRetryTime(3)).toBe(14000)
   })
 })

--- a/packages/core/src/priority-queue/backoff.ts
+++ b/packages/core/src/priority-queue/backoff.ts
@@ -10,10 +10,13 @@ type BackoffParams = {
 
   /** The current attempt */
   attempt: number
+
+  /* an optional multiplier -- typically between 0 and 1 */
+  rand?: number
 }
 
 export function backoff(params: BackoffParams): number {
-  const random = Math.random() + 1
+  const random = (params.rand ?? Math.random()) + 1
   const {
     minTimeout = 500,
     factor = 2,
@@ -21,4 +24,16 @@ export function backoff(params: BackoffParams): number {
     maxTimeout = Infinity,
   } = params
   return Math.min(random * minTimeout * Math.pow(factor, attempt), maxTimeout)
+}
+
+/**
+ *
+ * @returns Max total retry time in MS
+ */
+export const calculateMaxTotalRetryTime = (maxAttempts: number): number => {
+  let retryTime = 0
+  for (let i = maxAttempts; i > 0; i--) {
+    retryTime += backoff({ attempt: i, rand: 1 })
+  }
+  return retryTime
 }

--- a/packages/core/src/priority-queue/persisted.ts
+++ b/packages/core/src/priority-queue/persisted.ts
@@ -1,4 +1,4 @@
-import { PriorityQueue } from '.'
+import { PriorityQueue, Seen } from '.'
 import { CoreContext, SerializedContext } from '../context'
 
 const nullStorage = (): Storage => ({
@@ -31,16 +31,12 @@ function persistItems(loc: Storage, key: string, items: CoreContext[]): void {
   loc.setItem(key, JSON.stringify(Object.values(merged)))
 }
 
-function seen(loc: Storage, key: string): Record<string, number> {
+function seen(loc: Storage, key: string): Seen {
   const stored = loc.getItem(key)
   return stored ? JSON.parse(stored) : {}
 }
 
-function persistSeen(
-  loc: Storage,
-  key: string,
-  memory: Record<string, number>
-): void {
+function persistSeen(loc: Storage, key: string, memory: Seen): void {
   const stored = seen(loc, key)
 
   loc.setItem(
@@ -103,7 +99,7 @@ export class PersistedPriorityQueue extends PriorityQueue<CoreContext> {
     const seenKey = `persisted-queue:v1:${key}:seen`
 
     let saved: CoreContext[] = []
-    let lastSeen: Record<string, number> = {}
+    let lastSeen: Seen = {}
 
     mutex(this.loc, key, () => {
       try {


### PR DESCRIPTION
> The PriorityQueue class keeps track of any events (context) it sees so it can calculate whether an event can still be retried and how long the retry backoff should be.

> We don’t clear an event’s entry from this map after it has been delivered, so overtime this map can get large.

> Retries typically occur when there’s a network issue. For browsers, the memory leak is hard to detect because the in-memory map is cleared whenever the user navigates to a new page, and the persisted (localStorage) map has storage limits.

> In node.js, an application can run for a long time, so the memory leak is more likely to build up over time.