### PR TITLE
[feature] add option to disable converting ISO strings to dates

### DIFF
--- a/.changeset/khaki-mayflies-punch.md
+++ b/.changeset/khaki-mayflies-punch.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Adds a new load option `disableAutoISOConversions` that turns off converting ISO strings in event fields to Dates for integrations.

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -67,6 +67,13 @@ export interface InitOptions {
    *
    */
   disableClientPersistence?: boolean
+  /**
+   * Disables automatically converting ISO string event properties into Dates.
+   * ISO string to Date conversions occur right before sending events to a classic device mode integration,
+   * after any destination middleware have been ran.
+   * Defaults to `false`.
+   */
+  disableAutoISOConversion?: boolean
   initialPageview?: boolean
   cookie?: CookieOptions
   user?: UserOptions

--- a/packages/browser/src/lib/klona.ts
+++ b/packages/browser/src/lib/klona.ts
@@ -1,4 +1,0 @@
-import { SegmentEvent } from '../core/events'
-
-export const klona = (evt: SegmentEvent): SegmentEvent =>
-  JSON.parse(JSON.stringify(evt))

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -65,6 +65,7 @@ export class LegacyDestination implements Plugin {
   private _initialized = false
   private onReady: Promise<unknown> | undefined
   private onInitialize: Promise<unknown> | undefined
+  private disableAutoISOConversion: boolean
 
   integration: LegacyIntegration | undefined
 
@@ -80,6 +81,7 @@ export class LegacyDestination implements Plugin {
     this.name = name
     this.version = version
     this.settings = { ...settings }
+    this.disableAutoISOConversion = options.disableAutoISOConversion || false
 
     // AJS-Renderer sets an extraneous `type` setting that clobbers
     // existing type defaults. We need to remove it if it's present
@@ -228,7 +230,9 @@ export class LegacyDestination implements Plugin {
       return ctx
     }
 
-    const event = new clz(afterMiddleware, {})
+    const event = new clz(afterMiddleware, {
+      traverse: !this.disableAutoISOConversion,
+    })
 
     ctx.stats.increment('analytics_js.integration.invoke', 1, [
       `method:${eventType}`,

--- a/packages/browser/src/plugins/middleware/index.ts
+++ b/packages/browser/src/plugins/middleware/index.ts
@@ -27,6 +27,7 @@ export async function applyDestinationMiddleware(
   evt: SegmentEvent,
   middleware: DestinationMiddlewareFunction[]
 ): Promise<SegmentEvent | null> {
+  // Clone the event so mutations are localized to a single destination.
   let modifiedEvent = toFacade(evt, {
     clone: true,
     traverse: false,

--- a/packages/browser/src/plugins/middleware/index.ts
+++ b/packages/browser/src/plugins/middleware/index.ts
@@ -3,7 +3,6 @@ import { SegmentEvent } from '../../core/events'
 import { Plugin } from '../../core/plugin'
 import { asPromise } from '../../lib/as-promise'
 import { SegmentFacade, toFacade } from '../../lib/to-facade'
-import { klona } from '../../lib/klona'
 
 export interface MiddlewareParams {
   payload: SegmentFacade
@@ -28,7 +27,10 @@ export async function applyDestinationMiddleware(
   evt: SegmentEvent,
   middleware: DestinationMiddlewareFunction[]
 ): Promise<SegmentEvent | null> {
-  let modifiedEvent = klona(evt)
+  let modifiedEvent = toFacade(evt, {
+    clone: true,
+    traverse: false,
+  }).rawEvent() as SegmentEvent
   async function applyMiddleware(
     event: SegmentEvent,
     fn: DestinationMiddlewareFunction


### PR DESCRIPTION
This adds a new load option - `disableAutoISOConversions`. This turns off the automatic conversion of event fields where any strings that appear as an ISO8601 string (including just dates, e.g. `YYYY-MM-DD`) become `Date` objects.

## Background

Through `@segment/facade`, any events passed to classic integrations had any ISO strings converted to Dates. I suspect this was intentional behavior because the way we cloned events (`JSON.parse(JSON.stringify(event))`) converted Dates to ISO8601 strings, so facade was converting them back to dates.

However, some users want their ISO strings to be passed to integrations as is, especially when the string represents a calendar date and not a time.

## PR details
`@segment/facade` supports turning off this conversion by setting `traverse` to false, so the new option ultimately sets the `traverse` flag.

I also changed how we clone events so that users can still specify a property as a `Date` object and have that carried over to the cloned event regardless of the new setting. It looks like analytics.js classic also did a deep clone of the event instead of our `JSON.parse(JSON.stringify(event))` trick, so this shouldn't cause any unintended consequences.

I made this field default to `false`, meaning users need to opt-in to this new behavior. I made it opt-in to prevent potentially impacting user-defined destination middleware.


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).