### PR TITLE
switch back to node-fetch because of test incompatibility and node 14 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@npmcli/promise-spawn": "^3.0.0",
     "@types/jest": "^28.1.1",
     "@types/lodash": "^4",
+    "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "concurrently": "^7.2.1",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -71,7 +71,6 @@
     "@types/jsdom": "^16.2.14",
     "@types/mime": "^2.0.3",
     "@types/node": "^12.12.14",
-    "@types/node-fetch": "^2.5.7",
     "@types/serve-handler": "^6.1.0",
     "@types/spark-md5": "^3.0.2",
     "aws-sdk": "^2.814.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics-core": "1.1.2",
-    "tslib": "^2.4.0",
-    "undici": "^5.12.0"
+    "node-fetch": "^2.6.7",
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@internal/config": "0.0.0",

--- a/packages/node/src/lib/fetch.ts
+++ b/packages/node/src/lib/fetch.ts
@@ -1,3 +1,3 @@
-import { fetch as _fetch } from 'undici'
+import { default as _fetch } from 'node-fetch'
 
 export const fetch = globalThis.fetch || _fetch

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,7 +1852,6 @@ __metadata:
     "@types/jsdom": ^16.2.14
     "@types/mime": ^2.0.3
     "@types/node": ^12.12.14
-    "@types/node-fetch": ^2.5.7
     "@types/serve-handler": ^6.1.0
     "@types/spark-md5": ^3.0.2
     aws-sdk: ^2.814.0
@@ -1897,8 +1896,8 @@ __metadata:
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-core": 1.1.2
     "@types/node": ^14
+    node-fetch: ^2.6.7
     tslib: ^2.4.0
-    undici: ^5.12.0
   languageName: unknown
   linkType: soft
 
@@ -3543,13 +3542,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.7":
-  version: 2.5.7
-  resolution: "@types/node-fetch@npm:2.5.7"
+"@types/node-fetch@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "@types/node-fetch@npm:2.6.2"
   dependencies:
     "@types/node": "*"
     form-data: ^3.0.0
-  checksum: 41079d4898d66dbaea9911015c3f35694c20806dc8300bab77f3d0e46b89e967e89e7301a884c12c594bd770a24ae27fd393fc36d14747cf57bb1e24f9cfbcb7
+  checksum: 6f73b1470000d303d25a6fb92875ea837a216656cb7474f66cdd67bb014aa81a5a11e7ac9c21fe19bee9ecb2ef87c1962bceeaec31386119d1ac86e4c30ad7a6
   languageName: node
   linkType: hard
 
@@ -4434,6 +4433,7 @@ __metadata:
     "@npmcli/promise-spawn": ^3.0.0
     "@types/jest": ^28.1.1
     "@types/lodash": ^4
+    "@types/node-fetch": ^2.6.2
     "@typescript-eslint/eslint-plugin": ^5.21.0
     "@typescript-eslint/parser": ^5.21.0
     concurrently: ^7.2.1
@@ -5115,15 +5115,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"busboy@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "busboy@npm:1.6.0"
-  dependencies:
-    streamsearch: ^1.1.0
-  checksum: 32801e2c0164e12106bf236291a00795c3c4e4b709ae02132883fe8478ba2ae23743b11c5735a0aae8afe65ac4b6ca4568b91f0d9fed1fdbc32ede824a73746e
   languageName: node
   linkType: hard
 
@@ -7488,13 +7479,13 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "form-data@npm:3.0.0"
+  version: 3.0.1
+  resolution: "form-data@npm:3.0.1"
   dependencies:
     asynckit: ^0.4.0
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
-  checksum: 60ec3fe7e23154949ab6fef31baedf5afbfb8d6441ea8d19b211b43a5d0448be2918c9bba6218cade56a7cbd43f670d6e75f41f626f8d397d56bf8c60f4a829d
+  checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
   languageName: node
   linkType: hard
 
@@ -12700,13 +12691,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"streamsearch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "streamsearch@npm:1.1.0"
-  checksum: 1cce16cea8405d7a233d32ca5e00a00169cc0e19fbc02aa839959985f267335d435c07f96e5e0edd0eadc6d39c98d5435fb5bbbdefc62c41834eadc5622ad942
-  languageName: node
-  linkType: hard
-
 "string-argv@npm:^0.3.1":
   version: 0.3.1
   resolution: "string-argv@npm:0.3.1"
@@ -13680,15 +13664,6 @@ __metadata:
     buffer: ^5.2.1
     through: ^2.3.8
   checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
-  languageName: node
-  linkType: hard
-
-"undici@npm:^5.12.0":
-  version: 5.12.0
-  resolution: "undici@npm:5.12.0"
-  dependencies:
-    busboy: ^1.6.0
-  checksum: fbc227704943c05aa3dc1630695e10309c17d0a535678594d136db107c50593248e9ace70e1ab77496a6c837bf14aa2ab3c501a7a6c45fb6277dbf0846e15ffe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
So, you can't use nock with undici, since nock uses the http module (undici actually has a nice build-in way to intercept requests). Unfortunately, this makes perf test a bit harder, and I don't neccessarily want to deal with this atm -- since you probably have to switch some more universal stubbing solution (like using a mock server).