### PR TITLE
node: remove plugin array from settings and add plugin documentation

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -58,7 +58,6 @@ See complete list of settings in the [AnalyticsSettings interface](src/app/setti
 ```ts
 const analytics = new Analytics({
     writeKey: '<MY_WRITE_KEY>',
-    plugins: [plugin1, plugin2],
     host: 'https://api.segment.io',
     path: '/v1/batch',
     maxRetries: 3,

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -278,3 +278,26 @@ You should prefer mocking. However, if you need to intercept the request, you ca
 const analytics = new Analytics({ host: mockApiHost, path: mockPath })
 
 ```
+
+
+## Plugin Architecture
+- See segment's [documentation for plugin architecture](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#plugin-architecture).
+
+```ts
+import type { Plugin } from '@segment/analytics-node' // optional type
+
+export const lowercase: Plugin = {
+  name: 'Lowercase events',
+  type: 'enrichment',
+  version: '1.0.0',
+  isLoaded: () => true,
+  load: () => Promise.resolve(),
+  track: (ctx) => {
+    ctx.updateEvent('event', ctx.event.event.toLowerCase())
+    return ctx
+  }
+}
+
+analytics.register(lowercase)
+
+```

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -283,8 +283,7 @@ const analytics = new Analytics({ host: mockApiHost, path: mockPath })
 - See segment's [documentation for plugin architecture](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#plugin-architecture).
 
 ```ts
-import type { Plugin } from '@segment/analytics-node' // optional type
-
+import type { Plugin } from '@segment/analytics-node'
 export const lowercase: Plugin = {
   name: 'Lowercase events',
   type: 'enrichment',

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -24,6 +24,8 @@ import { createNodeEventFactory } from '../lib/create-node-event-factory'
 // create a derived class since we may want to add node specific things to Context later
 export class Context extends CoreContext {}
 
+export interface Plugin extends CorePlugin {}
+
 /**
  * An ID associated with the user. Note: at least one of userId or anonymousId must be included.
  **/

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -1,4 +1,4 @@
-import { CorePlugin, ValidationError } from '@segment/analytics-core'
+import { ValidationError } from '@segment/analytics-core'
 
 export interface AnalyticsSettings {
   /**
@@ -6,9 +6,6 @@ export interface AnalyticsSettings {
    */
   writeKey: string
   /**
-   * An optional array of additional plugins that are capable of augmenting analytics-node functionality and enriching data.
-   */
-  plugins?: CorePlugin[]
   /**
    * The base URL of the API. Default: "https://api.segment.io"
    */

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,4 +1,4 @@
-export * from './app/analytics-node'
+export { Analytics, Context, Plugin } from './app/analytics-node'
 export type { AnalyticsSettings } from './app/settings'
 
 // export Analytics as both a named export and a default export (for backwards-compat. reasons)


### PR DESCRIPTION
- add plugin documentation
- remove plugin array setting (user should just use "register", as that's in the[ existing documentation ](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#plugin-architecture)and there's no reason to expand the interface.)
- get rid of splat exports to avoid making the same mistake as browser