### PR TITLE
Adds integration test for action destinations in addDestinationMiddleware

### DIFF
--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -405,9 +405,7 @@ export class Analytics
     ...middlewares: DestinationMiddlewareFunction[]
   ): Promise<Analytics> {
     const legacyDestinations = this.queue.plugins.filter(
-      (xt) =>
-        // xt instanceof LegacyDestination &&
-        xt.name.toLowerCase() === integrationName.toLowerCase()
+      (xt) => xt.name.toLowerCase() === integrationName.toLowerCase()
     ) as LegacyDestination[]
 
     legacyDestinations.forEach((destination) => {


### PR DESCRIPTION
Per the work done in https://github.com/segmentio/analytics-next/pull/597, there was a question of whether or not the existing `addDestinationMiddleware` function would support action destinations. It appears that the logic that used to only allow `LegacyDestinations` into the plugins array was removed at some point, and this small addition to the existing integration test for the existing function confirms that action destinations are not filtered out if `addDestinationMiddleware` is invoked.