### PR TITLE
fix: can init with settings [wip]

### DIFF
--- a/examples/standalone-playground/pages/index-local.html
+++ b/examples/standalone-playground/pages/index-local.html
@@ -72,17 +72,18 @@
               var key = analytics.methods[e]
               analytics[key] = analytics.factory(key)
             }
-            analytics.load = function (key, e) {
+            analytics.load = function (settings, options) {
               var t = document.createElement('script')
               t.type = 'text/javascript'
               t.async = !0
               t.src = '/node_modules/@segment/analytics-next/dist/umd/standalone.js'
               var n = document.getElementsByTagName('script')[0]
               n.parentNode.insertBefore(t, n)
-              analytics._loadOptions = e
             }
             analytics.SNIPPET_VERSION = '4.13.1'
             analytics._writeKey = writeKey
+            analytics._loadSettings = { cdnURL: 'https://cdn.segment.com' }
+            analytics._loadOptions = {};
             analytics.load()
             analytics.page()
           }

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -388,9 +388,9 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
   }
 
   static standalone(
-    writeKey: string,
+    settings?: AnalyticsBrowserSettings,
     options?: InitOptions
   ): Promise<Analytics> {
-    return AnalyticsBrowser.load({ writeKey }, options).then((res) => res[0])
+    return AnalyticsBrowser.load(settings, options).then((res) => res[0])
   }
 }

--- a/packages/browser/src/browser/standalone-analytics.ts
+++ b/packages/browser/src/browser/standalone-analytics.ts
@@ -1,12 +1,13 @@
 import { Analytics, InitOptions } from '../core/analytics'
-import { AnalyticsBrowser } from '.'
+import { AnalyticsBrowser, AnalyticsBrowserSettings } from '.'
 import { embeddedWriteKey } from '../lib/embedded-write-key'
 
 export interface AnalyticsSnippet extends AnalyticsStandalone {
-  load: (writeKey: string, options?: InitOptions) => void
+  load: (settings?: AnalyticsBrowserSettings, options?: InitOptions) => void
 }
 
 export interface AnalyticsStandalone extends Analytics {
+  _loadSettings?: AnalyticsBrowserSettings
   _loadOptions?: InitOptions
   _writeKey?: string
   _cdn?: string
@@ -59,6 +60,7 @@ function getWriteKey(): string | undefined {
 
 export async function install(): Promise<void> {
   const writeKey = getWriteKey()
+  const settings = window.analytics?._loadSettings ?? {}
   const options = window.analytics?._loadOptions ?? {}
   if (!writeKey) {
     console.error(
@@ -68,7 +70,7 @@ export async function install(): Promise<void> {
   }
 
   window.analytics = (await AnalyticsBrowser.standalone(
-    writeKey,
+    { writeKey, ...settings },
     options
   )) as AnalyticsSnippet
 }


### PR DESCRIPTION
The browser load related code hard-code only the `writeKey` param. Other settings such as `cdn` has no way to pass in.

I'm not sure if this pr fix it correctly. It's a wip showcase how I expect the function signature behavior.

Please help me to clarify. Thanks.

[] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).