### PR TITLE
Listen to 'pagehide' event instead of 'unload' when exiting a page

### DIFF
--- a/.changeset/honest-pants-ring.md
+++ b/.changeset/honest-pants-ring.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-next': minor
+'@segment/analytics-core': minor
+---
+
+Listen to 'pagehide' event instead of 'beforeunload' event when closing the browser page and flushing the persisted queue

--- a/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
+++ b/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
@@ -43,7 +43,7 @@ describe('Persisted Priority Queue', () => {
     jest
       .spyOn(window, 'addEventListener')
       .mockImplementation((evt, handler) => {
-        if (evt === 'beforeunload') {
+        if (evt === 'pagehide') {
           onUnload = handler
         }
       })
@@ -104,7 +104,7 @@ describe('Persisted Priority Queue', () => {
       jest
         .spyOn(window, 'addEventListener')
         .mockImplementation((evt, handler) => {
-          if (evt === 'beforeunload') {
+          if (evt === 'pagehide') {
             onUnload = handler
           }
         })
@@ -202,7 +202,7 @@ describe('Persisted Priority Queue', () => {
       jest
         .spyOn(window, 'addEventListener')
         .mockImplementation((evt, handler) => {
-          if (evt === 'beforeunload') {
+          if (evt === 'pagehide') {
             onUnloadFunctions.push(handler)
           }
         })

--- a/packages/browser/src/lib/priority-queue/persisted.ts
+++ b/packages/browser/src/lib/priority-queue/persisted.ts
@@ -109,7 +109,7 @@ export class PersistedPriorityQueue extends PriorityQueue<Context> {
       }
     })
 
-    window.addEventListener('beforeunload', () => {
+    window.addEventListener('pagehide', () => {
       if (this.todo > 0) {
         const items = [...this.queue, ...this.future]
         try {

--- a/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
@@ -224,7 +224,7 @@ describe('Batching', () => {
 
       expect(fetch).not.toHaveBeenCalled()
 
-      window.dispatchEvent(new Event('beforeunload'))
+      window.dispatchEvent(new Event('pagehide'))
 
       expect(fetch).toHaveBeenCalledTimes(1)
 
@@ -253,7 +253,7 @@ describe('Batching', () => {
 
       expect(fetch).not.toHaveBeenCalled()
 
-      window.dispatchEvent(new Event('beforeunload'))
+      window.dispatchEvent(new Event('pagehide'))
 
       expect(fetch).toHaveBeenCalledTimes(2)
     })

--- a/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
@@ -92,7 +92,7 @@ export default function batch(apiHost: string, config?: BatchingConfig) {
     }, timeout)
   }
 
-  window.addEventListener('beforeunload', () => {
+  window.addEventListener('pagehide', () => {
     pageUnloaded = true
 
     if (buffer.length) {

--- a/packages/core/src/priority-queue/persisted.ts
+++ b/packages/core/src/priority-queue/persisted.ts
@@ -119,7 +119,7 @@ export class PersistedPriorityQueue extends PriorityQueue<CoreContext> {
       }
     })
 
-    window.addEventListener('beforeunload', () => {
+    window.addEventListener('pagehide', () => {
       if (this.todo > 0) {
         const items = [...this.queue, ...this.future]
         try {


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->
This PR updates the event the library is listening to when the browser page is closed from `beforeunload` to `pagehide` which is supported by all browsers include Mobile Safari on iOS.

More information about the above change can be found in this issue: https://github.com/segmentio/analytics-next/issues/607


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).