### PR TITLE
add version generation step

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
-    "build": "yarn concurrently 'yarn:build:*'",
+    "gen-version": "sh scripts/add-generated-version.sh",
+    "version": "yarn gen-version",
+    "build": "yarn gen-version && yarn concurrently 'yarn:build:*'",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "build:esm": "yarn tsc -p tsconfig.build.json",
     "watch": "yarn build:esm --watch --incremental",

--- a/packages/node/scripts/add-generated-version.sh
+++ b/packages/node/scripts/add-generated-version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+PKG_VERSION=$(node --eval="process.stdout.write(require('./package.json').version)")
+
+cat <<EOF >src/generated/version.ts
+// This file is generated.
+export const version = '$PKG_VERSION'
+EOF
+
+git add src/generated/version.ts

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -18,8 +18,7 @@ import {
 } from '@segment/analytics-core'
 import { AnalyticsNodeSettings, validateSettings } from './settings'
 import { analyticsNode } from './plugin'
-
-import { version } from '../../package.json'
+import { version } from '../generated/version'
 import { NodeEmittedError } from './emitted-errors'
 
 // create a derived class since we may want to add node specific things to Context later

--- a/packages/node/src/app/plugin.ts
+++ b/packages/node/src/app/plugin.ts
@@ -4,9 +4,8 @@ import {
   CoreContext,
 } from '@segment/analytics-core'
 import fetch, { Response } from 'node-fetch'
-import { version } from '../../package.json'
 import { AnalyticsNode } from './analytics-node'
-
+import { version } from '../generated/version'
 const btoa = (val: string): string => Buffer.from(val).toString('base64')
 
 export async function post(

--- a/packages/node/src/generated/__tests__/version.test.ts
+++ b/packages/node/src/generated/__tests__/version.test.ts
@@ -1,0 +1,18 @@
+import { version } from '../version'
+import { readFileSync } from 'fs'
+import { resolve as resolvePath } from 'path'
+
+function getPackageJsonVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(
+      resolvePath(__dirname, '..', '..', '..', 'package.json')
+    ).toString()
+  )
+  return packageJson.version
+}
+
+describe('version', () => {
+  it('matches version in package.json', async () => {
+    expect(version).toBe(getPackageJsonVersion())
+  })
+})

--- a/packages/node/src/generated/version.ts
+++ b/packages/node/src/generated/version.ts
@@ -1,0 +1,2 @@
+// This file is generated.
+export const version = '0.0.1'

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "resolveJsonModule": true,
     "module": "esnext",
     "target": "ES5",
     "moduleResolution": "node",


### PR DESCRIPTION
This fixes the broken node import map, which broke when the "version" method was added -- if you import a.json from outside the project, the typescript compiler will as a side effect automatically rebuild the project to include the "src" as a root folder. 

There are gotchas here, and actually generating the version file like we do in browser turned out to be the quickest/most reliable solution.


Stackoverflow:
https://stackoverflow.com/questions/55753163/package-json-is-not-under-rootdir

This can go away once we add typescript project references (and use resolveJSONModules).