### PR TITLE
Emit Reset Events

### DIFF
--- a/.changeset/curvy-lamps-behave.md
+++ b/.changeset/curvy-lamps-behave.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Emit a `reset` event when analytics.reset() is called

--- a/packages/browser/src/core/analytics/__tests__/integration.test.ts
+++ b/packages/browser/src/core/analytics/__tests__/integration.test.ts
@@ -260,5 +260,15 @@ describe('Analytics', () => {
       storedData = getAjsBrowserStorage()
       expect(storedData).toEqual({})
     })
+
+    it('emits a reset event', async () => {
+      const analytics = new Analytics({ writeKey: '' })
+      const fn = jest.fn()
+      analytics.on('reset', fn)
+      analytics.user().id('known-user')
+
+      analytics.reset()
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -336,6 +336,7 @@ export class Analytics
   reset(): void {
     this._user.reset()
     this._group.reset()
+    this.emit('reset')
   }
 
   timeout(timeout: number): void {


### PR DESCRIPTION
* Emitting a `reset` event when user calls `analytics.reset()`. This allows for external code to hook into the reset events and do further logic. 

- [X] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).