### PR TITLE
add node rc publish script

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-node",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.0",
   "private": true,
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -29,7 +29,8 @@
     "tsc": "yarn run -T tsc",
     "eslint": "yarn run -T eslint",
     "concurrently": "yarn run -T concurrently",
-    "jest": "yarn run -T jest"
+    "jest": "yarn run -T jest",
+    "publish-prerelease": "sh scripts/prerelease.sh"
   },
   "dependencies": {
     "@segment/analytics-core": "1.1.0",

--- a/packages/node/scripts/prerelease.sh
+++ b/packages/node/scripts/prerelease.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Run this script on master when ready to publish node.
+
+echo "bumping version..." &&
+  npm version prerelease &&
+  git add package.json &&
+  git commit -m "bump node version"
+
+echo "modifying package.json..." &&
+  # delete private field from package.json
+  echo "$(jq 'del(.private)' package.json)" >package.json &&
+  # add repository info to package.json
+  yarn constraints --fix
+
+echo "building and publishing..." &&
+  yarn build &&
+  npm publish --tag rc &&
+  git push
+
+echo "cleaning up" &&
+  git checkout .


### PR DESCRIPTION
Add script for publishing prerelease for nodejs (run locally on master)

Changesets has a way to do this, but I'd rather be able to release node independently (for now) rather than have to merge in version packages.