### PR TITLE
Allow use of integrations directly from NPM

### DIFF
--- a/.changeset/khaki-ducks-lick.md
+++ b/.changeset/khaki-ducks-lick.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Allow use of integrations directly from NPM

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
+    "@segment/analytics.js-integration-amplitude": "^3.3.3",
     "@segment/inspector-webext": "^2.0.3",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@types/flat": "^5.0.1",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "27.2 KB"
+      "limit": "27.3 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -19,7 +19,7 @@ import { PriorityQueue } from '../../lib/priority-queue'
 import { getCDN, setGlobalCDNUrl } from '../../lib/parse-cdn'
 import { clearAjsBrowserStorage } from '../../test-helpers/browser-storage'
 import { ActionDestination } from '@/plugins/remote-loader'
-import { LegacyIntegrationBuilder } from '../../plugins/ajs-destination/types'
+import { ClassicIntegrationBuilder } from '../../plugins/ajs-destination/types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let fetchCalls: Array<any>[] = []
@@ -1049,7 +1049,9 @@ describe('.Integrations', () => {
     const [analytics] = await AnalyticsBrowser.load(
       {
         writeKey,
-        classicIntegrations: [amplitude as unknown as LegacyIntegrationBuilder],
+        classicIntegrations: [
+          amplitude as unknown as ClassicIntegrationBuilder,
+        ],
       },
       {
         integrations: {
@@ -1077,7 +1079,7 @@ describe('.Integrations', () => {
 
     const [analytics] = await AnalyticsBrowser.load({
       writeKey,
-      classicIntegrations: [amplitude as unknown as LegacyIntegrationBuilder],
+      classicIntegrations: [amplitude as unknown as ClassicIntegrationBuilder],
     })
 
     await analytics.ready()

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -19,6 +19,7 @@ import { PriorityQueue } from '../../lib/priority-queue'
 import { getCDN, setGlobalCDNUrl } from '../../lib/parse-cdn'
 import { clearAjsBrowserStorage } from '../../test-helpers/browser-storage'
 import { ActionDestination } from '@/plugins/remote-loader'
+import { LegacyIntegrationBuilder } from '../../plugins/ajs-destination/types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let fetchCalls: Array<any>[] = []
@@ -975,6 +976,11 @@ describe('.Integrations', () => {
     windowSpy.mockImplementation(
       () => jsd.window as unknown as Window & typeof globalThis
     )
+
+    const documentSpy = jest.spyOn(global, 'document', 'get')
+    documentSpy.mockImplementation(
+      () => jsd.window.document as unknown as Document
+    )
   })
 
   it('lists all legacy destinations', async () => {
@@ -1031,6 +1037,56 @@ describe('.Integrations', () => {
         "Google-Analytics": [Function],
       }
     `)
+  })
+
+  it('uses directly provided classic integrations without fetching them from cdn', async () => {
+    const amplitude = // @ts-ignore
+      (await import('@segment/analytics.js-integration-amplitude')).default
+
+    const intializeSpy = jest.spyOn(amplitude.prototype, 'initialize')
+    const trackSpy = jest.spyOn(amplitude.prototype, 'track')
+
+    const [analytics] = await AnalyticsBrowser.load(
+      {
+        writeKey,
+        classicIntegrations: [amplitude as unknown as LegacyIntegrationBuilder],
+      },
+      {
+        integrations: {
+          Amplitude: {
+            apiKey: 'abc',
+          },
+        },
+      }
+    )
+
+    await analytics.ready()
+    expect(intializeSpy).toHaveBeenCalledTimes(1)
+
+    await analytics.track('test event')
+
+    expect(trackSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores directly provided classic integrations if settings for them are unavailable', async () => {
+    const amplitude = // @ts-ignore
+      (await import('@segment/analytics.js-integration-amplitude')).default
+
+    const intializeSpy = jest.spyOn(amplitude.prototype, 'initialize')
+    const trackSpy = jest.spyOn(amplitude.prototype, 'track')
+
+    const [analytics] = await AnalyticsBrowser.load({
+      writeKey,
+      classicIntegrations: [amplitude as unknown as LegacyIntegrationBuilder],
+    })
+
+    await analytics.ready()
+
+    expect(intializeSpy).not.toHaveBeenCalled()
+
+    await analytics.track('test event')
+
+    expect(trackSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -154,7 +154,7 @@ async function registerPlugins(
   opts: InitOptions,
   options: InitOptions,
   plugins: Plugin[],
-  legacyIntegrationSources?: LegacyIntegrationSource[]
+  legacyIntegrationSources: LegacyIntegrationSource[]
 ): Promise<Context> {
   const tsubMiddleware = hasTsubMiddleware(legacySettings)
     ? await import(
@@ -167,7 +167,7 @@ async function registerPlugins(
     : undefined
 
   const legacyDestinations =
-    hasLegacyDestinations(legacySettings) || legacyIntegrationSources
+    hasLegacyDestinations(legacySettings) || legacyIntegrationSources.length > 0
       ? await import(
           /* webpackChunkName: "ajs-destination" */ '../plugins/ajs-destination'
         ).then((mod) => {
@@ -278,26 +278,19 @@ async function loadAnalytics(
   inspectorHost.attach?.(analytics as any)
 
   const plugins = settings.plugins ?? []
+  const classicIntegrations = settings.classicIntegrations ?? []
   Context.initMetrics(legacySettings.metrics)
 
   // needs to be flushed before plugins are registered
   flushPreBuffer(analytics, preInitBuffer)
-
-  const legacyIntegrationSources = plugins.filter(
-    (pluginOrIntegration) => typeof pluginOrIntegration === 'function'
-  ) as LegacyIntegrationSource[]
-
-  const simplePlugins = plugins.filter(
-    (pluginOrIntegration) => typeof pluginOrIntegration !== 'function'
-  ) as Plugin[]
 
   const ctx = await registerPlugins(
     legacySettings,
     analytics,
     opts,
     options,
-    simplePlugins,
-    legacyIntegrationSources
+    plugins,
+    classicIntegrations
   )
 
   const search = window.location.search ?? ''

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../core/buffer'
 import { popSnippetWindowBuffer } from '../core/buffer/snippet'
 import { inspectorHost } from '../core/inspector'
-import { LegacyIntegrationSource } from '../plugins/ajs-destination/types'
+import { ClassicIntegrationSource } from '../plugins/ajs-destination/types'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -154,7 +154,7 @@ async function registerPlugins(
   opts: InitOptions,
   options: InitOptions,
   plugins: Plugin[],
-  legacyIntegrationSources: LegacyIntegrationSource[]
+  legacyIntegrationSources: ClassicIntegrationSource[]
 ): Promise<Context> {
   const tsubMiddleware = hasTsubMiddleware(legacySettings)
     ? await import(

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -28,7 +28,10 @@ import { CookieOptions, Group, ID, User, UserOptions } from '../user'
 import autoBind from '../../lib/bind-all'
 import { PersistedPriorityQueue } from '../../lib/priority-queue/persisted'
 import type { LegacyDestination } from '../../plugins/ajs-destination'
-import type { LegacyIntegration } from '../../plugins/ajs-destination/types'
+import type {
+  LegacyIntegration,
+  LegacyIntegrationSource,
+} from '../../plugins/ajs-destination/types'
 import type {
   DestinationMiddlewareFunction,
   MiddlewareFunction,
@@ -57,7 +60,7 @@ function createDefaultQueue(retryQueue = false, disablePersistance = false) {
 export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
-  plugins?: Plugin[]
+  plugins?: (Plugin | LegacyIntegrationSource)[]
 }
 
 export interface InitOptions {

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -60,7 +60,8 @@ function createDefaultQueue(retryQueue = false, disablePersistance = false) {
 export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
-  plugins?: (Plugin | LegacyIntegrationSource)[]
+  plugins?: Plugin[]
+  classicIntegrations?: LegacyIntegrationSource[]
 }
 
 export interface InitOptions {

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -30,7 +30,7 @@ import { PersistedPriorityQueue } from '../../lib/priority-queue/persisted'
 import type { LegacyDestination } from '../../plugins/ajs-destination'
 import type {
   LegacyIntegration,
-  LegacyIntegrationSource,
+  ClassicIntegrationSource,
 } from '../../plugins/ajs-destination/types'
 import type {
   DestinationMiddlewareFunction,
@@ -61,7 +61,7 @@ export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
   plugins?: Plugin[]
-  classicIntegrations?: LegacyIntegrationSource[]
+  classicIntegrations?: ClassicIntegrationSource[]
 }
 
 export interface InitOptions {

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -24,7 +24,7 @@ import {
   resolveVersion,
   unloadIntegration,
 } from './loader'
-import { LegacyIntegration, LegacyIntegrationSource } from './types'
+import { LegacyIntegration, ClassicIntegrationSource } from './types'
 import { isPlainObject } from '@segment/analytics-core'
 import {
   isDisabledIntegration as shouldSkipIntegration,
@@ -78,7 +78,7 @@ export class LegacyDestination implements Plugin {
   private onInitialize: Promise<unknown> | undefined
   private disableAutoISOConversion: boolean
 
-  integrationSource?: LegacyIntegrationSource
+  integrationSource?: ClassicIntegrationSource
   integration: LegacyIntegration | undefined
 
   buffer: PriorityQueue<Context>
@@ -89,7 +89,7 @@ export class LegacyDestination implements Plugin {
     version: string,
     settings: JSONObject = {},
     options: InitOptions,
-    integrationSource?: LegacyIntegrationSource
+    integrationSource?: ClassicIntegrationSource
   ) {
     this.name = name
     this.version = version
@@ -325,7 +325,7 @@ export function ajsDestinations(
   globalIntegrations: Integrations = {},
   options: InitOptions = {},
   routingMiddleware?: DestinationMiddlewareFunction,
-  legacyIntegrationSources?: LegacyIntegrationSource[]
+  legacyIntegrationSources?: ClassicIntegrationSource[]
 ): LegacyDestination[] {
   if (isServer()) {
     return []
@@ -350,16 +350,14 @@ export function ajsDestinations(
       ...acc,
       [resolveIntegrationNameFromSource(integrationSource)]: integrationSource,
     }),
-    {} as Record<string, LegacyIntegrationSource>
+    {} as Record<string, ClassicIntegrationSource>
   )
 
   const installableIntegrations = new Set([
     // Remotely configured installable integrations
-    ...Object.entries(remoteIntegrationsConfig)
-      .filter(([name, integrationSettings]) =>
-        isInstallableIntegration(name, integrationSettings)
-      )
-      .map(([name]) => name),
+    ...Object.keys(remoteIntegrationsConfig).filter((name) =>
+      isInstallableIntegration(name, remoteIntegrationsConfig[name])
+    ),
 
     // Directly provided integration sources are only installable if settings for them are available
     ...Object.keys(adhocIntegrationSources || {}).filter(

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -1,7 +1,7 @@
 import { Integrations, JSONObject } from '@/core/events'
 import { Alias, Facade, Group, Identify, Page, Track } from '@segment/facade'
 import { Analytics, InitOptions } from '../../core/analytics'
-import { LegacyIntegrationConfiguration, LegacySettings } from '../../browser'
+import { LegacySettings } from '../../browser'
 import { isOffline, isOnline } from '../../core/connection'
 import { Context, ContextCancelation } from '../../core/context'
 import { isServer } from '../../core/environment'

--- a/packages/browser/src/plugins/ajs-destination/loader.ts
+++ b/packages/browser/src/plugins/ajs-destination/loader.ts
@@ -18,6 +18,16 @@ function obfuscatePathName(pathName: string, obfuscate = false): string | void {
   return obfuscate ? btoa(pathName).replace(/=/g, '') : undefined
 }
 
+export function resolveIntegrationNameFromSource(
+  integrationSource: LegacyIntegrationSource
+) {
+  return (
+    'Integration' in integrationSource
+      ? integrationSource.Integration
+      : integrationSource
+  ).prototype.name
+}
+
 function recordLoadMetrics(fullPath: string, ctx: Context, name: string): void {
   try {
     const [metric] =
@@ -113,8 +123,8 @@ export function resolveVersion(
   settings: LegacyIntegrationConfiguration
 ): string {
   return (
-    settings.versionSettings?.override ??
-    settings.versionSettings?.version ??
+    settings?.versionSettings?.override ??
+    settings?.versionSettings?.version ??
     'latest'
   )
 }

--- a/packages/browser/src/plugins/ajs-destination/loader.ts
+++ b/packages/browser/src/plugins/ajs-destination/loader.ts
@@ -4,7 +4,11 @@ import { getNextIntegrationsURL } from '../../lib/parse-cdn'
 import { Context } from '../../core/context'
 import { User } from '../../core/user'
 import { loadScript, unloadScript } from '../../lib/load-script'
-import { LegacyIntegration } from './types'
+import {
+  LegacyIntegration,
+  LegacyIntegrationBuilder,
+  LegacyIntegrationSource,
+} from './types'
 
 function normalizeName(name: string): string {
   return name.toLowerCase().replace('.', '').replace(/\s+/g, '-')
@@ -29,14 +33,37 @@ function recordLoadMetrics(fullPath: string, ctx: Context, name: string): void {
   }
 }
 
+export function buildIntegration(
+  integrationSource: LegacyIntegrationSource,
+  integrationSettings: { [key: string]: any },
+  analyticsInstance: Analytics
+): LegacyIntegration {
+  let integrationCtr: LegacyIntegrationBuilder
+  // GA and Appcues use a different interface to instantiating integrations
+  if ('Integration' in integrationSource) {
+    const analyticsStub = {
+      user: (): User => analyticsInstance.user(),
+      addIntegration: (): void => {},
+    }
+
+    integrationSource(analyticsStub)
+    integrationCtr = integrationSource.Integration
+  } else {
+    integrationCtr = integrationSource
+  }
+
+  const integration = new integrationCtr(integrationSettings)
+  integration.analytics = analyticsInstance
+
+  return integration
+}
+
 export async function loadIntegration(
   ctx: Context,
-  analyticsInstance: Analytics,
   name: string,
   version: string,
-  settings?: { [key: string]: any },
   obfuscate?: boolean
-): Promise<LegacyIntegration> {
+): Promise<LegacyIntegrationSource> {
   const pathName = normalizeName(name)
   const obfuscatedPathName = obfuscatePathName(pathName, obfuscate)
   const path = getNextIntegrationsURL()
@@ -60,25 +87,10 @@ export async function loadIntegration(
   // @ts-ignore
   window[`${pathName}Loader`]()
 
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let integrationBuilder = window[`${pathName}Integration`] as any
-
-  // GA and Appcues use a different interface to instantiating integrations
-  if (integrationBuilder.Integration) {
-    const analyticsStub = {
-      user: (): User => analyticsInstance.user(),
-      addIntegration: (): void => {},
-    }
-
-    integrationBuilder(analyticsStub)
-    integrationBuilder = integrationBuilder.Integration
-  }
-
-  const integration = new integrationBuilder(settings) as LegacyIntegration
-  integration.analytics = analyticsInstance
-
-  return integration
+  return window[
+    // @ts-ignore
+    `${pathName}Integration`
+  ] as LegacyIntegrationSource
 }
 
 export async function unloadIntegration(

--- a/packages/browser/src/plugins/ajs-destination/loader.ts
+++ b/packages/browser/src/plugins/ajs-destination/loader.ts
@@ -6,8 +6,8 @@ import { User } from '../../core/user'
 import { loadScript, unloadScript } from '../../lib/load-script'
 import {
   LegacyIntegration,
-  LegacyIntegrationBuilder,
-  LegacyIntegrationSource,
+  ClassicIntegrationBuilder,
+  ClassicIntegrationSource,
 } from './types'
 
 function normalizeName(name: string): string {
@@ -19,7 +19,7 @@ function obfuscatePathName(pathName: string, obfuscate = false): string | void {
 }
 
 export function resolveIntegrationNameFromSource(
-  integrationSource: LegacyIntegrationSource
+  integrationSource: ClassicIntegrationSource
 ) {
   return (
     'Integration' in integrationSource
@@ -44,11 +44,11 @@ function recordLoadMetrics(fullPath: string, ctx: Context, name: string): void {
 }
 
 export function buildIntegration(
-  integrationSource: LegacyIntegrationSource,
+  integrationSource: ClassicIntegrationSource,
   integrationSettings: { [key: string]: any },
   analyticsInstance: Analytics
 ): LegacyIntegration {
-  let integrationCtr: LegacyIntegrationBuilder
+  let integrationCtr: ClassicIntegrationBuilder
   // GA and Appcues use a different interface to instantiating integrations
   if ('Integration' in integrationSource) {
     const analyticsStub = {
@@ -73,7 +73,7 @@ export async function loadIntegration(
   name: string,
   version: string,
   obfuscate?: boolean
-): Promise<LegacyIntegrationSource> {
+): Promise<ClassicIntegrationSource> {
   const pathName = normalizeName(name)
   const obfuscatedPathName = obfuscatePathName(pathName, obfuscate)
   const path = getNextIntegrationsURL()
@@ -100,7 +100,7 @@ export async function loadIntegration(
   return window[
     // @ts-ignore
     `${pathName}Integration`
-  ] as LegacyIntegrationSource
+  ] as ClassicIntegrationSource
 }
 
 export async function unloadIntegration(
@@ -120,7 +120,7 @@ export async function unloadIntegration(
 }
 
 export function resolveVersion(
-  settings: LegacyIntegrationConfiguration
+  settings?: LegacyIntegrationConfiguration
 ): string {
   return (
     settings?.versionSettings?.override ??

--- a/packages/browser/src/plugins/ajs-destination/types.ts
+++ b/packages/browser/src/plugins/ajs-destination/types.ts
@@ -29,16 +29,16 @@ export interface LegacyIntegration extends Emitter {
   options?: object
 }
 
-export interface LegacyIntegrationBuilder {
+export interface ClassicIntegrationBuilder {
   new (options: object): LegacyIntegration
   prototype: LegacyIntegration
 }
 
-export interface LegacyIntegrationGenerator {
+export interface ClassicIntegrationGenerator {
   (analytics: { user: () => User; addIntegration: () => void }): void
-  Integration: LegacyIntegrationBuilder
+  Integration: ClassicIntegrationBuilder
 }
 
-export type LegacyIntegrationSource =
-  | LegacyIntegrationGenerator
-  | LegacyIntegrationBuilder
+export type ClassicIntegrationSource =
+  | ClassicIntegrationGenerator
+  | ClassicIntegrationBuilder

--- a/packages/browser/src/plugins/ajs-destination/types.ts
+++ b/packages/browser/src/plugins/ajs-destination/types.ts
@@ -1,8 +1,10 @@
 import { Group, Identify, Track, Page, Alias } from '@segment/facade'
 import { Analytics } from '../../core/analytics'
 import { Emitter } from '@segment/analytics-core'
+import { User } from '../../core/user'
 
 export interface LegacyIntegration extends Emitter {
+  name: string
   analytics?: Analytics
   initialize: () => void
   loaded: () => boolean
@@ -26,3 +28,17 @@ export interface LegacyIntegration extends Emitter {
   _assumesPageview?: boolean
   options?: object
 }
+
+export interface LegacyIntegrationBuilder {
+  new (options: object): LegacyIntegration
+  prototype: LegacyIntegration
+}
+
+export interface LegacyIntegrationGenerator {
+  (analytics: { user: () => User; addIntegration: () => void }): void
+  Integration: LegacyIntegrationBuilder
+}
+
+export type LegacyIntegrationSource =
+  | LegacyIntegrationGenerator
+  | LegacyIntegrationBuilder

--- a/packages/browser/src/plugins/ajs-destination/utils.ts
+++ b/packages/browser/src/plugins/ajs-destination/utils.ts
@@ -15,7 +15,7 @@ export const isInstallableIntegration = (
   // checking for iterable is a quick fix we need in place to prevent
   // errors showing Iterable as a failed destiantion. Ideally, we should
   // fix the Iterable metadata instead, but that's a longer process.
-  return (deviceMode || name === 'Segment.io') && name !== 'Iterable'
+  return !name.startsWith('Segment') && name !== 'Iterable' && deviceMode
 }
 
 export const isDisabledIntegration = (
@@ -27,8 +27,6 @@ export const isDisabledIntegration = (
     globalIntegrations[integrationName] === undefined
 
   return (
-    integrationName.startsWith('Segment') ||
-    globalIntegrations[integrationName] === false ||
-    allDisableAndNotDefined
+    globalIntegrations[integrationName] === false || allDisableAndNotDefined
   )
 }

--- a/packages/browser/src/plugins/ajs-destination/utils.ts
+++ b/packages/browser/src/plugins/ajs-destination/utils.ts
@@ -1,0 +1,34 @@
+import { Integrations } from '@segment/analytics-core'
+import { LegacyIntegrationConfiguration } from '../..'
+
+export const isInstallableIntegration = (
+  name: string,
+  integrationSettings: LegacyIntegrationConfiguration
+) => {
+  const { type, bundlingStatus, versionSettings } = integrationSettings
+  // We use `!== 'unbundled'` (versus `=== 'bundled'`) to be inclusive of
+  // destinations without a defined value for `bundlingStatus`
+  const deviceMode =
+    bundlingStatus !== 'unbundled' &&
+    (type === 'browser' || versionSettings?.componentTypes?.includes('browser'))
+
+  // checking for iterable is a quick fix we need in place to prevent
+  // errors showing Iterable as a failed destiantion. Ideally, we should
+  // fix the Iterable metadata instead, but that's a longer process.
+  return (deviceMode || name === 'Segment.io') && name !== 'Iterable'
+}
+
+export const isDisabledIntegration = (
+  integrationName: string,
+  globalIntegrations: Integrations
+) => {
+  const allDisableAndNotDefined =
+    globalIntegrations.All === false &&
+    globalIntegrations[integrationName] === undefined
+
+  return (
+    integrationName.startsWith('Segment') ||
+    globalIntegrations[integrationName] === false ||
+    allDisableAndNotDefined
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,98 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ndhoule/clone@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@ndhoule/clone@npm:1.0.0"
+  dependencies:
+    component-type: ^1.2.1
+  checksum: 06f798ecb86c8e6bf466744332f3a5c2da4aaa02d4290858955eaf9d1ddd7abb84d60682fd436309f008b91b91536e6239e12745ff8eb9ebb15205664a6f748c
+  languageName: node
+  linkType: hard
+
+"@ndhoule/defaults@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/defaults@npm:2.0.1"
+  dependencies:
+    "@ndhoule/drop": ^2.0.0
+    "@ndhoule/rest": ^2.0.0
+  checksum: 7cb2b2de75d2cfc12d38a40450ea9943cea9f8bd8bbeb07d1bd304d2174ada5c019974497d97443d07912dfec4929942a092c4ae725a955cbec66ed77a82ac1e
+  languageName: node
+  linkType: hard
+
+"@ndhoule/drop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@ndhoule/drop@npm:2.0.0"
+  checksum: 92994ba0d243b6a5d0f57c2a5337127e626b6d899bf4d1192f9c4dda411e18984a810dde7f155d38bf121c722b214b425c18f60e820f27c926684185bf7eeb28
+  languageName: node
+  linkType: hard
+
+"@ndhoule/each@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/each@npm:2.0.1"
+  dependencies:
+    "@ndhoule/keys": ^2.0.0
+  checksum: f2aa44fb4248b2939b038c6cdbfb442f29cebb181f6058081b9af402c8c6e1e82a26fd9d89c2a2fc72be98b934902ecdf260bcfff171fa48aea4261a26a0e0c7
+  languageName: node
+  linkType: hard
+
+"@ndhoule/every@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/every@npm:2.0.1"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+  checksum: 0cda96255746b453cb5ab99aa64ec48bf7311c6ec8968800520faf80b96166edca98aaad4fb55c7268b8f05f24361c53feca4a4f50ac6c1f3302b5d956ac3e22
+  languageName: node
+  linkType: hard
+
+"@ndhoule/extend@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@ndhoule/extend@npm:2.0.0"
+  checksum: 0243af53a10926d700b4c2e9f279699164c5618023c2014ef31cb22c57451fb8de6fb65e58160e4be2c1bec3e3016c099f00ef0a23a6e669733fc449426b529d
+  languageName: node
+  linkType: hard
+
+"@ndhoule/foldl@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/foldl@npm:2.0.1"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+  checksum: 8cf9b26b8cbb8d17acbd254f4f2d20b97fb3354384610351b31a527efa362ec8f7502ccf04a3576a9b8520f04dabaea9d43e7311dca634889d21ef9beef14ae3
+  languageName: node
+  linkType: hard
+
+"@ndhoule/includes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/includes@npm:2.0.1"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+  checksum: 1516fd2a1b7b9245cdd012aed21743e03a3e17d3a57d30962d648cc6b236ba6b1072d413b9d3426b6abb63f8f137bb5914b31b13225c7f06db4d2a4e9cfe66b4
+  languageName: node
+  linkType: hard
+
+"@ndhoule/keys@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@ndhoule/keys@npm:2.0.0"
+  checksum: f77be060eb706a072e9c41d8939dcbd7bf27ead2f113a75fd9718b3c6a623540f324f7200e474418feb6277f1b99952b67667129bd66a39fdf93531980066488
+  languageName: node
+  linkType: hard
+
+"@ndhoule/map@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@ndhoule/map@npm:2.0.1"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+  checksum: b3bffd71babe9b9cdb882bd89d7785bb36d6063d44757aa7ed726a15a5d3c2ecb5198dbcda43a63d4585b4dfed96e2bd75b7b54bc1b5e44c58945118a2304d5c
+  languageName: node
+  linkType: hard
+
+"@ndhoule/rest@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@ndhoule/rest@npm:2.0.0"
+  checksum: cca16090ba631f65402ce1e1b3829f1723e3f7ca864376813edad2955e961ac811a176557c9ed82d8056e55f637f9ce30c4c5e029b5635c86e98ee881a3600b1
+  languageName: node
+  linkType: hard
+
 "@next/bundle-analyzer@npm:^12.1.5":
   version: 12.1.6
   resolution: "@next/bundle-analyzer@npm:12.1.6"
@@ -1840,6 +1932,7 @@ __metadata:
     "@internal/config": 0.0.0
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-core": 1.1.3
+    "@segment/analytics.js-integration-amplitude": ^3.3.3
     "@segment/analytics.js-video-plugins": ^0.2.1
     "@segment/facade": ^3.4.9
     "@segment/inspector-webext": ^2.0.3
@@ -1914,6 +2007,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@segment/analytics.js-integration-amplitude@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "@segment/analytics.js-integration-amplitude@npm:3.3.3"
+  dependencies:
+    "@ndhoule/each": ^2.0.1
+    "@segment/analytics.js-integration": ^3.3.0
+    "@segment/top-domain": ^3.0.0
+    component-bind: ^1.0.0
+    do-when: ^1.0.0
+    is: ^3.2.1
+    segmentio-facade: ^3.2.7
+  checksum: 9acaf611c9b431f54db745c3a740008e43b7c032ab8722033136d8c5030ea9220ebb14ad8e04df5135fd10fea66c082e3210ec25f5b81fe072e01188270d0c1c
+  languageName: node
+  linkType: hard
+
+"@segment/analytics.js-integration@npm:^3.3.0":
+  version: 3.3.3
+  resolution: "@segment/analytics.js-integration@npm:3.3.3"
+  dependencies:
+    "@ndhoule/clone": ^1.0.0
+    "@ndhoule/defaults": ^2.0.1
+    "@ndhoule/each": ^2.0.1
+    "@ndhoule/every": ^2.0.1
+    "@ndhoule/extend": ^2.0.0
+    "@ndhoule/foldl": ^2.0.1
+    "@ndhoule/includes": ^2.0.1
+    "@segment/fmt": ^1.0.0
+    "@segment/load-script": ^1.0.1
+    analytics-events: ^2.0.2
+    component-bind: ^1.0.0
+    component-emitter: ^1.2.0
+    debug: ^2.2.0
+    domify: ^1.4.1
+    extend: ^3.0.2
+    is: ^3.1.0
+    load-iframe: ^1.0.0
+    next-tick: ^0.2.2
+    slug-component: ^1.1.0
+    to-no-case: ^0.1.3
+  checksum: 60099edb161c7aaf93efdae61596a7d2a442ca050dba9b49375365c3ca3e8a631c5e7061778c9d0b9dfa8cb2c6af493611c3a2c4910a7fdc378bc7fde9d1ce0c
+  languageName: node
+  linkType: hard
+
 "@segment/analytics.js-video-plugins@npm:^0.2.1":
   version: 0.2.1
   resolution: "@segment/analytics.js-video-plugins@npm:0.2.1"
@@ -1932,6 +2068,13 @@ __metadata:
     new-date: ^1.0.3
     obj-case: 0.2.1
   checksum: c6e139fd16464a1adb204bc13b958c95c96e5fa82c7281a4e71be4589b1a50a1d072f41d2bd8533c5fe1891e5a124af8c856ce26c493a0c5f548dff80c5ce572
+  languageName: node
+  linkType: hard
+
+"@segment/fmt@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@segment/fmt@npm:1.0.0"
+  checksum: 1f12ac0559b1df48613f5fb59c729fb003c9ee14ed3f0012978615d417419eb33ece8e9624a588b7e4f0f7504b40e220377a873b59cce3515032d2be2b7484f5
   languageName: node
   linkType: hard
 
@@ -1978,7 +2121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@segment/isodate-traverse@npm:^1.1.1":
+"@segment/isodate-traverse@npm:^1.0.0, @segment/isodate-traverse@npm:^1.1.1":
   version: 1.1.1
   resolution: "@segment/isodate-traverse@npm:1.1.1"
   dependencies:
@@ -1994,6 +2137,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@segment/load-script@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@segment/load-script@npm:1.0.1"
+  dependencies:
+    component-type: ^1.2.0
+    next-tick: ^0.2.2
+    script-onload: ^1.0.2
+  checksum: 343ce5289afda2455871b009e2a20a81622310fa0c05ff80f8a647f46b1a2c13f30a723a15211bed014da07cf61897d6edc93b362ca6b91a1f3010acb19a6d6b
+  languageName: node
+  linkType: hard
+
 "@segment/loosely-validate-event@npm:^2.0.0":
   version: 2.0.0
   resolution: "@segment/loosely-validate-event@npm:2.0.0"
@@ -2001,6 +2155,16 @@ __metadata:
     component-type: ^1.2.1
     join-component: ^1.1.0
   checksum: 8c4aacc903fb717619b69ca7eecf8d4a7b928661b0e835c9cd98f1b858a85ce62c348369ad9a52cb2df8df02578c0525a73fce4c69a42ac414d9554cc6be7117
+  languageName: node
+  linkType: hard
+
+"@segment/top-domain@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@segment/top-domain@npm:3.0.1"
+  dependencies:
+    component-cookie: ^1.1.5
+    component-url: ^0.2.1
+  checksum: ca8ebf462d99b80d6da4954cd064abd3c19348c2bdfc149727776d6b68f911dcc15cd5251be0e3c03c1e93802006df84026dbb69ac52a414f52d2bf392708e2c
   languageName: node
   linkType: hard
 
@@ -4424,6 +4588,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"analytics-events@npm:^2.0.2":
+  version: 2.2.5
+  resolution: "analytics-events@npm:2.2.5"
+  dependencies:
+    "@ndhoule/foldl": ^2.0.1
+    "@ndhoule/map": ^2.0.1
+  checksum: 7c948ab9d905afcbc093402e4b135a7d5e2617a631d2eab89b978078e705a243d7ec853c1e390774a322e912d6da3c4ef3b4d04c46513d938db4f631216c134f
+  languageName: node
+  linkType: hard
+
 "analytics-monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "analytics-monorepo@workspace:."
@@ -5624,10 +5798,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"component-type@npm:^1.2.1":
+"component-bind@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "component-bind@npm:1.0.0"
+  checksum: 746c5810b9f8735643840ad04072e1ab817444d44dc1aadc813f1f1a17c47c27616584caa0db93db7e687bfe73b65073d8246c785bcdac80f8f3627d3bb26883
+  languageName: node
+  linkType: hard
+
+"component-cookie@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "component-cookie@npm:1.1.5"
+  dependencies:
+    debug: ^2.6.9
+  checksum: 2374e079eae8b2ae5ac3a76f6e2718ba25947a264c8e0b30b33996588e25b53f935fb8e289b79e6aa2fd8a4c41c65a882cf3bbda2597724d2b9f8d09ac3d206c
+  languageName: node
+  linkType: hard
+
+"component-emitter@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "component-emitter@npm:1.3.0"
+  checksum: b3c46de38ffd35c57d1c02488355be9f218e582aec72d72d1b8bbec95a3ac1b38c96cd6e03ff015577e68f550fbb361a3bfdbd9bb248be9390b7b3745691be6b
+  languageName: node
+  linkType: hard
+
+"component-type@npm:^1.2.0, component-type@npm:^1.2.1":
   version: 1.2.1
   resolution: "component-type@npm:1.2.1"
   checksum: 41a81f87425088c072dc99b7bd06d8c81057047a599955572bfa7f320e1f4d0b38422b2eee922e0ac6e4132376c572673dbf5eb02717898173ec11512bc06b34
+  languageName: node
+  linkType: hard
+
+"component-url@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "component-url@npm:0.2.1"
+  checksum: 864780df117b113d04d93968b117d14cab28be704a64f838dbdef985eab803651e9e11af80efe167fe0bb45bc6989aa01e2cfc58be57a4d630d992ebad5b0152
   languageName: node
   linkType: hard
 
@@ -5948,7 +6152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.6.8, debug@npm:^2.6.9":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.6.8, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -6179,6 +6383,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"do-when@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "do-when@npm:1.0.0"
+  dependencies:
+    next-tick: ^0.2.2
+  checksum: 6084b71246215009daad6abd8c6224a95837f0ed7511875662a04b60a888793306f3283113c5a8950ce3b8932f6f292230d47aa21e557b3cc4fb1c5c9679360b
+  languageName: node
+  linkType: hard
+
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
@@ -6203,6 +6416,13 @@ __metadata:
   dependencies:
     webidl-conversions: ^7.0.0
   checksum: ddbc1268edf33a8ba02ccc596735ede80375ee0cf124b30d2f05df5b464ba78ef4f49889b6391df4a04954e63d42d5631c7fcf8b1c4f12bc531252977a5f13d5
+  languageName: node
+  linkType: hard
+
+"domify@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "domify@npm:1.4.1"
+  checksum: d1165e840093fee2790107e4de2070e89e8c6fae47a4839838248d8adcfa56ff44614de46cd7579b7b0670a37e5fe4b7228ea8f34059f329575ba74bc9a76d42
   languageName: node
   linkType: hard
 
@@ -7180,6 +7400,13 @@ __metadata:
     utils-merge: 1.0.1
     vary: ~1.1.2
   checksum: d964e9e17af331ea6fa2f84999b063bc47189dd71b4a735df83f9126d3bb2b92e830f1cb1d7c2742530eb625e2689d7a9a9c71f0c3cc4dd6015c3cd32a01abd5
+  languageName: node
+  linkType: hard
+
+"extend@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
   languageName: node
   linkType: hard
 
@@ -8284,7 +8511,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -8462,6 +8689,13 @@ __metadata:
   bin:
     is-docker: cli.js
   checksum: 3fef7ddbf0be25958e8991ad941901bf5922ab2753c46980b60b05c1bf9c9c2402d35e6dc32e4380b980ef5e1970a5d9d5e5aa2e02d77727c3b6b5e918474c56
+  languageName: node
+  linkType: hard
+
+"is-email@npm:0.1.0":
+  version: 0.1.0
+  resolution: "is-email@npm:0.1.0"
+  checksum: 789159b191debe32b9c844d29731ebf05bc4d8749be417303b2c4a43405adde4fa686de05c7e9e5e241b7b59ec4750d10aea63dab24f79370a3fc2b22785a420
   languageName: node
   linkType: hard
 
@@ -8674,6 +8908,13 @@ __metadata:
   dependencies:
     is-docker: ^2.0.0
   checksum: 20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
+  languageName: node
+  linkType: hard
+
+"is@npm:^3.0.1, is@npm:^3.1.0, is@npm:^3.2.1":
+  version: 3.3.0
+  resolution: "is@npm:3.3.0"
+  checksum: 81fad3b40c606984c2d0699207c4c48d2a0d29cc834b274d0b74c172f3eeebdb981301fe0d690ce090a96bf021a8a1f8b1325262ad9870c525e557ac4a559c56
   languageName: node
   linkType: hard
 
@@ -9715,6 +9956,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-iframe@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "load-iframe@npm:1.0.0"
+  dependencies:
+    is: ^3.0.1
+    next-tick: ^0.2.2
+    script-onload: ^1.0.2
+  checksum: 377ab63109b60f10b40b7599c6163d613066f817d631ae0e8247d2fb7d0f4c3f5d261640f33bb79dfb0c4a9d67a850dc5c4ad73fdd99d46831496ff092975a25
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:^4.0.0":
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
@@ -10438,12 +10690,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"new-date@npm:^1.0.3":
+"new-date@npm:^1.0.0, new-date@npm:^1.0.3":
   version: 1.0.3
   resolution: "new-date@npm:1.0.3"
   dependencies:
     "@segment/isodate": 1.0.3
   checksum: 5bc778542276f5d947b77654f10ad796c7502b184bd7f9b87749064a3f69a5cb5631acfceb234b433b3408cfe151de34ee484d5751d1fd87a74d6ec1e7e1ac9c
+  languageName: node
+  linkType: hard
+
+"next-tick@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "next-tick@npm:0.2.2"
+  checksum: d5e8874f5c7ed7bec23d4b56b2598a2d86b363828b0aef846dab76a496e1e8eff4fcf74ba6a95caa73a90d7ab55970d7cd28a0cad389948287b823e7e8309eb0
   languageName: node
   linkType: hard
 
@@ -10645,7 +10904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obj-case@npm:0.2.1":
+"obj-case@npm:0.2.1, obj-case@npm:0.x":
   version: 0.2.1
   resolution: "obj-case@npm:0.2.1"
   checksum: 2726b29d054027c52c6ac1a18531c3f995fcc313047847c7f7357889a56cf07bd88bef459bd4645c139fa56f9432c282806e0f1c7ab444d6cbdb662e39073e36
@@ -12161,6 +12420,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"script-onload@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "script-onload@npm:1.0.2"
+  checksum: 5f94db6687f9bd98448a38ae30b3840b4d52e7806f139fc90a816d1b692d20c5bb93f2fb8335e332cfb0def08ac3855301e97c901311dc2505c78db7266ba5fd
+  languageName: node
+  linkType: hard
+
+"segmentio-facade@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "segmentio-facade@npm:3.2.7"
+  dependencies:
+    "@ndhoule/clone": ^1.0.0
+    "@segment/isodate-traverse": ^1.0.0
+    inherits: ^2.0.1
+    is-email: 0.1.0
+    new-date: ^1.0.0
+    obj-case: 0.x
+    trim: 1.0.0
+    type-component: 0.0.1
+  checksum: ffe9548e9cc04b3228c7dd0f797823e9ce602b03560ce0d542badd2e156957257a0b41f2eae0ca0e7ce91a9a526e502a804a87077307ce2c8b91de190c48ad37
+  languageName: node
+  linkType: hard
+
 "semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
@@ -12470,6 +12752,13 @@ __metadata:
     ansi-styles: ^6.0.0
     is-fullwidth-code-point: ^4.0.0
   checksum: 7e600a2a55e333a21ef5214b987c8358fe28bfb03c2867ff2cbf919d62143d1812ac27b4297a077fdaf27a03da3678e49551c93e35f9498a3d90221908a1180e
+  languageName: node
+  linkType: hard
+
+"slug-component@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "slug-component@npm:1.1.0"
+  checksum: 36197c145930806b41e9987e8d440e23afb797eebf235391dcd0beb2262a69408b3e2ade96790a5ad190ca731b2635464736218174ce0d97736abbbd7beece17
   languageName: node
   linkType: hard
 
@@ -13179,6 +13468,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"to-no-case@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "to-no-case@npm:0.1.3"
+  checksum: 86ffa96bdef0537f6c5a90d4feb3845c89e5bf561812b7510670ac2124bbc9e906f7e0a0b227bf783ec43d0098c1d628556bf40baf9c48410428ebb871c24a7e
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
@@ -13242,6 +13538,13 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"trim@npm:1.0.0":
+  version: 1.0.0
+  resolution: "trim@npm:1.0.0"
+  checksum: 14e82b1b14f43a26aad26a175136957bae2558356f98fa1004110410d036b22cbd0c1fd0410ed69638d84d21a02d71a8059485bfb192448900c780ac4a085b8f
   languageName: node
   linkType: hard
 
@@ -13555,6 +13858,13 @@ __metadata:
   dependencies:
     prelude-ls: ~1.1.2
   checksum: dd3b1495642731bc0e1fc40abe5e977e0263005551ac83342ecb6f4f89551d106b368ec32ad3fb2da19b3bd7b2d1f64330da2ea9176d8ddbfe389fb286eb5124
+  languageName: node
+  linkType: hard
+
+"type-component@npm:0.0.1":
+  version: 0.0.1
+  resolution: "type-component@npm:0.0.1"
+  checksum: d16f84abafe6bfa3d9f921848bb9fb0f512328bbc1b616d86ecfc878b847c2c22a96501ac64f78279a34553e809c988bfcc363fbd1ff11cf2f604c281d7c30d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This patch allows customers to import classic integrations directly from NPM, and use those instead of them being loaded from CDN.

This can be useful in a case where one can't afford to have too many concurrent network requests _(due to limits imposed by browsers)_ , and would rather prefer few larger requests instead.

**API**

```ts
import { AnalyticsBrowser } from '@segment/analytics-next'
import GoogleAnalyticsIntegration from '@segment/analytics.js-integration-google-analytics'

// the following rig assumes configuration for Google Analytics will be available in the fetched settings
const analytics = AnalyticsBrowser.load({
	writeKey: '<WRITE_KEY>',
	classicIntegrations: [ GoogleAnalyticsIntegration ]
}),

// if remote settings don't include the integration configuration, it must be supplied directly like so:
const analytics = AnalyticsBrowser.load({
	writeKey: '<WRITE_KEY>',
	classicIntegrations: [ GoogleAnalyticsIntegration ]
}, {
	integrations: {
		'Google Analytics': {
			// all the necessary must be set here
		}
	}
}),
```
