### PR TITLE
[bugfix] update analytics.reset() to clear group data

### DIFF
--- a/.changeset/dull-parents-breathe.md
+++ b/.changeset/dull-parents-breathe.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fixes analytics.reset() so that it clears group data.

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -328,6 +328,7 @@ export class Analytics
 
   reset(): void {
     this._user.reset()
+    this._group.reset()
   }
 
   timeout(timeout: number): void {

--- a/packages/browser/src/test-helpers/retrieve-stored-data.ts
+++ b/packages/browser/src/test-helpers/retrieve-stored-data.ts
@@ -1,0 +1,29 @@
+import cookie from 'js-cookie'
+
+export interface RetrieveStoredDataProps {
+  cookieNames: string[]
+  localStorageKeys: string[]
+}
+
+export function retrieveStoredData({
+  cookieNames,
+  localStorageKeys,
+}: RetrieveStoredDataProps): Record<string, string | {}> {
+  const result: ReturnType<typeof retrieveStoredData> = {}
+
+  const cookies = cookie.get()
+  cookieNames.forEach((name) => {
+    if (name in cookies) {
+      result[name] = cookies[name]
+    }
+  })
+
+  localStorageKeys.forEach((key) => {
+    const value = localStorage.getItem(key)
+    if (value !== null && typeof value !== 'undefined') {
+      result[key] = JSON.parse(value)
+    }
+  })
+
+  return result
+}


### PR DESCRIPTION
This PR updates `analytics.reset()` so that it also clears group data from cookies/localStorage.


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).