### PR TITLE
Fix actions loading

### DIFF
--- a/.changeset/breezy-kids-clean.md
+++ b/.changeset/breezy-kids-clean.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fixes an issue impacting a small number of destinations where explicitly enabling or disabling an integration on load would not work as expected.

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -533,6 +533,167 @@ describe('Remote Loader', () => {
     )
   })
 
+  // Action destinations should be toggled using the `integration` name which matches the `creationName`
+  // Most action destinations have the same value for creationName and name, but a few (Amplitude) do not.
+  // Continue to support toggling with plugin.name for backwards compatibility.
+  it('loads destinations when `All: false` but is enabled (pluginName)', async () => {
+    const cdnSettings = {
+      integrations: {
+        oldValidName: {
+          versionSettings: {
+            componentTypes: [],
+          },
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'valid',
+          creationName: 'oldValidName',
+          url: 'cdn/path/to/file.js',
+          libraryName: 'testPlugin',
+          settings: {
+            subscriptions: [],
+            versionSettings: {
+              componentTypes: [],
+            },
+          },
+        },
+      ],
+    }
+
+    await AnalyticsBrowser.load(
+      { writeKey: '', cdnSettings },
+      {
+        integrations: {
+          All: false,
+          valid: true,
+        },
+      }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(1)
+    expect(pluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining(cdnSettings.remotePlugins[0].settings)
+    )
+  })
+
+  it('loads destinations when `All: false` but is enabled (creationName)', async () => {
+    const cdnSettings = {
+      integrations: {
+        oldValidName: {
+          versionSettings: {
+            componentTypes: [],
+          },
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'valid',
+          creationName: 'oldValidName',
+          url: 'cdn/path/to/file.js',
+          libraryName: 'testPlugin',
+          settings: {
+            subscriptions: [],
+            versionSettings: {
+              componentTypes: [],
+            },
+          },
+        },
+      ],
+    }
+
+    await AnalyticsBrowser.load(
+      { writeKey: '', cdnSettings },
+      {
+        integrations: {
+          All: false,
+          oldValidName: true,
+        },
+      }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(1)
+    expect(pluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining(cdnSettings.remotePlugins[0].settings)
+    )
+  })
+
+  it('does not load destinations when disabled via pluginName', async () => {
+    const cdnSettings = {
+      integrations: {
+        oldValidName: {
+          versionSettings: {
+            componentTypes: [],
+          },
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'valid',
+          creationName: 'oldValidName',
+          url: 'cdn/path/to/file.js',
+          libraryName: 'testPlugin',
+          settings: {
+            subscriptions: [],
+            versionSettings: {
+              componentTypes: [],
+            },
+          },
+        },
+      ],
+    }
+
+    await AnalyticsBrowser.load(
+      { writeKey: '', cdnSettings },
+      {
+        integrations: {
+          All: true,
+          valid: false,
+        },
+      }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(0)
+  })
+
+  it('does not load destinations when disabled via creationName', async () => {
+    const cdnSettings = {
+      integrations: {
+        oldValidName: {
+          versionSettings: {
+            componentTypes: [],
+          },
+        },
+      },
+      remotePlugins: [
+        {
+          name: 'valid',
+          creationName: 'oldValidName',
+          url: 'cdn/path/to/file.js',
+          libraryName: 'testPlugin',
+          settings: {
+            subscriptions: [],
+            versionSettings: {
+              componentTypes: [],
+            },
+          },
+        },
+      ],
+    }
+
+    await AnalyticsBrowser.load(
+      { writeKey: '', cdnSettings },
+      {
+        integrations: {
+          All: true,
+          oldValidName: false,
+        },
+      }
+    )
+
+    expect(pluginFactory).toHaveBeenCalledTimes(0)
+  })
+
   it('applies remote routing rules based on creation name', async () => {
     const validPlugin = {
       name: 'valid',

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -135,6 +135,26 @@ function validate(pluginLike: unknown): pluginLike is Plugin[] {
   return true
 }
 
+function isPluginDisabled(
+  userIntegrations: Integrations,
+  remotePlugin: RemotePlugin
+) {
+  const creationNameEnabled = userIntegrations[remotePlugin.creationName]
+  const currentNameEnabled = userIntegrations[remotePlugin.name]
+
+  if (
+    userIntegrations.All === false &&
+    !creationNameEnabled &&
+    !currentNameEnabled
+  ) {
+    return true
+  }
+  if (creationNameEnabled === false || currentNameEnabled === false) {
+    return true
+  }
+  return false
+}
+
 export async function remoteLoader(
   settings: LegacySettings,
   userIntegrations: Integrations,
@@ -149,12 +169,7 @@ export async function remoteLoader(
 
   const pluginPromises = (settings.remotePlugins ?? []).map(
     async (remotePlugin) => {
-      if (
-        (userIntegrations.All === false &&
-          !userIntegrations[remotePlugin.name]) ||
-        userIntegrations[remotePlugin.name] === false
-      )
-        return
+      if (isPluginDisabled(userIntegrations, remotePlugin)) return
       try {
         if (obfuscate) {
           const urlSplit = remotePlugin.url.split('/')

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -142,6 +142,7 @@ function isPluginDisabled(
   const creationNameEnabled = userIntegrations[remotePlugin.creationName]
   const currentNameEnabled = userIntegrations[remotePlugin.name]
 
+  // Check that the plugin isn't explicitly enabled when All: false
   if (
     userIntegrations.All === false &&
     !creationNameEnabled &&
@@ -149,9 +150,12 @@ function isPluginDisabled(
   ) {
     return true
   }
+
+  // Check that the plugin isn't explicitly disabled
   if (creationNameEnabled === false || currentNameEnabled === false) {
     return true
   }
+
   return false
 }
 


### PR DESCRIPTION
This PR fixes an issue that occurs when explicitly enabling/disabling action destinations.

A very small handful of action destinations have a different plugin name than their creation name. Amplitude is one of these.
Our current remote loader implementation only takes into account the plugin's name and not the creation name when deciding whether to load the destination.

That means there are 2 scenarios where loading Amplitude would not do the expected thing.
1. `analytics.load(writeKey, { integrations: { All: false, "Actions Amplitude": true }})`
With this scenario, all destinations are disabled by default and only if one is explicitly enabled will it be loaded. In this specific example, the plugin name is `Amplitude (Actions)` despite the integration (creationName) being `Actions Amplitude`. This mismatch caused the plugin to fail to load.

2. `analytics.load(writeKey, { integrations: { "Actions Amplitude": false }})`
With this scenario, the destination is explicitly disabled. However without these changes users would have had to specify `Amplitude (Actions)` instead.


[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).