### PR TITLE
remove ambient globals tweak tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "jest",
     "test:scripts": "jest --config scripts/jest.config.js",
-    "lint": "yarn constraints && turbo run lint",
+    "lint": "yarn constraints && turbo run lint --continue",
     "build": "turbo run build --filter='./packages/*'",
     "watch": "turbo run watch --filter='./packages/*'",
     "dev": "yarn workspace with-next-js run dev",

--- a/packages/browser/qa/__tests__/destinations.test.ts
+++ b/packages/browser/qa/__tests__/destinations.test.ts
@@ -14,11 +14,7 @@ let destinations = Object.keys(samples)
 if (process.env.DESTINATION) {
   destinations = [process.env.DESTINATION]
 }
-declare global {
-  interface URLSearchParams {
-    entries(): [string, string][]
-  }
-}
+
 
 jest.retryTimes(10)
 describe('Destination Tests', () => {

--- a/packages/browser/src/core/auto-track.ts
+++ b/packages/browser/src/core/auto-track.ts
@@ -2,15 +2,6 @@ import { Analytics } from './analytics'
 import { EventProperties, Options } from './events'
 import { pTimeout } from './callback'
 
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    jQuery: any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Zepto: any
-  }
-}
-
 // Check if a user is opening the link in a new tab
 function userNewTab(event: Event): boolean {
   const typedEvent = event as Event & {
@@ -145,7 +136,8 @@ export function form(
 
     // Support the events happening through jQuery or Zepto instead of through
     // the normal DOM API, because `el.submit` doesn't bubble up events...
-    const $ = window.jQuery || window.Zepto
+
+    const $ = (window as any).jQuery || (window as any).Zepto
     if ($) {
       $(el).submit(handler)
     } else {

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -3,7 +3,6 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/test-helpers/**", "**/tester/**"],
   "compilerOptions": {
-    "incremental": false,
     "outDir": "./dist/pkg",
     "importHelpers": true,
     // publish sourceMaps

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -7,7 +7,7 @@
     "importHelpers": true,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "lib": ["es2020", "DOM"],
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,7 +3,7 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.test.*"],
   "compilerOptions": {
-    "incremental": true,
+    "incremental": false,
     "outDir": "./dist/esm",
     "importHelpers": true,
     // publish sourceMaps

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,7 +3,6 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.test.*"],
   "compilerOptions": {
-    "incremental": false,
     "outDir": "./dist/esm",
     "importHelpers": true,
     // publish sourceMaps

--- a/packages/node/tsconfig.build.json
+++ b/packages/node/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "./dist/esm",
     "importHelpers": true,
     // publish sourceMaps

--- a/packages/node/tsconfig.build.json
+++ b/packages/node/tsconfig.build.json
@@ -3,7 +3,6 @@
   "include": ["src"],
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "incremental": false,
     "outDir": "./dist/esm",
     "importHelpers": true,
     // publish sourceMaps

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Clear build artifacts and build cache
 
-find . -type d \( -name ".turbo" -o -name "dist" -o -name ".next" \) ! -path "*/node_modules/*" -print0 | xargs -0 rm -rf
+find . \( -name ".turbo" -o -name "dist" -o -name ".next" -o -name "tsconfig.tsbuildinfo" \) ! -path "*/node_modules/*" -print0 | xargs -0 rm -rf
 rm -rf node_modules/.cache
 
 echo "Build files and cache deleted."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "incremental": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,12 @@
     "incremental": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true,
+    "compilerOptions": {
+      "module": "commonjs" // get rid of "Cannot use import statement outside a module" for local scripts
+    }
   }
 }


### PR DESCRIPTION
Ambient globals are global to the entire project, even if they're declared in a test file. Under some circumstances, they can even have conflicts with imported code from other modules (if the other module has an ambient global that clashes) -- see segment inspector. This gets rid of all ambient globals, and makes some other typescript tweaks..