### PR TITLE
improve Segment.io retries

### DIFF
--- a/.changeset/clean-lizards-nail.md
+++ b/.changeset/clean-lizards-nail.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Improves Segment.io retries to include exponential backoff and work across page loads.

--- a/packages/browser-integration-tests/package.json
+++ b/packages/browser-integration-tests/package.json
@@ -20,6 +20,7 @@
     "@playwright/test": "^1.28.1",
     "@segment/analytics-next": "workspace:^",
     "http-server": "14.1.1",
-    "nock": "^13.2.9"
+    "nock": "^13.2.9",
+    "tslib": "^2.4.1"
   }
 }

--- a/packages/browser-integration-tests/src/segment-retries.test.ts
+++ b/packages/browser-integration-tests/src/segment-retries.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { Request, test, expect } from '@playwright/test'
 import { SettingsBuilder } from './fixtures/settings'
 import { standaloneMock } from './helpers/standalone-mock'
 
@@ -25,9 +25,14 @@ test.describe('Standalone tests', () => {
       )
     })
 
-    test.skip('supports retries on page navigation', async ({ page }) => {
+    test('supports retrying failed requests on page navigation', async ({
+      page,
+    }) => {
       // Load analytics.js
       await page.goto('/standalone.html')
+      await page.evaluate(() =>
+        window.addEventListener('pagehide', () => console.log('hidden'))
+      )
       await page.evaluate(() => window.analytics.load('fake-key'))
 
       // fail the 1st request
@@ -50,6 +55,56 @@ test.describe('Standalone tests', () => {
       })
 
       await requestFailure
+      await page.reload()
+
+      // load analytics.js again and wait for a new request.
+      const [request] = await Promise.all([
+        page.waitForRequest('https://api.segment.io/v1/t'),
+        page.evaluate(() => window.analytics.load('fake-key')),
+      ])
+
+      expect(request.method()).toBe('POST')
+    })
+
+    test('supports retrying in-flight requests on page navigation', async ({
+      page,
+    }) => {
+      // Load analytics.js
+      await page.goto('/standalone.html')
+      await page.evaluate(() =>
+        window.addEventListener('pagehide', () => console.log('hidden'))
+      )
+      await page.evaluate(() => window.analytics.load('fake-key'))
+
+      // blackhole the request so that it stays in-flight when we reload the page
+      await page.route(
+        'https://api.segment.io/v1/t',
+        async () => {
+          // do nothing
+        },
+        {
+          times: 1,
+        }
+      )
+
+      // Detect when we've seen a track request initiated by the browser
+      const requestSent = new Promise<void>((resolve) => {
+        const onRequest: (req: Request) => void = (req) => {
+          if (req.url() === 'https://api.segment.io/v1/t') {
+            page.off('request', onRequest)
+            resolve()
+          }
+        }
+
+        page.on('request', onRequest)
+      })
+
+      // trigger an event
+      await page.evaluate(() => {
+        void window.analytics.track('test event')
+      })
+
+      await requestSent
       await page.reload()
 
       // load analytics.js again and wait for a new request.

--- a/packages/browser-integration-tests/src/segment-retries.test.ts
+++ b/packages/browser-integration-tests/src/segment-retries.test.ts
@@ -42,8 +42,8 @@ test.describe('Standalone tests', () => {
           times: 1,
         }
       )
-      const requestFailure = new Promise((resolve) => {
-        page.once('requestfailed', resolve)
+      const requestFailure = new Promise<Record<string, any>>((resolve) => {
+        page.once('requestfailed', (request) => resolve(request.postDataJSON()))
       })
 
       // trigger an event
@@ -51,7 +51,7 @@ test.describe('Standalone tests', () => {
         void window.analytics.track('test event')
       })
 
-      await requestFailure
+      const { messageId } = await requestFailure
       await page.reload()
 
       // load analytics.js again and wait for a new request.
@@ -61,6 +61,7 @@ test.describe('Standalone tests', () => {
       ])
 
       expect(request.method()).toBe('POST')
+      expect(request.postDataJSON().messageId).toBe(messageId)
     })
 
     test('supports retrying in-flight requests on page navigation', async ({
@@ -68,9 +69,6 @@ test.describe('Standalone tests', () => {
     }) => {
       // Load analytics.js
       await page.goto('/standalone.html')
-      await page.evaluate(() =>
-        window.addEventListener('pagehide', () => console.log('hidden'))
-      )
       await page.evaluate(() => window.analytics.load('fake-key'))
 
       // blackhole the request so that it stays in-flight when we reload the page
@@ -85,11 +83,11 @@ test.describe('Standalone tests', () => {
       )
 
       // Detect when we've seen a track request initiated by the browser
-      const requestSent = new Promise<void>((resolve) => {
+      const requestSent = new Promise<Record<string, any>>((resolve) => {
         const onRequest: (req: Request) => void = (req) => {
           if (req.url() === 'https://api.segment.io/v1/t') {
             page.off('request', onRequest)
-            resolve()
+            resolve(req.postDataJSON())
           }
         }
 
@@ -101,7 +99,7 @@ test.describe('Standalone tests', () => {
         void window.analytics.track('test event')
       })
 
-      await requestSent
+      const { messageId } = await requestSent
       await page.reload()
 
       // load analytics.js again and wait for a new request.
@@ -111,6 +109,7 @@ test.describe('Standalone tests', () => {
       ])
 
       expect(request.method()).toBe('POST')
+      expect(request.postDataJSON().messageId).toBe(messageId)
     })
   })
 })

--- a/packages/browser-integration-tests/src/segment-retries.test.ts
+++ b/packages/browser-integration-tests/src/segment-retries.test.ts
@@ -30,9 +30,6 @@ test.describe('Standalone tests', () => {
     }) => {
       // Load analytics.js
       await page.goto('/standalone.html')
-      await page.evaluate(() =>
-        window.addEventListener('pagehide', () => console.log('hidden'))
-      )
       await page.evaluate(() => window.analytics.load('fake-key'))
 
       // fail the 1st request

--- a/packages/browser-integration-tests/src/shims.d.ts
+++ b/packages/browser-integration-tests/src/shims.d.ts
@@ -1,0 +1,7 @@
+import type { AnalyticsSnippet } from '@segment/analytics-next'
+
+declare global {
+  interface Window {
+    analytics: AnalyticsSnippet
+  }
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -56,7 +56,7 @@
     "js-cookie": "3.0.1",
     "node-fetch": "^2.6.7",
     "spark-md5": "^3.0.1",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "unfetch": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/browser/src/lib/__tests__/on-page-leave.test.ts
+++ b/packages/browser/src/lib/__tests__/on-page-leave.test.ts
@@ -2,7 +2,8 @@ import { onPageLeave } from '../on-page-leave'
 
 const helpers = {
   dispatchEvent(event: 'pagehide' | 'visibilitychange') {
-    document.dispatchEvent(new Event(event))
+    const target = event === 'pagehide' ? window : document
+    target.dispatchEvent(new Event(event))
   },
   setVisibilityState(state: DocumentVisibilityState) {
     Object.defineProperty(document, 'visibilityState', {

--- a/packages/browser/src/lib/on-page-leave.ts
+++ b/packages/browser/src/lib/on-page-leave.ts
@@ -10,13 +10,13 @@
 export const onPageLeave = (cb: (...args: unknown[]) => void) => {
   let unloaded = false // prevents double firing if both are supported
 
-  // using document instead of window because of bug affecting browsers before safari 14 (detail in footnotes https://caniuse.com/?search=visibilitychange)
-  document.addEventListener('pagehide', () => {
+  window.addEventListener('pagehide', () => {
     if (unloaded) return
     unloaded = true
     cb()
   })
 
+  // using document instead of window because of bug affecting browsers before safari 14 (detail in footnotes https://caniuse.com/?search=visibilitychange)
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState == 'hidden') {
       if (unloaded) return

--- a/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
+++ b/packages/browser/src/lib/priority-queue/__tests__/persisted.test.ts
@@ -41,7 +41,7 @@ describe('Persisted Priority Queue', () => {
     let onUnload: any = jest.fn()
 
     jest
-      .spyOn(document, 'addEventListener')
+      .spyOn(window, 'addEventListener')
       .mockImplementation((evt, handler) => {
         if (evt === 'pagehide') {
           onUnload = handler
@@ -102,7 +102,7 @@ describe('Persisted Priority Queue', () => {
       let onUnload: any = jest.fn()
 
       jest
-        .spyOn(document, 'addEventListener')
+        .spyOn(window, 'addEventListener')
         .mockImplementation((evt, handler) => {
           if (evt === 'pagehide') {
             onUnload = handler
@@ -200,7 +200,7 @@ describe('Persisted Priority Queue', () => {
       const onUnloadFunctions: any[] = []
 
       jest
-        .spyOn(document, 'addEventListener')
+        .spyOn(window, 'addEventListener')
         .mockImplementation((evt, handler) => {
           if (evt === 'pagehide') {
             onUnloadFunctions.push(handler)

--- a/packages/browser/src/lib/priority-queue/persisted.ts
+++ b/packages/browser/src/lib/priority-queue/persisted.ts
@@ -109,7 +109,7 @@ export class PersistedPriorityQueue extends PriorityQueue<Context> {
       }
     })
 
-    document.addEventListener('pagehide', () => {
+    window.addEventListener('pagehide', () => {
       // we deliberately want to use the less powerful 'pagehide' API to only persist on events where the analytics instance gets destroyed, and not on tab away.
       if (this.todo > 0) {
         const items = [...this.queue, ...this.future]

--- a/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
@@ -224,7 +224,7 @@ describe('Batching', () => {
 
       expect(fetch).not.toHaveBeenCalled()
 
-      document.dispatchEvent(new Event('pagehide'))
+      window.dispatchEvent(new Event('pagehide'))
 
       expect(fetch).toHaveBeenCalledTimes(1)
 
@@ -253,7 +253,7 @@ describe('Batching', () => {
 
       expect(fetch).not.toHaveBeenCalled()
 
-      document.dispatchEvent(new Event('pagehide'))
+      window.dispatchEvent(new Event('pagehide'))
 
       expect(fetch).toHaveBeenCalledTimes(2)
     })

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -103,12 +103,10 @@ export function segmentio(
         normalize(analytics, json, settings, integrations)
       )
       .then(() => ctx)
-      .catch((err) => {
-        if (err.type === 'error' || err.message === 'Failed to fetch') {
-          buffer.pushWithBackoff(ctx)
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          scheduleFlush(flushing, buffer, segmentio, scheduleFlush)
-        }
+      .catch(() => {
+        buffer.pushWithBackoff(ctx)
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        scheduleFlush(flushing, buffer, segmentio, scheduleFlush)
         return ctx
       })
       .finally(() => {

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -50,12 +50,21 @@ export function segmentio(
   settings?: SegmentioSettings,
   integrations?: LegacySettings['integrations']
 ): Plugin {
+  // Attach `pagehide` before buffer is created so that inflight events are added
+  // to the buffer before the buffer persists events in its own `pagehide` handler.
+  window.addEventListener('pagehide', () => {
+    buffer.push(...Array.from(inflightEvents))
+    inflightEvents.clear()
+  })
+
   const buffer = analytics.options.disableClientPersistence
     ? new PriorityQueue<Context>(analytics.queue.queue.maxAttempts, [])
     : new PersistedPriorityQueue(
         analytics.queue.queue.maxAttempts,
         `dest-Segment.io`
       )
+
+  const inflightEvents = new Set<Context>()
   const flushing = false
 
   const apiHost = settings?.apiHost ?? 'api.segment.io/v1'
@@ -74,6 +83,8 @@ export function segmentio(
       scheduleFlush(flushing, buffer, segmentio, scheduleFlush)
       return ctx
     }
+
+    inflightEvents.add(ctx)
 
     const path = ctx.event.type.charAt(0)
     let json = toFacade(ctx.event).json()
@@ -94,11 +105,14 @@ export function segmentio(
       .then(() => ctx)
       .catch((err) => {
         if (err.type === 'error' || err.message === 'Failed to fetch') {
-          buffer.push(ctx)
+          buffer.pushWithBackoff(ctx)
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           scheduleFlush(flushing, buffer, segmentio, scheduleFlush)
         }
         return ctx
+      })
+      .finally(() => {
+        inflightEvents.delete(ctx)
       })
   }
 
@@ -113,6 +127,12 @@ export function segmentio(
     page: send,
     alias: send,
     group: send,
+  }
+
+  // Buffer may already have items if they were previously stored in localStorage.
+  // Start flushing them immediately.
+  if (buffer.todo) {
+    scheduleFlush(flushing, buffer, segmentio, scheduleFlush)
   }
 
   return segmentio

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,6 @@
   "dependencies": {
     "@lukeed/uuid": "^2.0.0",
     "dset": "^3.1.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,7 +36,7 @@
     "@lukeed/uuid": "^2.0.0",
     "@segment/analytics-core": "1.1.5",
     "node-fetch": "^2.6.7",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@internal/config": "0.0.0",

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -19,7 +19,7 @@
     "concurrently": "yarn run -T concurrently"
   },
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,6 +1194,7 @@ __metadata:
     "@segment/analytics-next": "workspace:^"
     http-server: 14.1.1
     nock: ^13.2.9
+    tslib: ^2.4.1
   languageName: unknown
   linkType: soft
 
@@ -13792,6 +13793,13 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "tslib@npm:2.4.1"
+  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,7 +1233,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/test-helpers@workspace:packages/test-helpers"
   dependencies:
-    tslib: ^2.4.0
+    tslib: ^2.4.1
   languageName: unknown
   linkType: soft
 
@@ -1946,7 +1946,7 @@ __metadata:
   dependencies:
     "@lukeed/uuid": ^2.0.0
     dset: ^3.1.2
-    tslib: ^2.4.0
+    tslib: ^2.4.1
   languageName: unknown
   linkType: soft
 
@@ -2000,7 +2000,7 @@ __metadata:
     terser-webpack-plugin: ^5.1.4
     ts-loader: ^9.1.1
     ts-node: ^10.8.0
-    tslib: ^2.4.0
+    tslib: ^2.4.1
     unfetch: ^4.1.0
     webpack: ^5.36.1
     webpack-bundle-analyzer: ^4.4.2
@@ -2017,7 +2017,7 @@ __metadata:
     "@segment/analytics-core": 1.1.5
     "@types/node": ^14
     node-fetch: ^2.6.7
-    tslib: ^2.4.0
+    tslib: ^2.4.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR improves retry handling for the `Segment.io` plugin. It also fixes an issue where `PersistedPriorityQueue` was no longer storing events in `localStorage` on `pagehide`.

### Fix `PersistedPriorityQueue`

The PersistedPriorityQueue listens for the `pagehide` event then stores all of its events in localStorage. Currently, it listens for the `pagehide` event to be emitted on `document`, but `pagehide` is a `Window` event. This caused the queue to stop working with `pagehide`.

### Apply backoff to segment retries

Currently, when fetch errors are encountered events are pushed back onto the buffer via `buffer.push(ctx)`. This does not apply any backoff, so this is updated to `buffer.pushWithBackoff(ctx)`. This causes the event to be part of the buffer's `todo` length. The `schedule-flush` function already checks `buffer.todo > 0`, so we're covered here.

### Store canceled events

In the scenario where the user navigates away from the page between while there are pending HTTP requests, those events are not currently persisted in localStorage. This change keeps track of events that are 'in-flight' and adds them to the persisted priority queue. 

## Testing

I was able to add tests for this using playwright. Also tested manually with Chrome and Firefox.

[x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).