### PR TITLE
Change node messageId, and update core in order to remove transient dependencies from nodejs

### DIFF
--- a/.changeset/short-balloons-worry.md
+++ b/.changeset/short-balloons-worry.md
@@ -1,0 +1,4 @@
+---
+'@segment/analytics-core': patch
+---
+Allow consumers to inject custom messageId into EventFactory, allowing us to remove node transient dependency on md5 library. Change node messageId to format "node-next-[unix epoch time]-[uuid]".

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,6 @@
   },
   "packageManager": "yarn@3.2.1",
   "dependencies": {
-    "@lukeed/uuid": "^2.0.0",
     "dset": "^3.1.2",
     "tslib": "^2.4.0"
   }

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -15,7 +15,7 @@ describe('Event Factory', () => {
     }
     factory = new EventFactory({
       user,
-      getMessageId: () => 'foo',
+      createMessageId: () => 'foo',
     })
   })
 
@@ -79,7 +79,7 @@ describe('Event Factory', () => {
 
     it('uses userId / anonymousId from the user class (if specified)', function () {
       factory = new EventFactory({
-        getMessageId: () => 'foo',
+        createMessageId: () => 'foo',
         user: {
           id: () => 'abc',
           anonymousId: () => '123',

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,5 +1,4 @@
 export * from './interfaces'
-import { v4 as uuid } from '@lukeed/uuid'
 import { dset } from 'dset'
 import { ID, User } from '../user'
 import {
@@ -9,14 +8,20 @@ import {
   CoreSegmentEvent,
   CoreOptions,
 } from './interfaces'
-import md5 from 'spark-md5'
 import { validateEvent } from '../validation/assertions'
 
+interface EventFactorySettings {
+  getMessageId: () => string
+  user?: User
+}
+
 export class EventFactory {
+  getMessageId: EventFactorySettings['getMessageId']
   user?: User
 
-  constructor(user?: User) {
-    this.user = user
+  constructor(settings: EventFactorySettings) {
+    this.user = settings.user
+    this.getMessageId = settings.getMessageId
   }
 
   track(
@@ -240,11 +245,9 @@ export class EventFactory {
       ...overrides,
     }
 
-    const messageId = 'ajs-next-' + md5.hash(JSON.stringify(body) + uuid())
-
     const evt: CoreSegmentEvent = {
       ...body,
-      messageId,
+      messageId: this.getMessageId(),
     }
 
     validateEvent(evt)

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -11,17 +11,17 @@ import {
 import { validateEvent } from '../validation/assertions'
 
 interface EventFactorySettings {
-  getMessageId: () => string
+  createMessageId: () => string
   user?: User
 }
 
 export class EventFactory {
-  getMessageId: EventFactorySettings['getMessageId']
+  createMessageId: EventFactorySettings['createMessageId']
   user?: User
 
   constructor(settings: EventFactorySettings) {
     this.user = settings.user
-    this.getMessageId = settings.getMessageId
+    this.createMessageId = settings.createMessageId
   }
 
   track(
@@ -247,7 +247,7 @@ export class EventFactory {
 
     const evt: CoreSegmentEvent = {
       ...body,
-      messageId: this.getMessageId(),
+      messageId: this.createMessageId(),
     }
 
     validateEvent(evt)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,6 +33,7 @@
     "publish-prerelease": "sh scripts/prerelease.sh"
   },
   "dependencies": {
+    "@lukeed/uuid": "^2.0.0",
     "@segment/analytics-core": "1.1.1",
     "node-fetch": "^2.6.7",
     "tslib": "^2.4.0"

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -19,6 +19,7 @@ import {
 import { AnalyticsSettings, validateSettings } from './settings'
 import { version } from '../../package.json'
 import { configureNodePlugin } from '../plugins/segmentio'
+import { createNodeEventFactory } from '../lib/create-node-event-factory'
 
 // create a derived class since we may want to add node specific things to Context later
 export class Context extends CoreContext {}
@@ -82,7 +83,8 @@ export class Analytics
   constructor(settings: AnalyticsSettings) {
     super()
     validateSettings(settings)
-    this._eventFactory = new EventFactory()
+
+    this._eventFactory = createNodeEventFactory()
     this.queue = new EventQueue(new NodePriorityQueue())
 
     const flushInterval = settings.flushInterval ?? 10000

--- a/packages/node/src/lib/__tests__/get-message-id.test.ts
+++ b/packages/node/src/lib/__tests__/get-message-id.test.ts
@@ -1,0 +1,21 @@
+import { getMessageId } from '../get-message-id'
+
+// https://gist.github.com/johnelliott/cf77003f72f889abbc3f32785fa3df8d
+const uuidv4Regex =
+  /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+
+describe(getMessageId, () => {
+  it('creates a messageId that may look like "node-next-166820896773a9-c7404832-feea-4e70-ac7f-2dc94d96acca"', () => {
+    const msg = getMessageId().split('-')
+    expect(msg.length).toBe(8)
+
+    expect(`${msg[0]}-${msg[1]}`).toBe('node-next')
+
+    const epochTimeSeg = msg[2]
+    expect(typeof parseInt(epochTimeSeg)).toBe('number')
+    expect(epochTimeSeg.length > 10).toBeTruthy()
+
+    const uuidSeg = msg.slice(3).join('-')
+    expect(uuidSeg).toEqual(expect.stringMatching(uuidv4Regex))
+  })
+})

--- a/packages/node/src/lib/__tests__/get-message-id.test.ts
+++ b/packages/node/src/lib/__tests__/get-message-id.test.ts
@@ -1,12 +1,12 @@
-import { getMessageId } from '../get-message-id'
+import { createMessageId } from '../get-message-id'
 
 // https://gist.github.com/johnelliott/cf77003f72f889abbc3f32785fa3df8d
 const uuidv4Regex =
   /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
 
-describe(getMessageId, () => {
+describe(createMessageId, () => {
   it('creates a messageId that may look like "node-next-166820896773a9-c7404832-feea-4e70-ac7f-2dc94d96acca"', () => {
-    const msg = getMessageId().split('-')
+    const msg = createMessageId().split('-')
     expect(msg.length).toBe(8)
 
     expect(`${msg[0]}-${msg[1]}`).toBe('node-next')

--- a/packages/node/src/lib/__tests__/get-message-id.test.ts
+++ b/packages/node/src/lib/__tests__/get-message-id.test.ts
@@ -5,7 +5,7 @@ const uuidv4Regex =
   /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
 
 describe(createMessageId, () => {
-  it('creates a messageId that may look like "node-next-166820896773a9-c7404832-feea-4e70-ac7f-2dc94d96acca"', () => {
+  it('returns a string in the format "node-next-[unix epoch time]-[uuid v4]"', () => {
     const msg = createMessageId().split('-')
     expect(msg.length).toBe(8)
 

--- a/packages/node/src/lib/create-node-event-factory.ts
+++ b/packages/node/src/lib/create-node-event-factory.ts
@@ -1,0 +1,7 @@
+import { EventFactory } from '@segment/analytics-core'
+import { getMessageId } from './get-message-id'
+
+export const createNodeEventFactory = () =>
+  new EventFactory({
+    getMessageId,
+  })

--- a/packages/node/src/lib/create-node-event-factory.ts
+++ b/packages/node/src/lib/create-node-event-factory.ts
@@ -1,7 +1,7 @@
 import { EventFactory } from '@segment/analytics-core'
-import { getMessageId } from './get-message-id'
+import { createMessageId } from './get-message-id'
 
 export const createNodeEventFactory = () =>
   new EventFactory({
-    getMessageId,
+    createMessageId,
   })

--- a/packages/node/src/lib/get-message-id.ts
+++ b/packages/node/src/lib/get-message-id.ts
@@ -1,0 +1,10 @@
+import { v4 } from '@lukeed/uuid/secure'
+
+/**
+ * get a unique messageId with a very low chance of collisions
+ * using @lukeed/uuid/secure uses the node crypto module, which is the fastest
+ * @example "node-next-1668208232027-743be593-7789-4b74-8078-cbcc8894c586"
+ */
+export const getMessageId = (): string => {
+  return `node-next-${Date.now()}-${v4()}`
+}

--- a/packages/node/src/lib/get-message-id.ts
+++ b/packages/node/src/lib/get-message-id.ts
@@ -5,6 +5,6 @@ import { v4 } from '@lukeed/uuid/secure'
  * using @lukeed/uuid/secure uses the node crypto module, which is the fastest
  * @example "node-next-1668208232027-743be593-7789-4b74-8078-cbcc8894c586"
  */
-export const getMessageId = (): string => {
+export const createMessageId = (): string => {
   return `node-next-${Date.now()}-${v4()}`
 }

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 const fetcher = jest.fn()
 jest.mock('node-fetch', () => fetcher)
 
-import { CoreContext, EventFactory } from '@segment/analytics-core'
+import { CoreContext } from '@segment/analytics-core'
+import { createNodeEventFactory } from '../../../lib/create-node-event-factory'
 import {
   createError,
   createSuccess,
@@ -9,7 +10,7 @@ import {
 import { configureNodePlugin } from '../index'
 
 const bodyPropertyMatchers = {
-  messageId: expect.stringMatching(/^ajs-next-[\w\d]+$/),
+  messageId: expect.stringMatching(/^node-next-\d*-\w*-\w*-\w*-\w*-\w*/),
   timestamp: expect.stringMatching(
     /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
   ),
@@ -49,7 +50,7 @@ function validateFetcherInputs(...contexts: CoreContext[]) {
 }
 
 describe('SegmentNodePlugin', () => {
-  const eventFactory = new EventFactory()
+  const eventFactory = createNodeEventFactory()
   const realSetTimeout = setTimeout
 
   beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,7 +1827,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@segment/analytics-core@workspace:packages/core"
   dependencies:
-    "@lukeed/uuid": ^2.0.0
     dset: ^3.1.2
     tslib: ^2.4.0
   languageName: unknown
@@ -1895,6 +1894,7 @@ __metadata:
   resolution: "@segment/analytics-node@workspace:packages/node"
   dependencies:
     "@internal/config": 0.0.0
+    "@lukeed/uuid": ^2.0.0
     "@segment/analytics-core": 1.1.1
     "@types/node": ^12.12.14
     node-fetch: ^2.6.7


### PR DESCRIPTION
- Allow consumers to inject custom messageId into EventFactory, allowing us to remove node transient dependency on md5 library.

- node messageId looks like: `node-next-1668208232027-743be593-7789-4b74-8078-cbcc8894c586` ("node-next-[date]-[uuidv4]")
  - notice that there is no final hashing of this messageId -- [per stackoverflow,](https://stackoverflow.com/questions/36369506/is-using-the-java-util-uuid-after-hashing-it-with-md5-a-good-option) hashing a UUID (or any unique value in general) is a no-no as it increases the chances of collisions (and adds needless cpu overhead). It seems like a smell we should avoid if we can. Open to more discussion -- cc @pooyaj