### PR TITLE
node: "maxWaitTimeInMs" -> "flushInterval" (and update default value)

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -38,7 +38,18 @@ app.post('/cart', (req, res) => {
 ```
 
 ## Complete Settings / Configuration
-See [settings interface](src/app/settings.ts).
+See complete list of settings in the [AnalyticsSettings interface](src/app/settings.ts).
+```ts
+new Analytics({
+    writeKey: '<MY_WRITE_KEY>',
+    host: 'https://api.segment.io',
+    path: '/v1/batch',
+    flushInterval: 10000,
+    plugins: [plugin1, plugin2],
+    // ... and more!
+  })
+
+```
 
 ## Graceful Shutdown
 ### Avoid losing events on exit!

--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -16,6 +16,7 @@ describe('Analytics Node', () => {
     fetcher.mockReturnValue(createSuccess())
 
     ajs = new Analytics({
+      flushInterval: 500,
       writeKey: 'abc123',
     })
 

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -91,7 +91,7 @@ export class Analytics
         path: settings.path,
         maxRetries: settings.maxRetries ?? 3,
         maxEventsInBatch: settings.maxEventsInBatch ?? 15,
-        flushInterval: settings.flushInterval ?? 1000,
+        flushInterval: settings.flushInterval ?? 10000,
       })
     ).then(() => undefined)
 

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -91,7 +91,7 @@ export class Analytics
         path: settings.path,
         maxRetries: settings.maxRetries ?? 3,
         maxEventsInBatch: settings.maxEventsInBatch ?? 15,
-        maxWaitTimeInMs: settings.maxWaitTimeInMs ?? 1000,
+        flushInterval: settings.flushInterval ?? 1000,
       })
     ).then(() => undefined)
 

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -28,7 +28,7 @@ export interface AnalyticsSettings {
   /**
    * The number of milliseconds to wait before flushing the queue automatically. Default: 1000
    */
-  maxWaitTimeInMs?: number
+  flushInterval?: number
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -26,7 +26,7 @@ export interface AnalyticsSettings {
    */
   maxEventsInBatch?: number
   /**
-   * The number of milliseconds to wait before flushing the queue automatically. Default: 1000
+   * The number of milliseconds to wait before flushing the queue automatically. Default: 10000
    */
   flushInterval?: number
 }

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -70,7 +70,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -99,7 +99,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -137,7 +137,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -169,7 +169,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -208,7 +208,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -246,7 +246,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -286,7 +286,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -320,7 +320,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -350,7 +350,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 2,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -368,7 +368,7 @@ describe('SegmentNodePlugin', () => {
       expect(fetcher).toHaveBeenCalledTimes(1)
       validateFetcherInputs(context, context)
 
-      // 2nd batch is not full, so need to wait for the maxWaitTimeInMs to be reached before sending.
+      // 2nd batch is not full, so need to wait for the flushInterval to be reached before sending.
       jest.advanceTimersByTime(500)
       expect(fetcher).toHaveBeenCalledTimes(1)
       jest.advanceTimersByTime(500)
@@ -387,7 +387,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 20,
-        maxWaitTimeInMs: 100,
+        flushInterval: 100,
         writeKey: '',
       })
 
@@ -426,7 +426,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -462,7 +462,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -493,7 +493,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 2,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 
@@ -523,7 +523,7 @@ describe('SegmentNodePlugin', () => {
       const segmentPlugin = configureNodePlugin({
         maxRetries: 2,
         maxEventsInBatch: 1,
-        maxWaitTimeInMs: 1000,
+        flushInterval: 1000,
         writeKey: '',
       })
 

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -18,7 +18,7 @@ interface PendingItem {
 export interface PublisherProps {
   host?: string
   path?: string
-  maxWaitTimeInMs: number
+  flushInterval: number
   maxEventsInBatch: number
   maxRetries: number
   writeKey: string
@@ -31,7 +31,7 @@ export class Publisher {
   private pendingFlushTimeout?: ReturnType<typeof setTimeout>
   private batch?: ContextBatch
 
-  private _maxWaitTimeInMs: number
+  private _flushInterval: number
   private _maxEventsInBatch: number
   private _maxRetries: number
   private _auth: string
@@ -42,12 +42,12 @@ export class Publisher {
     path,
     maxRetries,
     maxEventsInBatch,
-    maxWaitTimeInMs,
+    flushInterval,
     writeKey,
   }: PublisherProps) {
     this._maxRetries = maxRetries
     this._maxEventsInBatch = Math.max(maxEventsInBatch, 1)
-    this._maxWaitTimeInMs = maxWaitTimeInMs
+    this._flushInterval = flushInterval
     this._auth = Buffer.from(`${writeKey}:`).toString('base64')
     this._url = tryCreateFormattedUrl(
       host ?? 'https://api.segment.io',
@@ -67,7 +67,7 @@ export class Publisher {
       if (batch.length) {
         this.send(batch).catch(noop)
       }
-    }, this._maxWaitTimeInMs)
+    }, this._flushInterval)
     return batch
   }
 


### PR DESCRIPTION
- renames `maxWaitTimeInMs` -> `flushInterval` (easy migration from old SDK + in googling, idiomatic around queue flushing)
- change `flushInterval` default from 1 sec to old SDK default of 10 seconds (that was the old default -- 5 secs might be better?)

