### PR TITLE
do not trigger a retry on thrown errors in before plugins

### DIFF
--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -48,7 +48,7 @@ type NodeEmitterEvents = CoreEmitterContract<Context> & {
 
 class NodePriorityQueue extends PriorityQueue<Context> {
   constructor() {
-    super(3, [])
+    super(1, [])
   }
   // do not use an internal "seen" map
   getAttempts(ctx: Context): number {


### PR DESCRIPTION
I feel like this retry queue ("before-plugin only!") behavior is something we want to eventually deprecate in the browser. IMO, we shouldn't bring it over.