### PR TITLE
fix broken node build structure / import map

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,12 +2,12 @@
   "name": "@segment/analytics-node",
   "version": "0.0.1",
   "private": true,
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "module": "./dist/esm/src/index.js",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/src/index.js",
+    "import": "./dist/esm/src/index.js"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Oops, npm import map is broken. (this is one of a few benefits to having integration tests that _live outside_ the package that they are testing -- it catches this sort of thing!).

TIL A project that imports a json module (i.e. to retrieve the lib version from `package.json`) will silently change the build structure if the imported module is outside of the "includes" directory and no root is explicitly defined. This is convenient, but wonky.

see: https://stackoverflow.com/questions/55753163/package-json-is-not-under-rootdir