### PR TITLE
F: update import code style

### DIFF
--- a/packages/browser/src/lib/merged-options.ts
+++ b/packages/browser/src/lib/merged-options.ts
@@ -1,4 +1,4 @@
-import { JSONObject, Options } from '@/core/events/interfaces'
+import { JSONObject, Options } from '../core/events/interfaces'
 import { LegacySettings } from '../browser'
 
 /**


### PR DESCRIPTION
This line confused my IDE a little.

As I searched through the project, only a few use `import @`. Most code prefer `import ../`.

Are they legacy code from previous repos?

Will fix more and include a changeset if approved.

[] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).