### PR TITLE
Passing Storage to Plugins

### DIFF
--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -304,8 +304,7 @@ export class Analytics
 
     const registrations = plugins.map((xt) =>
       this.queue.register(ctx, xt, this, {
-        priority: 'critical',
-        options: { storage: this._storage },
+        dependencies: { storage: this._storage },
       })
     )
     await Promise.all(registrations)

--- a/packages/browser/src/core/plugin/index.ts
+++ b/packages/browser/src/core/plugin/index.ts
@@ -1,7 +1,7 @@
 import { Analytics } from '../analytics'
 import { Context } from '../context'
 
-interface PluginConfig {
+export interface PluginConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options: any
   priority: 'critical' | 'non-critical' // whether AJS should expect this plugin to be loaded before starting event delivery

--- a/packages/browser/src/core/plugin/index.ts
+++ b/packages/browser/src/core/plugin/index.ts
@@ -1,10 +1,14 @@
 import { Analytics } from '../analytics'
 import { Context } from '../context'
+import { UniversalStorage } from '../user'
 
 export interface PluginConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  options: any
-  priority: 'critical' | 'non-critical' // whether AJS should expect this plugin to be loaded before starting event delivery
+  options?: any
+  priority?: 'critical' | 'non-critical' // whether AJS should expect this plugin to be loaded before starting event delivery
+  dependencies?: {
+    storage?: UniversalStorage
+  }
 }
 
 // enrichment - modifies the event. Enrichment can happen in parallel, by reducing all changes in the final event. Failures in this stage could halt event delivery.

--- a/packages/browser/src/core/queue/event-queue.ts
+++ b/packages/browser/src/core/queue/event-queue.ts
@@ -6,7 +6,7 @@ import { isOnline } from '../connection'
 import { Context, ContextCancelation } from '../context'
 import { Emitter } from '@segment/analytics-core'
 import { Integrations } from '../events'
-import { Plugin } from '../plugin'
+import { Plugin, PluginConfig } from '../plugin'
 import { createTaskGroup, TaskGroup } from '../task/task-group'
 import { attempt, ensure } from './delivery'
 import { inspectorHost } from '../inspector'
@@ -43,9 +43,10 @@ export class EventQueue extends Emitter {
   async register(
     ctx: Context,
     plugin: Plugin,
-    instance: Analytics
+    instance: Analytics,
+    pluginConfig?: PluginConfig
   ): Promise<void> {
-    await Promise.resolve(plugin.load(ctx, instance))
+    await Promise.resolve(plugin.load(ctx, instance, pluginConfig))
       .then(() => {
         this.plugins.push(plugin)
       })


### PR DESCRIPTION
# RFC - Storage Layer for Plugins 💾  
Problem: If a plugin needs to use browser storage ( cookies, LS, etc. ), it has to implement the storage handling functionality, and Cookie handling in particular requires decent amount of code. Furthermore, plugins aren't aware of AJS storage configuration, so they may use storage regardless of how users configured the AJS. 

In order to enable plugins ( our particular use-case is action destinations ) access the storage layer of AJS, we are creating a universalStorage object during initialization and pass it down to plugins as a dependency when registering plugins. 

Few things of note: 
- [ ] We are using `PluginConfig` object to pass the dependencies to the plugin. Better options? 
- [ ] There is decent amount of overlap between `User` class and `UniversalStorage`, so there is some opportunity for refactoring. 

[] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).