### PR TITLE
fix node build structure

### DIFF
--- a/packages/node/src/global.d.ts
+++ b/packages/node/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.json' // workaround - https://stackoverflow.com/questions/55753163/package-json-is-not-under-rootdir/61467483#61467483

--- a/packages/node/tsconfig.build.json
+++ b/packages/node/tsconfig.build.json
@@ -11,6 +11,7 @@
     "declarationMap": true,
     // add type declarations to "types" folder
     "declaration": true,
-    "declarationDir": "./dist/types"
+    "declarationDir": "./dist/types",
+    "resolveJsonModule": false // workaround - https://stackoverflow.com/questions/55753163/package-json-is-not-under-rootdir/61467483#61467483
   }
 }


### PR DESCRIPTION
Simple thing: we want to import the version from package.json, but using "resolveJSONModules" has the somewhat opaque side effect of completely changing the typescript build structure.

 Problem:
 - if you import from outside the project, the typescript compiler will as a side effect automatically rebuild the project to include the "src" as a folder, rather than the just the contents -- *we want dist/index.ts, rather than dist/src/index.ts*
    - If you use use "root: "./src", you will get an error "cannot import from outside the project"
- This is a documented issue, and this fix came from this thread: https://stackoverflow.com/a/61426303

The best way would be to fix this with typescript project references -- but that was more code than I felt like pushing atm.