### PR TITLE
Delay initialization (lazy loading)

### DIFF
--- a/.changeset/friendly-mails-heal.md
+++ b/.changeset/friendly-mails-heal.md
@@ -1,5 +1,5 @@
 ---
-'@segment/analytics-next': patch
+'@segment/analytics-next': minor
 ---
 
 Add ability to delay initialization

--- a/.changeset/friendly-mails-heal.md
+++ b/.changeset/friendly-mails-heal.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Add ability to delay initialization

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ document.body?.addEventListener('click', () => {
 ```
 
 ## Lazy / Delayed Loading
-You can load a buffered version of analytics that requires `.load` to be explicitly called before initatiating any network activity. This can be useful if you want to wait for a user to consent before fetching any tracking destinations or sending buffered events to segment.
+You can load a buffered version of analytics that requires `.load` to be explicitly called before initiating any network activity. This can be useful if you want to wait for a user to consent before fetching any tracking destinations or sending buffered events to segment.
 
 - ⚠️ ️`.load` should only be called _once_.
 

--- a/README.md
+++ b/README.md
@@ -70,15 +70,11 @@ if (userConsentsToBeingTracked) {
 This strategy also comes in handy if you have some settings that are fetched asynchronously.
 ```ts
 const analytics = new AnalyticsBrowser()
-
-fetchSettings().then(writeKey => analytics.load({ writeKey }))
+fetchWriteKey().then(writeKey => analytics.load({ writeKey }))
 
 analytics.identify("hello world")
-document.body?.addEventListener('click', () => {
-  analytics.track('document body clicked!')
-})
-
 ```
+
 ## Usage in Common Frameworks
 ### using `React` (Simple)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,33 @@ document.body?.addEventListener('click', () => {
 })
 ```
 
+## Lazy / Delayed Loading
+You can load a buffered version of analytics that requires `.load` to be explicitly called before initatiating any network activity. This can be useful if you want to wait for a user to consent before fetching any tracking destinations or sending buffered events to segment.
+
+- ⚠️ ️`.load` should only be called _once_.
+
+```ts
+export const analytics = new AnalyticsBrowser()
+
+analytics.identify("hello world")
+
+if (userConsentsToBeingTracked) {
+    analytics.load({ writeKey: '<YOUR_WRITE_KEY>' }) // destinations loaded, enqueued events are flushed
+}
+```
+This strategy also comes in handy if you have some settings that are fetched asynchronously.
+```ts
+const analytics = new AnalyticsBrowser()
+
+fetchSettings().then(writeKey => analytics.load({ writeKey }))
+
+analytics.identify("hello world")
+document.body?.addEventListener('click', () => {
+  analytics.track('document body clicked!')
+})
+
+```
+## Usage in Common Frameworks
 ### using `React` (Simple)
 
 ```tsx

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -53,7 +53,30 @@ document.body?.addEventListener('click', () => {
 })
 ```
 
-### using `React` (Simple / client-side only)
+## Lazy / Delayed Loading
+You can load a buffered version of analytics that requires `.load` to be explicitly called before initiating any network activity. This can be useful if you want to wait for a user to consent before fetching any tracking destinations or sending buffered events to segment.
+
+- ⚠️ ️`.load` should only be called _once_.
+
+```ts
+export const analytics = new AnalyticsBrowser()
+
+analytics.identify("hello world")
+
+if (userConsentsToBeingTracked) {
+    analytics.load({ writeKey: '<YOUR_WRITE_KEY>' }) // destinations loaded, enqueued events are flushed
+}
+```
+This strategy also comes in handy if you have some settings that are fetched asynchronously.
+```ts
+const analytics = new AnalyticsBrowser()
+fetchWriteKey().then(writeKey => analytics.load({ writeKey }))
+
+analytics.identify("hello world")
+```
+
+## Usage in Common Frameworks
+### using `React` (Simple)
 
 ```tsx
 import { AnalyticsBrowser } from '@segment/analytics-next'
@@ -71,6 +94,8 @@ const App = () => (
 ### using `React` (Advanced w/ React Context)
 
 ```tsx
+import { AnalyticsBrowser } from '@segment/analytics-next'
+
 const AnalyticsContext = React.createContext<AnalyticsBrowser>(undefined!);
 
 type Props = {
@@ -102,7 +127,7 @@ export const useAnalytics = () => {
 const TrackButton = () => {
   const analytics = useAnalytics()
   return (
-    <button onClick={() => analytics.track('hello world').then(console.log)}>
+    <button onClick={() => analytics.track('hello world')}>
       Track!
     </button>
   )
@@ -126,7 +151,7 @@ More React Examples:
 1. create composable file `segment.ts` with factory ref analytics:
 
 ```ts
-import { Analytics, AnalyticsBrowser } from '@segment/analytics-next'
+import { AnalyticsBrowser } from '@segment/analytics-next'
 
 export const analytics = AnalyticsBrowser.load({
   writeKey: '<YOUR_WRITE_KEY>',
@@ -200,7 +225,10 @@ First, clone the repo and then startup our local dev environment:
 ```sh
 $ git clone git@github.com:segmentio/analytics-next.git
 $ cd analytics-next
-$ yarn dev
+$ nvm use  # installs correct version of node defined in .nvmrc.
+$ yarn && yarn build
+$ yarn test
+$ yarn dev  # optional: runs analytics-next playground.
 ```
 
 > If you get "Cannot find module '@segment/analytics-next' or its corresponding type declarations.ts(2307)" (in VSCode), you may have to "cmd+shift+p -> "TypeScript: Restart TS server"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "27.1 KB"
+      "limit": "27.2 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
@@ -29,20 +29,21 @@ describe('Lazy initialization', () => {
     await track
     expect(trackSpy).toBeCalledWith('foo')
   })
-  it('load method return an analytics instance', async () => {
+
+  it('.load method return an analytics instance', async () => {
     const analytics = new AnalyticsBrowser().load({ writeKey: 'foo' })
     expect(analytics instanceof AnalyticsBrowser).toBeTruthy()
-    await analytics.track('foo')
-    expect(trackSpy).toBeCalledWith('foo')
   })
 
   it('should ignore subsequent .load calls', async () => {
     const analytics = new AnalyticsBrowser()
-    await analytics.load({ writeKey: 'abc' })
-    await analytics.load({ writeKey: 'abc' })
+    await analytics.load({ writeKey: 'my-write-key' })
+    await analytics.load({ writeKey: 'def' })
     expect(fetched).toBeCalledTimes(1)
     expect(fetched).toBeCalledWith(
-      expect.stringContaining('https://cdn.segment.com/v1/projects/')
+      expect.stringContaining(
+        'https://cdn.segment.com/v1/projects/my-write-key/settings'
+      )
     )
   })
 })

--- a/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
@@ -1,0 +1,37 @@
+import { sleep } from '@segment/analytics-core'
+import unfetch from 'unfetch'
+import { AnalyticsBrowser } from '..'
+import { Analytics } from '../../core/analytics'
+import { createSuccess } from '../../test-helpers/factories'
+
+jest.mock('unfetch')
+
+const mockFetchSettingsSuccessResponse = () => {
+  jest
+    .mocked(unfetch)
+    .mockImplementation(() => createSuccess({ integrations: {} }))
+}
+
+describe('Lazy initialization', () => {
+  let trackSpy: jest.SpiedFunction<Analytics['track']>
+  beforeEach(() => {
+    trackSpy = jest.spyOn(Analytics.prototype, 'track')
+    mockFetchSettingsSuccessResponse()
+  })
+
+  it('Should be able to delay initialization ', async () => {
+    const analytics = new AnalyticsBrowser()
+    const track = analytics.track('foo')
+    await sleep(100)
+    expect(trackSpy).not.toBeCalled()
+    analytics.load({ writeKey: 'abc' })
+    await track
+    expect(trackSpy).toBeCalledWith('foo')
+  })
+  it('load method return an analytics instance', async () => {
+    const analytics = new AnalyticsBrowser().load({ writeKey: 'foo' })
+    expect(analytics instanceof AnalyticsBrowser).toBeTruthy()
+    await analytics.track('foo')
+    expect(trackSpy).toBeCalledWith('foo')
+  })
+})

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -398,16 +398,4 @@ describe('Pre-initialization', () => {
       await ajsBrowser2
     })
   })
-
-  describe('Delayed initialization', () => {
-    it('Should be able to delay initialization ', async () => {
-      const analytics = new AnalyticsBrowser()
-      const track = analytics.track('foo')
-      await sleep(100)
-      expect(trackSpy).not.toBeCalled()
-      analytics.load({ writeKey: 'abc' })
-      await track
-      expect(trackSpy).toBeCalledWith('foo')
-    })
-  })
 })

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -401,11 +401,11 @@ describe('Pre-initialization', () => {
 
   describe('Delayed initialization', () => {
     it('Should be able to delay initialization ', async () => {
-      const analytics = new AnalyticsBrowser({ writeKey: 'foo' })
+      const analytics = new AnalyticsBrowser()
       const track = analytics.track('foo')
       await sleep(100)
       expect(trackSpy).not.toBeCalled()
-      analytics.load()
+      analytics.load({ writeKey: 'abc' })
       await track
       expect(trackSpy).toBeCalledWith('foo')
     })

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -398,4 +398,16 @@ describe('Pre-initialization', () => {
       await ajsBrowser2
     })
   })
+
+  describe('Delayed initialization', () => {
+    it('Should be able to delay initialization ', async () => {
+      const analytics = new AnalyticsBrowser({ writeKey: 'foo' })
+      const track = analytics.track('foo')
+      await sleep(100)
+      expect(trackSpy).not.toBeCalled()
+      analytics.load()
+      await track
+      expect(trackSpy).toBeCalledWith('foo')
+    })
+  })
 })

--- a/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
+++ b/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
@@ -9,6 +9,12 @@ import { Group, User } from '../../../core/user'
  * They aren't meant to be run by anything but the typescript compiler.
  */
 export default {
+  'AnalyticsBrowser should accept settings': () => {
+    const analytics = new AnalyticsBrowser({ writeKey: 'foo' })
+    assertNotAny(analytics)
+    assertIs<AnalyticsBrowser>(analytics)
+    void analytics.track('foo')
+  },
   'AnalyticsBrowser should return the correct type': () => {
     const result = AnalyticsBrowser.load({ writeKey: 'abc' })
     assertNotAny(result)

--- a/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
+++ b/packages/browser/src/browser/__tests__/typedef-tests/analytics-browser.ts
@@ -9,12 +9,6 @@ import { Group, User } from '../../../core/user'
  * They aren't meant to be run by anything but the typescript compiler.
  */
 export default {
-  'AnalyticsBrowser should accept settings': () => {
-    const analytics = new AnalyticsBrowser({ writeKey: 'foo' })
-    assertNotAny(analytics)
-    assertIs<AnalyticsBrowser>(analytics)
-    void analytics.track('foo')
-  },
   'AnalyticsBrowser should return the correct type': () => {
     const result = AnalyticsBrowser.load({ writeKey: 'abc' })
     assertNotAny(result)
@@ -115,5 +109,17 @@ export default {
       thing: 123
     }
     void AnalyticsBrowser.load({ writeKey: 'foo' }).track('foo', {} as User)
+  },
+  'Lazy instantiation should be supported': () => {
+    const analytics = new AnalyticsBrowser()
+    assertNotAny(analytics)
+    assertIs<AnalyticsBrowser>(analytics)
+    analytics.load({ writeKey: 'foo' })
+    void analytics.track('foo')
+  },
+  '.load should return this': () => {
+    const analytics = new AnalyticsBrowser().load({ writeKey: 'foo' })
+    assertNotAny(analytics)
+    assertIs<AnalyticsBrowser>(analytics)
   },
 }

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -324,7 +324,7 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
 
   constructor() {
     const { promise: loadStart, resolve: resolveLoadStart } =
-      createDeferred<[AnalyticsBrowserSettings, InitOptions]>()
+      createDeferred<Parameters<AnalyticsBrowser['load']>>()
 
     super((buffer) =>
       loadStart.then(([settings, options]) =>

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -310,6 +310,8 @@ async function loadAnalytics(
 
 /**
  * The public browser interface for Segment Analytics
+ *
+ * @example
  * ```ts
  *  export const analytics = new AnalyticsBrowser()
  *  analytics.load({ writeKey: 'foo' })
@@ -337,12 +339,18 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
   }
 
   /**
-   * Starts loading an analytics instance including:
-   * * Fetching all destinations configured by the user (if applicable).
+   * Fully initialize an analytics instance, including:
+   *
+   * * Fetching settings from the segment CDN (by default).
+   * * Fetching all remote destinations configured by the user (if applicable).
+   * * Flushing buffered analytics events.
    * * Loading all middleware.
-   * * Flushing any analytics events that were captured before this method was called.
+   *
+   * Note:️  This method should only be called *once* in your application.
+   *
+   * @example
    * ```ts
-   * export const analytics = new AnalyticsBrowser() // nothing loaded yet
+   * export const analytics = new AnalyticsBrowser()
    * analytics.load({ writeKey: 'foo' })
    * ```
    */
@@ -354,6 +362,7 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
   /**
    * Instantiates an object exposing Analytics methods.
    *
+   * @example
    * ```ts
    * const ajs = AnalyticsBrowser.load({ writeKey: '<YOUR_WRITE_KEY>' })
    *

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -309,8 +309,12 @@ async function loadAnalytics(
 }
 
 /**
- * The public browser interface for this package.
- * Use AnalyticsBrowser.load to create an instance.
+ * The public browser interface for Segment Analytics
+ * ```ts
+ *  export const analytics = new AnalyticsBrowser()
+ *  analytics.load({ writeKey: 'foo' })
+ * ```
+ * @link https://github.com/segmentio/analytics-next/#readme
  */
 export class AnalyticsBrowser extends AnalyticsBuffered {
   private _resolveLoadStart: (
@@ -332,6 +336,16 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
       resolveLoadStart([settings, options])
   }
 
+  /**
+   * Starts loading an analytics instance including:
+   * * Fetching all destinations configured by the user (if applicable).
+   * * Loading all middleware.
+   * * Flushing any analytics events that were captured before this method was called.
+   * ```ts
+   * export const analytics = new AnalyticsBrowser() // nothing loaded yet
+   * analytics.load({ writeKey: 'foo' })
+   * ```
+   */
   load(settings: AnalyticsBrowserSettings, options: InitOptions = {}): this {
     this._resolveLoadStart(settings, options)
     return this
@@ -351,9 +365,7 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
     settings: AnalyticsBrowserSettings,
     options: InitOptions = {}
   ): AnalyticsBrowser {
-    const ajs = new AnalyticsBrowser()
-    ajs.load(settings, options)
-    return ajs
+    return new AnalyticsBrowser().load(settings, options)
   }
 
   static standalone(

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -8,6 +8,7 @@ import { Plan } from '../core/events'
 import { Plugin } from '../core/plugin'
 import { MetricsOptions } from '../core/stats/remote-metrics'
 import { mergedOptions } from '../lib/merged-options'
+import { createDeferred } from '../lib/create-deferred'
 import { pageEnrichment } from '../plugins/page-enrichment'
 import { remoteLoader, RemotePlugin } from '../plugins/remote-loader'
 import type { RoutingRule } from '../plugins/routing-middleware'
@@ -308,20 +309,6 @@ async function loadAnalytics(
 }
 
 /**
- * Return a promise that can be externally resolved
- */
-const createDeferred = <T>() => {
-  let resolve!: (promiseValue?: T) => void
-  const promise = new Promise<T>((_resolve) => {
-    resolve = (promiseValue?: T) => _resolve(promiseValue as T)
-  })
-  return {
-    promise,
-    resolve,
-  }
-}
-
-/**
  * The public browser interface for this package.
  * Use AnalyticsBrowser.load to create an instance.
  */
@@ -345,8 +332,9 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
       resolveLoadStart([settings, options])
   }
 
-  load(settings: AnalyticsBrowserSettings, options: InitOptions = {}): void {
-    return this._resolveLoadStart(settings, options)
+  load(settings: AnalyticsBrowserSettings, options: InitOptions = {}): this {
+    this._resolveLoadStart(settings, options)
+    return this
   }
 
   /**

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -354,7 +354,10 @@ export class AnalyticsBrowser extends AnalyticsBuffered {
    * analytics.load({ writeKey: 'foo' })
    * ```
    */
-  load(settings: AnalyticsBrowserSettings, options: InitOptions = {}): this {
+  load(
+    settings: AnalyticsBrowserSettings,
+    options: InitOptions = {}
+  ): AnalyticsBrowser {
     this._resolveLoadStart(settings, options)
     return this
   }

--- a/packages/browser/src/lib/create-deferred.ts
+++ b/packages/browser/src/lib/create-deferred.ts
@@ -1,0 +1,16 @@
+/**
+ * Return a promise that can be externally resolved
+ */
+export const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason: any) => void
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return {
+    resolve,
+    reject,
+    promise,
+  }
+}


### PR DESCRIPTION
```ts
import { AnalyticsBrowser } from '@segment/analytics-next'

const analytics = new AnalyticsBrowser() // nothing loaded yet

// queue events
analytics.track('foo')
analytics.identify('bar')

if (userConsentsToTracking) {
  analytics.load({ writeKey: 'foo' }) // loaded. queued events should now be sent.
}


```