### PR TITLE
force publish core library

### DIFF
--- a/.changeset/chatty-readers-judge.md
+++ b/.changeset/chatty-readers-judge.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-core': patch
+---
+
+Force publish core library


### PR DESCRIPTION
Infra broke npm publish, so I published locally but it accidentally published some older build artifacts.