### PR TITLE
Upgrade minimum node support on analytics-node to 14.x

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -31,7 +31,8 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, Depende
     '@segment/analytics-next',
     '@segment/analytics-node',
     '@segment/analytics-core',
-    '@internal/config'
+    '@internal/config',
+    '@types/node'
   ]).
 
 % Enforces that a dependency doesn't appear in both `dependencies` and `devDependencies`

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -2,6 +2,8 @@
 ## Warning: Until 1.x release, use this library at your own risk!
 While the API is very similar, the documentation for the legacy SDK (`analytics-node`) is here: https://segment.com/docs/connections/sources/catalog/libraries/server/node/
 
+## Requirements
+- NodeJS >= 14.x
 
 ## Quick Start
 ### Install library

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,7 +16,7 @@
     "!*.tsbuildinfo"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "test": "yarn jest",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
-    "@types/node": "^12.12.14"
+    "@types/node": "^14"
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "module": "esnext",
-    "target": "ES5",
+    "target": "es2020", // node 14
     "moduleResolution": "node",
-    "lib": ["es2020"] // TODO: https://www.npmjs.com/package/@tsconfig/node12?
+    "lib": ["es2020"] // TODO: https://www.npmjs.com/package/@tsconfig/node14
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,7 +1896,7 @@ __metadata:
   dependencies:
     "@internal/config": 0.0.0
     "@segment/analytics-core": 1.1.1
-    "@types/node": ^12.12.14
+    "@types/node": ^14
     node-fetch: ^2.6.7
     tslib: ^2.4.0
   languageName: unknown
@@ -3571,6 +3571,13 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: e4f86785f4092706e0d3b0edff8dca5a13b45627e4b36700acd8dfe6ad53db71928c8dee914d4276c7fd3b6ccd829aa919811c9eb708a2c8e4c6eb3701178c37
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^14":
+  version: 14.18.33
+  resolution: "@types/node@npm:14.18.33"
+  checksum: 4e23f95186d8ae1d38c999bc6b46fe94e790da88744b0a3bfeedcbd0d9ffe2cb0ff39e85f43014f6739e5270292c1a1f6f97a1fc606fd573a0c17fda9a1d42de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Node 12 LTS has been at complete end-of-life for 6 months, we should not include any official support for it. This change also allows us to compile to ES2020 (smaller package and allows us to use actual JS private fields / methods if we want).

We already use node 14 for buildkite runner, so no change needed.

<img width="763" alt="image" src="https://user-images.githubusercontent.com/5115498/201492147-3bcef67a-2cc6-4462-8503-a39031d494a5.png">