### PR TITLE
node: add configurable request timeout

### DIFF
--- a/.changeset/empty-pets-behave.md
+++ b/.changeset/empty-pets-behave.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-core': patch
+---
+
+EventFactory should filter out option keys with undefined values

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { EventFactory } from '..'
 import { User } from '../../user'
 import { CoreSegmentEvent } from '../..'
+import { isDate } from 'lodash'
 
 describe('Event Factory', () => {
   let factory: EventFactory
@@ -378,5 +379,16 @@ describe('Event Factory', () => {
         context: {},
       })
     })
+  })
+
+  it('should ignore undefined options', () => {
+    const event = factory.track(
+      'Order Completed',
+      { ...shoes },
+      { timestamp: undefined, traits: { foo: 123 } }
+    )
+
+    expect(typeof event.timestamp).toBe('object')
+    expect(isDate(event.timestamp)).toBeTruthy()
   })
 })

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -8,6 +8,7 @@ import {
   CoreSegmentEvent,
   CoreOptions,
 } from './interfaces'
+import { pickBy } from '../utils/pick'
 import { validateEvent } from '../validation/assertions'
 
 interface EventFactorySettings {
@@ -221,6 +222,11 @@ export class EventFactory {
       },
       {} as Record<string, boolean>
     )
+
+    // filter out any undefined options
+    event.options = pickBy(event.options || {}, (_, value) => {
+      return value !== undefined
+    })
 
     // This is pretty trippy, but here's what's going on:
     // - a) We don't pass initial integration options as part of the event, only if they're true or false

--- a/packages/core/src/utils/pick.ts
+++ b/packages/core/src/utils/pick.ts
@@ -1,7 +1,8 @@
-const pickBy = <T, K extends keyof T>(
+export const pickBy = <T, K extends keyof T>(
   obj: T,
   fn: (key: K, v: T[K]) => boolean
-) =>
-  (Object.keys(obj) as K[])
+) => {
+  return (Object.keys(obj) as K[])
     .filter((k) => fn(k, obj[k]))
     .reduce((acc, key) => ((acc[key] = obj[key]), acc), {} as Partial<T>)
+}

--- a/packages/core/src/utils/pick.ts
+++ b/packages/core/src/utils/pick.ts
@@ -1,0 +1,7 @@
+const pickBy = <T, K extends keyof T>(
+  obj: T,
+  fn: (key: K, v: T[K]) => boolean
+) =>
+  (Object.keys(obj) as K[])
+    .filter((k) => fn(k, obj[k]))
+    .reduce((acc, key) => ((acc[key] = obj[key]), acc), {} as Partial<T>)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -40,7 +40,8 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
-    "@types/node": "^14"
+    "@types/node": "^14",
+    "nock": "^13.2.9"
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -86,7 +86,7 @@ describe('Method Smoke Tests', () => {
         userId: 'foo',
         properties: { hello: 'world' },
         integrations: {
-          foo: 123,
+          foo: true,
         },
         timestamp: new Date(),
       }

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -88,6 +88,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       path: settings.path,
       maxRetries: settings.maxRetries ?? 3,
       maxEventsInBatch: settings.maxEventsInBatch ?? 15,
+      httpRequestTimeout: settings.httpRequestTimeout,
       flushInterval,
     })
     this._publisher = publisher

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -26,6 +26,10 @@ export interface AnalyticsSettings {
    * The number of milliseconds to wait before flushing the queue automatically. Default: 10000
    */
   flushInterval?: number
+  /**
+   * The maximum number of milliseconds to wait for an http request. Default: 10000
+   */
+  httpRequestTimeout?: number
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/lib/__tests__/abort.test.ts
+++ b/packages/node/src/lib/__tests__/abort.test.ts
@@ -12,7 +12,7 @@ describe(abortSignalAfterTimeout, () => {
     jest.useRealTimers()
     nock(HOST).get('/').reply(201)
     try {
-      const signal = abortSignalAfterTimeout(1000)
+      const [signal] = abortSignalAfterTimeout(1000)
       await fetch(HOST, { signal })
     } catch (err: any) {
       throw Error('fail')
@@ -28,7 +28,7 @@ describe(abortSignalAfterTimeout, () => {
         return true
       })
     try {
-      const signal = abortSignalAfterTimeout(2000)
+      const [signal] = abortSignalAfterTimeout(2000)
       jest.advanceTimersByTime(6000)
       await fetch(HOST, { signal })
       throw Error('fail test.')
@@ -40,8 +40,9 @@ describe(abortSignalAfterTimeout, () => {
   it('should abort operation immediately if timeout is 0', async () => {
     jest.useRealTimers()
     nock(HOST).get('/').reply(201)
+    const [signal] = abortSignalAfterTimeout(0)
     try {
-      await fetch(HOST, { signal: abortSignalAfterTimeout(0) })
+      await fetch(HOST, { signal })
       throw Error('fail test.')
     } catch (err: any) {
       expect(err.name).toMatch('AbortError')

--- a/packages/node/src/lib/__tests__/abort.test.ts
+++ b/packages/node/src/lib/__tests__/abort.test.ts
@@ -1,0 +1,51 @@
+import { abortSignalAfterTimeout } from '../abort'
+import nock from 'nock'
+import { fetch } from '../fetch'
+import { sleep } from '@segment/analytics-core'
+
+describe(abortSignalAfterTimeout, () => {
+  const HOST = 'https://foo.com'
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+  it('should not abort operation if timeout has not expired', async () => {
+    jest.useRealTimers()
+    nock(HOST).get('/').reply(201)
+    try {
+      const signal = abortSignalAfterTimeout(1000)
+      await fetch(HOST, { signal })
+    } catch (err: any) {
+      throw Error('fail')
+    }
+  })
+
+  it('should abort operation if timeout expires', async () => {
+    jest.useFakeTimers()
+    nock(HOST)
+      .get('/')
+      .reply(201, async () => {
+        await sleep(10000)
+        return true
+      })
+    try {
+      const signal = abortSignalAfterTimeout(2000)
+      jest.advanceTimersByTime(6000)
+      await fetch(HOST, { signal })
+      throw Error('fail test.')
+    } catch (err: any) {
+      expect(err.name).toMatch('AbortError')
+      expect(err.message).toMatch('The user aborted a request')
+    }
+  })
+  it('should abort operation immediately if timeout is 0', async () => {
+    jest.useRealTimers()
+    nock(HOST).get('/').reply(201)
+    try {
+      await fetch(HOST, { signal: abortSignalAfterTimeout(0) })
+      throw Error('fail test.')
+    } catch (err: any) {
+      expect(err.name).toMatch('AbortError')
+      expect(err.message).toMatch('The user aborted a request')
+    }
+  })
+})

--- a/packages/node/src/lib/abort.ts
+++ b/packages/node/src/lib/abort.ts
@@ -66,5 +66,5 @@ export const abortSignalAfterTimeout = (timeoutMs: number) => {
   // Allow Node.js processes to exit early if only the timeout is running
   timeoutId?.unref?.()
 
-  return ac.signal
+  return [ac.signal, timeoutId] as const
 }

--- a/packages/node/src/lib/abort.ts
+++ b/packages/node/src/lib/abort.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from 'events'
+
+/**
+ * adapted from: https://www.npmjs.com/package/node-abort-controller
+ */
+class AbortSignal {
+  onabort: globalThis.AbortSignal['onabort'] = null
+  aborted = false
+  eventEmitter = new EventEmitter()
+
+  toString() {
+    return '[object AbortSignal]'
+  }
+  get [Symbol.toStringTag]() {
+    return 'AbortSignal'
+  }
+  removeEventListener(...args: Parameters<EventEmitter['removeListener']>) {
+    this.eventEmitter.removeListener(...args)
+  }
+  addEventListener(...args: Parameters<EventEmitter['addListener']>) {
+    this.eventEmitter.on(...args)
+  }
+  dispatchEvent(type: string) {
+    const event = { type, target: this }
+
+    const handlerName = `on${type}`
+
+    if (typeof (this as any)[handlerName] === 'function') {
+      ;(this as any)[handlerName](event)
+    }
+
+    this.eventEmitter.emit(type, event)
+  }
+}
+
+/**
+ * This polyfill is only neccessary to support versions of node < 14.17.
+ * Can be removed once node 14 support is dropped.
+ */
+class AbortController {
+  signal = new AbortSignal()
+  abort() {
+    if (this.signal.aborted) return
+
+    this.signal.aborted = true
+    this.signal.dispatchEvent('abort')
+  }
+  toString() {
+    return '[object AbortController]'
+  }
+  get [Symbol.toStringTag]() {
+    return 'AbortController'
+  }
+}
+
+/**
+ * @param timeoutMs - Set a request timeout, after which the request is cancelled.
+ */
+export const abortSignalAfterTimeout = (timeoutMs: number) => {
+  const ac = new (global.AbortController || AbortController)()
+
+  const timeoutId = setTimeout(() => {
+    ac.abort()
+  }, timeoutMs)
+
+  // Allow Node.js processes to exit early if only the timeout is running
+  timeoutId?.unref?.()
+
+  return ac.signal
+}

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -180,9 +180,12 @@ export class Publisher {
       currentAttempt++
 
       let failureReason: unknown
+      const [signal, timeoutId] = abortSignalAfterTimeout(
+        this._httpRequestTimeout
+      )
       try {
         const response = await fetch(this._url, {
-          signal: abortSignalAfterTimeout(this._httpRequestTimeout),
+          signal: signal,
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -191,6 +194,7 @@ export class Publisher {
           },
           body: payload,
         })
+        clearTimeout(timeoutId)
 
         if (response.ok) {
           // Successfully sent events, so exit!

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,6 +1990,7 @@ __metadata:
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-core": 1.1.4
     "@types/node": ^14
+    nock: ^13.2.9
     node-fetch: ^2.6.7
     tslib: ^2.4.0
   languageName: unknown


### PR DESCRIPTION
Currently, the default timeout is set at 10 seconds (this number is arbitrary, IIRC some other SDK did it)

also: refactor tests to use nock.
