### PR TITLE
node: eliminate flush delay

### DIFF
--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -312,10 +312,10 @@ describe('version', () => {
 describe('ready', () => {
   it('should only resolve when plugin registration is done', async () => {
     const analytics = createTestAnalytics()
-    expect(analytics.queue.plugins.length).toBe(0)
+    expect(analytics['_queue'].plugins.length).toBe(0)
     const result = await analytics.ready
     expect(result).toBeUndefined()
-    expect(analytics.queue.plugins.length).toBeGreaterThan(0)
+    expect(analytics['_queue'].plugins.length).toBeGreaterThan(0)
   })
 
   it.skip('should not reject if a plugin fails registration during initialization?', async () => {

--- a/packages/node/src/__tests__/plugins.test.ts
+++ b/packages/node/src/__tests__/plugins.test.ts
@@ -14,7 +14,7 @@ describe('Plugins', () => {
       const analytics = createTestAnalytics()
       await analytics.ready
 
-      const ajsNodeXt = analytics.queue.plugins.find(
+      const ajsNodeXt = analytics['_queue'].plugins.find(
         (xt) => xt.name === 'Segment.io'
       )
       expect(ajsNodeXt).toBeDefined()

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -14,7 +14,7 @@ import {
 } from '@segment/analytics-core'
 import { AnalyticsSettings, validateSettings } from './settings'
 import { version } from '../../package.json'
-import { configureNodePlugin } from '../plugins/segmentio'
+import { createConfiguredNodePlugin } from '../plugins/segmentio'
 import { createNodeEventFactory } from '../lib/create-node-event-factory'
 import { Callback, dispatchAndEmit } from './dispatch-emit'
 import { NodeEmitter } from './emitter'
@@ -59,12 +59,15 @@ export interface SegmentEvent extends CoreSegmentEvent {
 }
 
 export class Analytics extends NodeEmitter implements CoreAnalytics {
-  private _eventFactory: EventFactory
+  private readonly _eventFactory: EventFactory
   private _isClosed = false
   private _pendingEvents = 0
   private readonly _closeAndFlushDefaultTimeout: number
+  private readonly _publisher: ReturnType<
+    typeof createConfiguredNodePlugin
+  >['publisher']
 
-  queue: EventQueue
+  private readonly _queue: EventQueue
 
   ready: Promise<void>
 
@@ -73,22 +76,22 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
     validateSettings(settings)
 
     this._eventFactory = createNodeEventFactory()
-    this.queue = new EventQueue(new NodePriorityQueue())
+    this._queue = new EventQueue(new NodePriorityQueue())
 
     const flushInterval = settings.flushInterval ?? 10000
 
     this._closeAndFlushDefaultTimeout = flushInterval * 1.25 // add arbitrary multiplier in case an event is in a plugin.
 
-    this.ready = this.register(
-      configureNodePlugin({
-        writeKey: settings.writeKey,
-        host: settings.host,
-        path: settings.path,
-        maxRetries: settings.maxRetries ?? 3,
-        maxEventsInBatch: settings.maxEventsInBatch ?? 15,
-        flushInterval,
-      })
-    ).then(() => undefined)
+    const { plugin, publisher } = createConfiguredNodePlugin({
+      writeKey: settings.writeKey,
+      host: settings.host,
+      path: settings.path,
+      maxRetries: settings.maxRetries ?? 3,
+      maxEventsInBatch: settings.maxEventsInBatch ?? 15,
+      flushInterval,
+    })
+    this._publisher = publisher
+    this.ready = this.register(plugin).then(() => undefined)
 
     this.emit('initialize', settings)
 
@@ -110,6 +113,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
     /** Set a maximum time permitted to wait before resolving. */
     timeout?: number
   } = {}): Promise<void> {
+    this._publisher.flushAfterClose(this._pendingEvents)
     this._isClosed = true
     const promise = new Promise<void>((resolve) => {
       if (!this._pendingEvents) {
@@ -129,7 +133,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
 
     this._pendingEvents++
 
-    dispatchAndEmit(segmentEvent, this.queue, this, callback)
+    dispatchAndEmit(segmentEvent, this._queue, this, callback)
       .catch((ctx) => ctx)
       .finally(() => {
         this._pendingEvents--
@@ -307,11 +311,11 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
    * @param plugins
    */
   async register(...plugins: CorePlugin<any, any>[]): Promise<void> {
-    return this.queue.criticalTasks.run(async () => {
+    return this._queue.criticalTasks.run(async () => {
       const ctx = Context.system()
 
       const registrations = plugins.map((xt) =>
-        this.queue.register(ctx, xt, this)
+        this._queue.register(ctx, xt, this)
       )
       await Promise.all(registrations)
       this.emit(
@@ -329,9 +333,9 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
     const ctx = Context.system()
 
     const deregistrations = pluginNames.map(async (pl) => {
-      const plugin = this.queue.plugins.find((p) => p.name === pl)
+      const plugin = this._queue.plugins.find((p) => p.name === pl)
       if (plugin) {
-        return this.queue.deregister(ctx, plugin, this)
+        return this._queue.deregister(ctx, plugin, this)
       } else {
         ctx.log('warn', `plugin ${pl} not found`)
       }

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -7,7 +7,11 @@ import {
   createError,
   createSuccess,
 } from '../../../__tests__/test-helpers/factories'
-import { configureNodePlugin } from '../index'
+import { createConfiguredNodePlugin } from '../index'
+import { PublisherProps } from '../publisher'
+
+const createTestNodePlugin = (props: PublisherProps) =>
+  createConfiguredNodePlugin(props).plugin
 
 const bodyPropertyMatchers = {
   messageId: expect.stringMatching(/^node-next-\d*-\w*-\w*-\w*-\w*-\w*/),
@@ -68,7 +72,7 @@ describe('SegmentNodePlugin', () => {
 
   describe('methods', () => {
     it('alias', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -97,7 +101,7 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('group', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -135,7 +139,7 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('identify', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -167,7 +171,7 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('page', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -206,7 +210,7 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('screen', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -244,7 +248,7 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('track', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -284,7 +288,7 @@ describe('SegmentNodePlugin', () => {
     it('supports multiple events in a batch', async () => {
       fetcher.mockReturnValue(createSuccess())
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
         flushInterval: 1000,
@@ -318,7 +322,7 @@ describe('SegmentNodePlugin', () => {
     it('supports waiting a max amount of time before sending', async () => {
       fetcher.mockReturnValue(createSuccess())
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
         flushInterval: 1000,
@@ -348,7 +352,7 @@ describe('SegmentNodePlugin', () => {
     it('sends as soon as batch fills up or max time is reached', async () => {
       fetcher.mockReturnValue(createSuccess())
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 2,
         flushInterval: 1000,
@@ -385,7 +389,7 @@ describe('SegmentNodePlugin', () => {
 
     it('sends if batch will exceed max size in bytes when adding event', async () => {
       fetcher.mockReturnValue(createSuccess())
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 20,
         flushInterval: 100,
@@ -424,7 +428,7 @@ describe('SegmentNodePlugin', () => {
 
   describe('error handling', () => {
     it('excludes events that are too large', async () => {
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -460,7 +464,7 @@ describe('SegmentNodePlugin', () => {
         createError({ status: 400, statusText: 'Bad Request' })
       )
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -491,7 +495,7 @@ describe('SegmentNodePlugin', () => {
         createError({ status: 500, statusText: 'Internal Server Error' })
       )
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 2,
         maxEventsInBatch: 1,
         flushInterval: 1000,
@@ -521,7 +525,7 @@ describe('SegmentNodePlugin', () => {
 
       fetcher.mockRejectedValue(new Error('Connection Error'))
 
-      const segmentPlugin = configureNodePlugin({
+      const segmentPlugin = createTestNodePlugin({
         maxRetries: 2,
         maxEventsInBatch: 1,
         flushInterval: 1000,

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -56,19 +56,9 @@ function validateFetcherInputs(...contexts: CoreContext[]) {
 describe('SegmentNodePlugin', () => {
   const eventFactory = createNodeEventFactory()
 
-  const realSetTimeout = setTimeout
-
   beforeEach(() => {
-    jest.resetAllMocks()
-    jest.restoreAllMocks()
+    fetcher.mockReturnValue(createSuccess())
     jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    if (setTimeout !== realSetTimeout) {
-      jest.runAllTimers()
-      jest.useRealTimers()
-    }
   })
 
   describe('methods', () => {
@@ -287,8 +277,6 @@ describe('SegmentNodePlugin', () => {
 
   describe('batching', () => {
     it('supports multiple events in a batch', async () => {
-      fetcher.mockReturnValue(createSuccess())
-
       const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
@@ -321,8 +309,6 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('supports waiting a max amount of time before sending', async () => {
-      fetcher.mockReturnValue(createSuccess())
-
       const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 3,
@@ -351,8 +337,6 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('sends as soon as batch fills up or max time is reached', async () => {
-      fetcher.mockReturnValue(createSuccess())
-
       const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 2,
@@ -389,7 +373,6 @@ describe('SegmentNodePlugin', () => {
     })
 
     it('sends if batch will exceed max size in bytes when adding event', async () => {
-      fetcher.mockReturnValue(createSuccess())
       const segmentPlugin = createTestNodePlugin({
         maxRetries: 3,
         maxEventsInBatch: 20,
@@ -446,7 +429,6 @@ describe('SegmentNodePlugin', () => {
             )
           )
 
-        fetcher.mockReturnValue(createSuccess())
         const { plugin: segmentPlugin, publisher } = createConfiguredNodePlugin(
           {
             maxRetries: 3,
@@ -466,7 +448,6 @@ describe('SegmentNodePlugin', () => {
       })
 
       it('continues to flush on each event if batch size is 1', async () => {
-        fetcher.mockReturnValue(createSuccess())
         const { plugin: segmentPlugin, publisher } = createConfiguredNodePlugin(
           {
             maxRetries: 3,
@@ -494,7 +475,6 @@ describe('SegmentNodePlugin', () => {
             )
           )
 
-        fetcher.mockReturnValue(createSuccess())
         const { plugin: segmentPlugin, publisher } = createConfiguredNodePlugin(
           {
             maxRetries: 3,

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -453,7 +453,7 @@ describe('SegmentNodePlugin', () => {
       expect(updatedContext.failedDelivery()).toBeTruthy()
       expect(updatedContext.failedDelivery()).toMatchInlineSnapshot(`
         Object {
-          "reason": [Error: Event exceeds maximum event size of 32 kb],
+          "reason": [Error: Event exceeds maximum event size of 32 KB],
         }
       `)
       expect(fetcher).not.toHaveBeenCalled()

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -26,11 +26,7 @@ type SegmentNodePlugin = CorePlugin &
 
 export type ConfigureNodePluginProps = PublisherProps
 
-export function configureNodePlugin(
-  props: ConfigureNodePluginProps
-): SegmentNodePlugin {
-  const publisher = new Publisher(props)
-
+export function createNodePlugin(publisher: Publisher): SegmentNodePlugin {
   function action(ctx: CoreContext): Promise<CoreContext> {
     normalizeEvent(ctx)
     return publisher.enqueue(ctx)
@@ -48,5 +44,13 @@ export function configureNodePlugin(
     page: action,
     screen: action,
     track: action,
+  }
+}
+
+export const createConfiguredNodePlugin = (props: ConfigureNodePluginProps) => {
+  const publisher = new Publisher(props)
+  return {
+    publisher: publisher,
+    plugin: createNodePlugin(publisher),
   }
 }

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -166,8 +166,10 @@ export class Publisher {
     const events = batch.getEvents()
     const payload = JSON.stringify({ batch: events })
     const maxAttempts = this._maxRetries + 1
-
     let currentAttempt = 0
+    if (this._closeAndFlushPendingItemsCount) {
+      this._closeAndFlushPendingItemsCount -= batch.length
+    }
     while (currentAttempt < maxAttempts) {
       currentAttempt++
 

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -163,13 +163,14 @@ export class Publisher {
   }
 
   private async send(batch: ContextBatch) {
-    const events = batch.getEvents()
-    const payload = JSON.stringify({ batch: events })
-    const maxAttempts = this._maxRetries + 1
-    let currentAttempt = 0
     if (this._closeAndFlushPendingItemsCount) {
       this._closeAndFlushPendingItemsCount -= batch.length
     }
+    const events = batch.getEvents()
+    const payload = JSON.stringify({ batch: events })
+    const maxAttempts = this._maxRetries + 1
+
+    let currentAttempt = 0
     while (currentAttempt < maxAttempts) {
       currentAttempt++
 

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -29,13 +29,14 @@ export interface PublisherProps {
  */
 export class Publisher {
   private pendingFlushTimeout?: ReturnType<typeof setTimeout>
-  private batch?: ContextBatch
+  private _batch?: ContextBatch
 
   private _flushInterval: number
   private _maxEventsInBatch: number
   private _maxRetries: number
   private _auth: string
   private _url: string
+  private _closeAndFlushPendingItemsCount?: number
 
   constructor({
     host,
@@ -58,10 +59,10 @@ export class Publisher {
   private createBatch(): ContextBatch {
     this.pendingFlushTimeout && clearTimeout(this.pendingFlushTimeout)
     const batch = new ContextBatch(this._maxEventsInBatch)
-    this.batch = batch
+    this._batch = batch
     this.pendingFlushTimeout = setTimeout(() => {
-      if (batch === this.batch) {
-        this.batch = undefined
+      if (batch === this._batch) {
+        this._batch = undefined
       }
       this.pendingFlushTimeout = undefined
       if (batch.length) {
@@ -73,7 +74,27 @@ export class Publisher {
 
   private clearBatch() {
     this.pendingFlushTimeout && clearTimeout(this.pendingFlushTimeout)
-    this.batch = undefined
+    this._batch = undefined
+  }
+
+  flushAfterClose(pendingItemsCount: number) {
+    if (!pendingItemsCount) {
+      // if number of pending items is 0, there will never be anything else entering the batch, since the app is closed.
+      return
+    }
+
+    this._closeAndFlushPendingItemsCount = pendingItemsCount
+
+    // if batch is empty, there's nothing to flush, and when things come in, enqueue will handle them.
+    if (!this._batch) return
+
+    // the number of globally pending items will always be larger or the same as batch size.
+    // Any mismatch is because some globally pending items are in plugins.
+    const isExpectingNoMoreItems = this._batch.length === pendingItemsCount
+    if (isExpectingNoMoreItems) {
+      this.send(this._batch).catch(noop)
+      this.clearBatch()
+    }
   }
 
   /**
@@ -82,7 +103,7 @@ export class Publisher {
    * @returns a promise that resolves with the context after the event has been delivered.
    */
   enqueue(ctx: CoreContext): Promise<CoreContext> {
-    const batch = this.batch ?? this.createBatch()
+    const batch = this._batch ?? this.createBatch()
 
     const { promise: ctxPromise, resolve } = extractPromiseParts<CoreContext>()
 
@@ -96,7 +117,7 @@ export class Publisher {
       and is always sent before a new batch is created.
 
       Add an event to the existing batch.
-        Success: Check if batch is full and send if it is.
+        Success: Check if batch is full or no more items are expected to come in (i.e. closing). If so, send batch.
         Failure: Assume event is too big to fit in current batch - send existing batch.
           Add an event to the new batch.
             Success: Check if batch is full and send if it is.
@@ -104,7 +125,11 @@ export class Publisher {
     */
 
     if (batch.tryAdd(pendingItem)) {
-      if (batch.length === this._maxEventsInBatch) {
+      const isFull = batch.length === this._maxEventsInBatch
+      const isExpectingNoMoreItems =
+        batch.length === this._closeAndFlushPendingItemsCount
+
+      if (isFull || isExpectingNoMoreItems) {
         this.send(batch).catch(noop)
         this.clearBatch()
       }


### PR DESCRIPTION
If closeAndFlush is called, we to wait for pending events to make it to the segment plugin before flushing, but not wait any additional time for the flushInterval to expire.