### PR TITLE
refactor get cdn to have smaller footprint

### DIFF
--- a/.changeset/tall-stingrays-approve.md
+++ b/.changeset/tall-stingrays-approve.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Refactor get cdn to have smaller footprint

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -1,6 +1,6 @@
 import jsdom, { JSDOM } from 'jsdom'
 import { InitOptions } from '../../'
-import { AnalyticsBrowser, loadLegacySettings } from '../../browser'
+import { AnalyticsBrowser } from '../../browser'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
 import { install, AnalyticsStandalone } from '../standalone-analytics'
 import unfetch from 'unfetch'
@@ -127,10 +127,10 @@ describe('standalone bundle', () => {
       // @ts-ignore ignore Response required fields
       .mockImplementation((): Promise<Response> => fetchSettings)
 
-    await loadLegacySettings(segmentDotCom)
+    await AnalyticsBrowser.standalone('my-write-key')
 
     expect(unfetch).toHaveBeenCalledWith(
-      'https://cdn.foo.com/v1/projects/foo/settings'
+      'https://cdn.foo.com/v1/projects/my-write-key/settings'
     )
   })
 
@@ -142,7 +142,7 @@ describe('standalone bundle', () => {
     const mockCdn = 'http://my-overridden-cdn.com'
 
     window.analytics._cdn = mockCdn
-    await loadLegacySettings(segmentDotCom)
+    await AnalyticsBrowser.standalone('abc')
 
     expect(unfetch).toHaveBeenCalledWith(expect.stringContaining(mockCdn))
   })

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -79,11 +79,9 @@ export interface AnalyticsBrowserSettings extends AnalyticsSettings {
 
 export function loadLegacySettings(
   writeKey: string,
-  cdnURL?: string
+  cdnURL: string
 ): Promise<LegacySettings> {
-  const baseUrl = cdnURL ?? getCDN()
-
-  return fetch(`${baseUrl}/v1/projects/${writeKey}/settings`)
+  return fetch(`${cdnURL}/v1/projects/${writeKey}/settings`)
     .then((res) => {
       if (!res.ok) {
         return res.text().then((errorResponseMessage) => {
@@ -263,7 +261,7 @@ async function loadAnalytics(
 
   const legacySettings =
     settings.cdnSettings ??
-    (await loadLegacySettings(settings.writeKey, settings.cdnURL))
+    (await loadLegacySettings(settings.writeKey, settings.cdnURL || getCDN()))
 
   const retryQueue: boolean =
     legacySettings.integrations['Segment.io']?.retryQueue ?? true


### PR DESCRIPTION
got rid of some smells, like testing loadLegacySettings in tests.