### PR TITLE
Fix action destination middleware bug

### DIFF
--- a/.changeset/rich-icons-nail.md
+++ b/.changeset/rich-icons-nail.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix bug where destination middleware were applying to other plugin types

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -44,7 +44,9 @@ export class ActionDestination implements Plugin {
   }
 
   addMiddleware(...fn: DestinationMiddlewareFunction[]): void {
-    this.middleware.push(...fn)
+    if (this.type === 'destination') {
+      this.middleware.push(...fn)
+    }
   }
 
   private async transform(ctx: Context): Promise<Context> {

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -73,7 +73,7 @@ export class ActionDestination implements Plugin {
       if (!this.action[methodName]) return ctx
 
       let transformedContext: Context = ctx
-      // sev-skinny-viper - make sure that transformations are only applied to destination-actions of 'destination' type.
+      // Transformations only allowed for destination plugins. Other plugin types support mutating events.
       if (this.type === 'destination') {
         transformedContext = await this.transform(ctx)
       }

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -72,7 +72,11 @@ export class ActionDestination implements Plugin {
     return async (ctx: Context): Promise<Context> => {
       if (!this.action[methodName]) return ctx
 
-      const transformedContext = await this.transform(ctx)
+      let transformedContext: Context = ctx
+      if (this.type === 'destination') {
+        transformedContext = await this.transform(ctx)
+      }
+
       await this.action[methodName]!(transformedContext)
 
       return ctx

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -73,6 +73,7 @@ export class ActionDestination implements Plugin {
       if (!this.action[methodName]) return ctx
 
       let transformedContext: Context = ctx
+      // sev-skinny-viper - make sure that transformations are only applied to destination-actions of 'destination' type.
       if (this.type === 'destination') {
         transformedContext = await this.transform(ctx)
       }


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

This PR fixes a bug where destination filters (and other destination middleware) were being applied to all action destination types instead only those of type 'destination'. This was breaking behaviour such as amplitude adding a sessionId to the integrations object.


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).