### PR TITLE
elaborate on emitter api

### DIFF
--- a/packages/core/src/analytics/dispatch-emit.ts
+++ b/packages/core/src/analytics/dispatch-emit.ts
@@ -1,5 +1,4 @@
 import { dispatch } from './dispatch'
-import { CoreContext } from '../context'
 
 /* Dispatch function, but swallow promise rejections and use event emitter instead */
 export const dispatchAndEmit = async (
@@ -8,13 +7,20 @@ export const dispatchAndEmit = async (
   try {
     const ctx = await dispatch(event, queue, emitter, options)
     if (ctx.failedDelivery()) {
-      throw ctx
+      emitter.emit('error', {
+        code: 'delivery_failure',
+        message: 'failed to deliver event',
+        ctx: ctx,
+      })
     } else {
       emitter.emit(event.type, ctx)
       return ctx
     }
   } catch (err) {
-    emitter.emit('error', err as CoreContext)
-    return err
+    emitter.emit('error', {
+      code: 'unknown',
+      message: 'an unknown error occurred when dispatching an event.',
+      err: err,
+    })
   }
 }

--- a/packages/core/src/analytics/dispatch.ts
+++ b/packages/core/src/analytics/dispatch.ts
@@ -2,10 +2,10 @@ import { CoreContext } from '../context'
 import { CoreSegmentEvent, Callback } from '../events/interfaces'
 import { EventQueue } from '../queue/event-queue'
 import { isOffline } from '../connection'
-import { Emitter } from '../emitter'
 import { invokeCallback } from '../callback'
+import { Emitter } from '../emitter'
 
-type DispatchOptions = {
+export type DispatchOptions = {
   timeout?: number
   debug?: boolean
   callback?: Callback
@@ -27,7 +27,8 @@ export async function dispatch(
   options?: DispatchOptions
 ): Promise<CoreContext> {
   const ctx = new CoreContext(event)
-  emitter.emit('message_dispatch_pending', ctx) // TODO: inspectorHost.triggered?.(ctx as any)
+  emitter.emit('dispatch_pending', ctx) // This is just for inspector host
+  // TODO: inspectorHost.triggered?.(ctx as any)
 
   if (isOffline() && !options?.retryQueue) {
     return ctx

--- a/packages/core/src/emitter/interface.ts
+++ b/packages/core/src/emitter/interface.ts
@@ -1,0 +1,36 @@
+import { CoreContext } from '../context'
+
+export type EmittedUnknownError<Ctx extends CoreContext> = {
+  code: 'unknown'
+  message: string
+  ctx?: Ctx
+  err?: any
+}
+
+export type EmittedDeliveryFailureError<Ctx extends CoreContext> = {
+  code: 'delivery_failure'
+  message: string
+  ctx: Ctx
+}
+
+/**
+ * Discriminated of all errors with a discriminant key of "code"
+ */
+export type CoreEmittedError<Ctx extends CoreContext> =
+  | EmittedUnknownError<Ctx>
+  | EmittedDeliveryFailureError<Ctx>
+
+export type CoreEmitterContract<
+  Ctx extends CoreContext,
+  AdditionalErrors = CoreEmittedError<Ctx>
+> = {
+  alias: [ctx: Ctx]
+  track: [ctx: Ctx]
+  identify: [ctx: Ctx]
+  page: [ctx: Ctx]
+  screen: [ctx: Ctx]
+  group: [ctx: Ctx]
+  register: [pluginNames: string[]]
+  deregister: [pluginNames: string[]]
+  error: [CoreEmittedError<Ctx> | AdditionalErrors]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './emitter'
+export * from './emitter/interface'
 export * from './plugins'
 export * from './plugins/middleware'
 export * from './events/interfaces'

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -13,12 +13,13 @@ import {
   CoreSegmentEvent,
   bindAll,
   PriorityQueue,
+  CoreEmitterContract,
 } from '@segment/analytics-core'
 import { AnalyticsNodeSettings, validateSettings } from './settings'
 import { analyticsNode, AnalyticsNodePluginSettings } from './plugin'
 
 import { version } from '../../package.json'
-import { EmittedError } from './errors'
+import { NodeEmittedError } from './emitted-errors'
 
 // create a derived class since we may want to add node specific things to Context later
 export class NodeContext extends CoreContext {}
@@ -42,17 +43,8 @@ export interface NodeSegmentEventOptions {
 /**
  * Map of emitter event names to method args.
  */
-type NodeEmitterEvents = {
-  error: [error: EmittedError]
+type NodeEmitterEvents = CoreEmitterContract<NodeContext, NodeEmittedError> & {
   initialize: [AnalyticsNodeSettings]
-  alias: [ctx: NodeContext]
-  track: [ctx: NodeContext]
-  identify: [ctx: NodeContext]
-  page: [ctx: NodeContext]
-  screen: NodeEmitterEvents['page']
-  group: [ctx: NodeContext]
-  register: [pluginNames: string[]]
-  deregister: [pluginNames: string[]]
 }
 
 class NodePriorityQueue extends PriorityQueue<NodeContext> {

--- a/packages/node/src/app/emitted-errors.ts
+++ b/packages/node/src/app/emitted-errors.ts
@@ -1,12 +1,6 @@
 import { CoreContext } from '@segment/analytics-core'
 import { Response } from 'node-fetch'
 
-export interface UnknownError {
-  message: string
-  ctx: CoreContext
-  code: 'unknown'
-}
-
 export interface HTTPError {
   message: string
   ctx: CoreContext
@@ -14,4 +8,4 @@ export interface HTTPError {
   response: Response
 }
 
-export type EmittedError = HTTPError | UnknownError
+export type NodeEmittedError = HTTPError


### PR DESCRIPTION
- tighten emitter contract
- elaborate on emitter API by creating a standard emitter error in core and sharing it
