### PR TITLE
Undefined options bug

### DIFF
--- a/.changeset/flat-chefs-bathe.md
+++ b/.changeset/flat-chefs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fixes issue where options object would not be properly assigned if properties arg was explicitly undefined

--- a/packages/browser/src/core/arguments-resolver/__tests__/index.test.ts
+++ b/packages/browser/src/core/arguments-resolver/__tests__/index.test.ts
@@ -101,6 +101,18 @@ describe(resolveArguments, () => {
       expect(options).toEqual({})
       expect(cb).toEqual(fn)
     })
+
+    test('options set if properties undefined', () => {
+      const [event, props, options] = resolveArguments(
+        'Test Event',
+        undefined,
+        { context: { page: { path: '/custom' } } }
+      )
+
+      expect(event).toEqual('Test Event')
+      expect(props).toEqual({})
+      expect(options).toEqual({ context: { page: { path: '/custom' } } })
+    })
   })
 
   describe('event as object', () => {

--- a/packages/browser/src/core/arguments-resolver/index.ts
+++ b/packages/browser/src/core/arguments-resolver/index.ts
@@ -38,7 +38,7 @@ export function resolveArguments(
     : {}
 
   let opts: Options = {}
-  if (isPlainObject(properties) && !isFunction(options)) {
+  if (!isFunction(options)) {
     opts = options ?? {}
   }
 

--- a/packages/browser/src/core/events/__tests__/index.test.ts
+++ b/packages/browser/src/core/events/__tests__/index.test.ts
@@ -156,6 +156,14 @@ describe('Event Factory', () => {
       expect(track.context).toEqual({ opt1: true })
     })
 
+    test('sets context correctly if property arg is undefined', () => {
+      const track = factory.track('Order Completed', undefined, {
+        context: { page: { path: '/custom' } },
+      })
+
+      expect(track.context).toEqual({ page: { path: '/custom' } })
+    })
+
     test('sets integrations', () => {
       const track = factory.track(
         'Order Completed',


### PR DESCRIPTION
Addressing #649, there was a gap in the `resolveArguments` logic that wouldn't let `options` be set if `properties` were `undefined`, as the original logic did not account for the case where `properties` wouldn't be defined.