### PR TITLE
fix ambient import conflict

### DIFF
--- a/.changeset/rotten-chefs-eat.md
+++ b/.changeset/rotten-chefs-eat.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix ambient import conflict bug

--- a/packages/browser/src/browser/standalone-analytics.ts
+++ b/packages/browser/src/browser/standalone-analytics.ts
@@ -14,7 +14,7 @@ export interface AnalyticsStandalone extends Analytics {
 
 declare global {
   interface Window {
-    analytics: AnalyticsStandalone
+    analytics: AnalyticsSnippet
   }
 }
 
@@ -67,5 +67,8 @@ export async function install(): Promise<void> {
     return
   }
 
-  window.analytics = await AnalyticsBrowser.standalone(writeKey, options)
+  window.analytics = (await AnalyticsBrowser.standalone(
+    writeKey,
+    options
+  )) as AnalyticsSnippet
 }


### PR DESCRIPTION
It occurred to me as I was walking my dog that by using an ambient interface of AnalyticsStandalone locally, we would end up clobbering consumer global declarations since these ambient declarations cross module boundaries. Sure enough:

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/5115498/194761355-4354d62c-01ff-44af-8d86-112127cf6dcf.png">
