### PR TITLE
Help analytics-node work with other runtimes

### DIFF
--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -16,10 +16,7 @@ const snapshotMatchers = {
           version: expect.any(String),
         },
       },
-
-      _metadata: {
-        nodeVersion: expect.any(String),
-      },
+      _metadata: expect.any(Object),
       timestamp: expect.any(String),
     }
   },
@@ -37,6 +34,32 @@ describe('Method Smoke Tests', () => {
   let ajs: Analytics
   beforeEach(async () => {
     ajs = createTestAnalytics()
+  })
+
+  describe('Metadata', () => {
+    const calls: any[] = []
+    beforeEach(async () => {
+      scope = nock('https://api.segment.io') // using regex matching in nock changes the perf profile quite a bit
+        .post('/v1/batch', function (_body: any) {
+          calls.push(_body)
+          return true
+        })
+        .reply(201)
+    })
+
+    it('should show appropriate metadata', async () => {
+      ajs.identify({ userId: 'my_user_id', traits: { foo: 'bar' } })
+      await resolveCtx(ajs, 'identify')
+      expect(calls[0].batch[0]._metadata).toMatchInlineSnapshot(
+        { nodeVersion: expect.any(String), runtime: 'node' },
+        `
+        Object {
+          "nodeVersion": Any<String>,
+          "runtime": "node",
+        }
+      `
+      )
+    })
   })
 
   describe('Headers', () => {
@@ -108,30 +131,28 @@ describe('Method Smoke Tests', () => {
       expect(calls[0]).toMatchInlineSnapshot(
         snapshotMatchers.defaultReqBody,
         `
-              Object {
-                "batch": Array [
-                  Object {
-                    "_metadata": Object {
-                      "nodeVersion": Any<String>,
-                    },
-                    "context": Object {
-                      "library": Object {
-                        "name": "AnalyticsNode",
-                        "version": Any<String>,
-                      },
-                    },
-                    "integrations": Object {},
-                    "messageId": Any<String>,
-                    "timestamp": Any<String>,
-                    "traits": Object {
-                      "foo": "bar",
-                    },
-                    "type": "identify",
-                    "userId": "my_user_id",
-                  },
-                ],
-              }
-          `
+        Object {
+          "batch": Array [
+            Object {
+              "_metadata": Any<Object>,
+              "context": Object {
+                "library": Object {
+                  "name": "AnalyticsNode",
+                  "version": Any<String>,
+                },
+              },
+              "integrations": Object {},
+              "messageId": Any<String>,
+              "timestamp": Any<String>,
+              "traits": Object {
+                "foo": "bar",
+              },
+              "type": "identify",
+              "userId": "my_user_id",
+            },
+          ],
+        }
+      `
       )
 
       const event = calls[0].batch[0]
@@ -148,9 +169,7 @@ describe('Method Smoke Tests', () => {
         Object {
           "batch": Array [
             Object {
-              "_metadata": Object {
-                "nodeVersion": Any<String>,
-              },
+              "_metadata": Any<Object>,
               "context": Object {
                 "library": Object {
                   "name": "AnalyticsNode",
@@ -182,9 +201,7 @@ describe('Method Smoke Tests', () => {
         Object {
           "batch": Array [
             Object {
-              "_metadata": Object {
-                "nodeVersion": Any<String>,
-              },
+              "_metadata": Any<Object>,
               "anonymousId": "foo",
               "context": Object {
                 "library": Object {
@@ -218,9 +235,7 @@ describe('Method Smoke Tests', () => {
         Object {
           "batch": Array [
             Object {
-              "_metadata": Object {
-                "nodeVersion": Any<String>,
-              },
+              "_metadata": Any<Object>,
               "anonymousId": "foo",
               "context": Object {
                 "library": Object {
@@ -252,9 +267,7 @@ describe('Method Smoke Tests', () => {
         Object {
           "batch": Array [
             Object {
-              "_metadata": Object {
-                "nodeVersion": Any<String>,
-              },
+              "_metadata": Any<Object>,
               "context": Object {
                 "library": Object {
                   "name": "AnalyticsNode",
@@ -287,9 +300,7 @@ describe('Method Smoke Tests', () => {
         Object {
           "batch": Array [
             Object {
-              "_metadata": Object {
-                "nodeVersion": Any<String>,
-              },
+              "_metadata": Any<Object>,
               "anonymousId": "foo",
               "context": Object {
                 "library": Object {

--- a/packages/node/src/lib/__tests__/env.test.ts
+++ b/packages/node/src/lib/__tests__/env.test.ts
@@ -15,9 +15,7 @@ describe(detectRuntime, () => {
     globalThis.WorkerGlobalScope = {}
     // @ts-ignore
     globalThis.importScripts = () => {}
-    expect(detectRuntime()).toEqual<RuntimeEnv>({
-      type: 'web-worker',
-    })
+    expect(detectRuntime()).toEqual<RuntimeEnv>('web-worker')
   })
   it('should return browser if correct env', () => {
     // @ts-ignore
@@ -25,17 +23,12 @@ describe(detectRuntime, () => {
     delete process.env
     // @ts-ignore
     globalThis.window = {}
-    expect(detectRuntime()).toEqual<RuntimeEnv>({
-      type: 'browser',
-    })
+    expect(detectRuntime()).toEqual<RuntimeEnv>('browser')
   })
   it('should return node if correct env', () => {
     // @ts-ignore
     // eslint-disable-next-line
-    process = { versions: { node: '123' }, env: {} }
-    expect(detectRuntime()).toEqual<RuntimeEnv>({
-      type: 'node',
-      version: '123',
-    })
+    process = { env: {} }
+    expect(detectRuntime()).toEqual<RuntimeEnv>('node')
   })
 })

--- a/packages/node/src/lib/__tests__/env.test.ts
+++ b/packages/node/src/lib/__tests__/env.test.ts
@@ -1,0 +1,41 @@
+import { detectRuntime, RuntimeEnv } from '../env'
+
+const ogProcess = { ...process.env }
+afterEach(() => {
+  process.env = ogProcess
+  // @ts-ignore
+  delete globalThis.window
+})
+describe(detectRuntime, () => {
+  it('should return web worker if correct env', () => {
+    // @ts-ignore
+    // eslint-disable-next-line
+    delete process.env
+    // @ts-ignore
+    globalThis.WorkerGlobalScope = {}
+    // @ts-ignore
+    globalThis.importScripts = () => {}
+    expect(detectRuntime()).toEqual<RuntimeEnv>({
+      type: 'web-worker',
+    })
+  })
+  it('should return browser if correct env', () => {
+    // @ts-ignore
+    // eslint-disable-next-line
+    delete process.env
+    // @ts-ignore
+    globalThis.window = {}
+    expect(detectRuntime()).toEqual<RuntimeEnv>({
+      type: 'browser',
+    })
+  })
+  it('should return node if correct env', () => {
+    // @ts-ignore
+    // eslint-disable-next-line
+    process = { versions: { node: '123' }, env: {} }
+    expect(detectRuntime()).toEqual<RuntimeEnv>({
+      type: 'node',
+      version: '123',
+    })
+  })
+})

--- a/packages/node/src/lib/env.ts
+++ b/packages/node/src/lib/env.ts
@@ -1,0 +1,25 @@
+export interface RuntimeEnv {
+  type: 'node' | 'browser' | 'web-worker' | 'unknown'
+  version?: string
+}
+
+export const detectRuntime = (): RuntimeEnv => {
+  if (typeof process?.env === 'object') {
+    return { type: 'node', version: process.versions?.node || 'unknown' }
+  }
+
+  if (typeof window === 'object') {
+    return { type: 'browser' }
+  }
+
+  if (
+    // @ts-ignore
+    typeof WorkerGlobalScope !== 'undefined' && // this may sometimes be available in a CF worker, so check for importScripts
+    // @ts-ignore
+    typeof importScripts === 'function'
+  ) {
+    return { type: 'web-worker' }
+  }
+
+  return { type: 'unknown' }
+}

--- a/packages/node/src/lib/env.ts
+++ b/packages/node/src/lib/env.ts
@@ -1,15 +1,12 @@
-export interface RuntimeEnv {
-  type: 'node' | 'browser' | 'web-worker' | 'unknown'
-  version?: string
-}
+export type RuntimeEnv = 'node' | 'browser' | 'web-worker' | 'unknown'
 
 export const detectRuntime = (): RuntimeEnv => {
   if (typeof process?.env === 'object') {
-    return { type: 'node', version: process.versions?.node || 'unknown' }
+    return 'node'
   }
 
   if (typeof window === 'object') {
-    return { type: 'browser' }
+    return 'browser'
   }
 
   if (
@@ -18,8 +15,8 @@ export const detectRuntime = (): RuntimeEnv => {
     // @ts-ignore
     typeof importScripts === 'function'
   ) {
-    return { type: 'web-worker' }
+    return 'web-worker'
   }
 
-  return { type: 'unknown' }
+  return 'unknown'
 }

--- a/packages/node/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/index.test.ts
@@ -18,9 +18,7 @@ const bodyPropertyMatchers = {
   timestamp: expect.stringMatching(
     /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
   ),
-  _metadata: {
-    nodeVersion: expect.any(String),
-  },
+  _metadata: expect.any(Object),
   context: {
     library: {
       name: 'AnalyticsNode',

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -7,10 +7,10 @@ function normalizeEvent(ctx: CoreContext) {
   ctx.updateEvent('context.library.name', 'AnalyticsNode')
   ctx.updateEvent('context.library.version', version)
   const runtime = detectRuntime()
-  if (runtime.type === 'node') {
-    ctx.updateEvent('_metadata.nodeVersion', runtime.version)
+  if (runtime === 'node') {
+    ctx.updateEvent('_metadata.nodeVersion', process.versions.node)
   }
-  ctx.updateEvent('_metadata.runtime', runtime.type)
+  ctx.updateEvent('_metadata.runtime', runtime)
 }
 
 type DefinedPluginFields =

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -1,11 +1,16 @@
 import { CoreContext, CorePlugin } from '@segment/analytics-core'
 import { Publisher, PublisherProps } from './publisher'
 import { version } from '../../../package.json'
+import { detectRuntime } from '../../lib/env'
 
 function normalizeEvent(ctx: CoreContext) {
   ctx.updateEvent('context.library.name', 'AnalyticsNode')
   ctx.updateEvent('context.library.version', version)
-  ctx.updateEvent('_metadata.nodeVersion', process.versions.node)
+  const runtime = detectRuntime()
+  if (runtime.type === 'node') {
+    ctx.updateEvent('_metadata.nodeVersion', runtime.version)
+  }
+  ctx.updateEvent('_metadata.runtime', runtime.type)
 }
 
 type DefinedPluginFields =


### PR DESCRIPTION
- removed dependency on process.env.
- added a _metadata.runtime field.
