### PR TITLE
export Analytics as both a named export and a default export

### DIFF
--- a/packages/node-integration-tests/src/smoke/smoke.ts
+++ b/packages/node-integration-tests/src/smoke/smoke.ts
@@ -1,0 +1,8 @@
+import { default as AnalyticsDefaultImport } from '@segment/analytics-node'
+import { Analytics as AnalyticsNamedImport } from '@segment/analytics-node'
+
+{
+  // test named imports vs default imports
+  new AnalyticsNamedImport({ writeKey: 'hello world' })
+  new AnalyticsDefaultImport({ writeKey: 'hello world' })
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,2 +1,6 @@
 export * from './app/analytics-node'
 export type { AnalyticsSettings } from './app/settings'
+
+// export Analytics as both a named export and a default export (for backwards-compat. reasons)
+import { Analytics } from './app/analytics-node'
+export default Analytics


### PR DESCRIPTION
To make migration a bit easier.