### PR TITLE
Bump tsub to 1.0.1

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
     "@segment/analytics-core": "1.1.1",
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
-    "@segment/tsub": "^0.2.0",
+    "@segment/tsub": "1.0.1",
     "dset": "^3.1.2",
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,7 +1843,7 @@ __metadata:
     "@segment/analytics.js-video-plugins": ^0.2.1
     "@segment/facade": ^3.4.9
     "@segment/inspector-webext": ^2.0.3
-    "@segment/tsub": ^0.2.0
+    "@segment/tsub": 1.0.1
     "@size-limit/preset-big-lib": ^7.0.8
     "@types/flat": ^5.0.1
     "@types/fs-extra": ^9.0.2
@@ -2004,9 +2004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@segment/tsub@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@segment/tsub@npm:0.2.0"
+"@segment/tsub@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@segment/tsub@npm:1.0.1"
   dependencies:
     "@stdlib/math-base-special-ldexp": ^0.0.5
     dlv: ^1.1.3
@@ -2014,7 +2014,7 @@ __metadata:
     tiny-hashes: ^1.0.1
   bin:
     tsub: dist/index.js
-  checksum: 869fbe797441f349a466a13e4641e1245d8fe2e6260521e34af6bbac25000740986bbf75799f5447863fdb800c00a2b9781920170789c8bf78394d33f41969db
+  checksum: a5a1cedcc98dc19e09a3cb806906a457ef956a592079a14c8f88041b95fc32c876bc7df04d8c6d34b905fef128fd6dfec7222cf7fbd3302e1a4a47dcd4b8fa1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This brings [tsub-js](https://www.npmjs.com/package/@segment/tsub/v/1.0.1) into an official release, no functionality changes. 

`dist/` folder did not properly upload with `1.0.0`, so I did a patch update to get it in there.