### PR TITLE
Exposing Universal Storage on the Analytics object rather than passing it directly to plugins

### DIFF
--- a/.changeset/small-mails-chew.md
+++ b/.changeset/small-mails-chew.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Expose universal storage directly on analytics object

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,9 +24,9 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,5 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
 }

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -15,11 +15,8 @@ import * as SegmentPlugin from '../../plugins/segmentio'
 import jar from 'js-cookie'
 import { PriorityQueue } from '../../lib/priority-queue'
 import { getCDN, setGlobalCDNUrl } from '../../lib/parse-cdn'
-import { UniversalStorage } from '../../core/user'
 import { clearAjsBrowserStorage } from '../../test-helpers/browser-storage'
 import { ActionDestination } from '@/plugins/remote-loader'
-
-const storage = {} as UniversalStorage
 
 let fetchCalls: Array<any>[] = []
 
@@ -882,8 +879,7 @@ describe('retries', () => {
           throw new Error('aaay')
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     // Dispatching an event will push it into the priority queue.
@@ -911,8 +907,7 @@ describe('retries', () => {
         ready: () => Promise.resolve(true),
         track: (ctx) => ctx,
       },
-      ajs,
-      storage
+      ajs
     )
 
     // @ts-ignore ignore reassining function

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -134,9 +134,7 @@ export class Analytics
       queue ?? createDefaultQueue(options?.retryQueue, disablePersistance)
 
     this._universalStorage = new UniversalStorage(
-      disablePersistance !== false
-        ? ['localStorage', 'cookie', 'memory']
-        : ['memory'],
+      disablePersistance ? ['memory'] : ['localStorage', 'cookie', 'memory'],
       getAvailableStorageOptions(cookieOptions)
     )
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -167,6 +167,10 @@ export class Analytics
     return this._user
   }
 
+  storage(): UniversalStorage {
+    return this._universalStorage
+  }
+
   async track(...args: EventParams): Promise<DispatchedEvent> {
     const [name, data, opts, cb] = resolveArguments(...args)
 
@@ -322,7 +326,7 @@ export class Analytics
     const ctx = Context.system()
 
     const registrations = plugins.map((xt) =>
-      this.queue.register(ctx, xt, this, this._universalStorage)
+      this.queue.register(ctx, xt, this)
     )
     await Promise.all(registrations)
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -167,7 +167,7 @@ export class Analytics
     return this._user
   }
 
-  storage(): UniversalStorage {
+  get storage(): UniversalStorage {
     return this._universalStorage
   }
 

--- a/packages/browser/src/core/plugin/index.ts
+++ b/packages/browser/src/core/plugin/index.ts
@@ -1,12 +1,10 @@
 import { Analytics } from '../analytics'
 import { Context } from '../context'
-import { UniversalStorage } from '../user'
 
 interface PluginConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options?: any
   priority?: 'critical' | 'non-critical' // whether AJS should expect this plugin to be loaded before starting event delivery
-  storage?: UniversalStorage
 }
 
 // enrichment - modifies the event. Enrichment can happen in parallel, by reducing all changes in the final event. Failures in this stage could halt event delivery.

--- a/packages/browser/src/core/queue/__tests__/event-queue.test.ts
+++ b/packages/browser/src/core/queue/__tests__/event-queue.test.ts
@@ -12,9 +12,6 @@ import { Plugin } from '../../plugin'
 import { EventQueue } from '../event-queue'
 import { pTimeout } from '../../callback'
 import { ActionDestination } from '../../../plugins/remote-loader'
-import { UniversalStorage } from '../../user'
-
-const storage = {} as UniversalStorage
 
 async function flushAll(eq: EventQueue): Promise<Context[]> {
   const flushSpy = jest.spyOn(eq, 'flush')
@@ -152,8 +149,7 @@ describe('Flushing', () => {
           return Promise.resolve(ctx)
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     eq.dispatch(fruitBasket)
@@ -223,8 +219,7 @@ describe('Flushing', () => {
           return Promise.resolve(ctx)
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     eq.dispatch(fruitBasket)
@@ -262,8 +257,7 @@ describe('Flushing', () => {
           return ctx
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const dispatches = [
@@ -300,8 +294,7 @@ describe('Flushing', () => {
           return ctx
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const context = await eq.dispatchSingle(fruitBasket)
@@ -328,8 +321,7 @@ describe('Flushing', () => {
           return Promise.resolve(ctx)
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     eq.dispatch(fruitBasket)
@@ -370,8 +362,7 @@ describe('Flushing', () => {
           return Promise.resolve(ctx)
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const fruitBasketDelivery = eq.dispatch(fruitBasket)
@@ -438,9 +429,9 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -471,9 +462,9 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -505,9 +496,9 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -539,9 +530,9 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -572,9 +563,9 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -607,8 +598,8 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -641,8 +632,8 @@ describe('Flushing', () => {
 
       const ctx = new Context(evt)
 
-      await eq.register(Context.system(), fullstory, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), fullstory, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
 
       eq.dispatch(ctx)
 
@@ -672,9 +663,9 @@ describe('Flushing', () => {
       }
 
       const ctx = new Context(evt)
-      await eq.register(Context.system(), amplitude, ajs, storage)
-      await eq.register(Context.system(), mixPanel, ajs, storage)
-      await eq.register(Context.system(), segmentio, ajs, storage)
+      await eq.register(Context.system(), amplitude, ajs)
+      await eq.register(Context.system(), mixPanel, ajs)
+      await eq.register(Context.system(), segmentio, ajs)
       await eq.dispatch(ctx)
 
       const skipAmplitudeAndSegment: MiddlewareFunction = ({
@@ -693,8 +684,7 @@ describe('Flushing', () => {
       await eq.register(
         Context.system(),
         sourceMiddlewarePlugin(skipAmplitudeAndSegment, {}),
-        ajs,
-        storage
+        ajs
       )
 
       await eq.dispatch(ctx)
@@ -712,9 +702,7 @@ describe('deregister', () => {
     const toBeRemoved = { ...testPlugin, name: 'remove-me' }
     const plugins = [testPlugin, toBeRemoved]
 
-    const promises = plugins.map((p) =>
-      eq.register(Context.system(), p, ajs, storage)
-    )
+    const promises = plugins.map((p) => eq.register(Context.system(), p, ajs))
     await Promise.all(promises)
 
     await eq.deregister(Context.system(), toBeRemoved, ajs)
@@ -727,9 +715,7 @@ describe('deregister', () => {
     const toBeRemoved = { ...testPlugin, name: 'remove-me', unload: jest.fn() }
     const plugins = [testPlugin, toBeRemoved]
 
-    const promises = plugins.map((p) =>
-      eq.register(Context.system(), p, ajs, storage)
-    )
+    const promises = plugins.map((p) => eq.register(Context.system(), p, ajs))
     await Promise.all(promises)
 
     await eq.deregister(Context.system(), toBeRemoved, ajs)
@@ -792,8 +778,7 @@ describe('dispatchSingle', () => {
           return Promise.resolve(ctx)
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     expect(eq.queue.length).toBe(0)

--- a/packages/browser/src/core/queue/__tests__/extension-flushing.test.ts
+++ b/packages/browser/src/core/queue/__tests__/extension-flushing.test.ts
@@ -4,7 +4,6 @@ import { PriorityQueue } from '../../../lib/priority-queue'
 import { Context } from '../../context'
 import { Plugin } from '../../plugin'
 import { EventQueue } from '../event-queue'
-import { UniversalStorage } from '../../user'
 
 const fruitBasket = new Context({
   type: 'track',
@@ -25,7 +24,6 @@ const testPlugin: Plugin = {
 }
 
 const ajs = {} as Analytics
-const storage = {} as UniversalStorage
 
 describe('Registration', () => {
   test('can register plugins', async () => {
@@ -41,9 +39,9 @@ describe('Registration', () => {
     }
 
     const ctx = Context.system()
-    await eq.register(ctx, plugin, ajs, storage)
+    await eq.register(ctx, plugin, ajs)
 
-    expect(load).toHaveBeenCalledWith(ctx, ajs, { storage })
+    expect(load).toHaveBeenCalledWith(ctx, ajs)
   })
 
   test('fails if plugin cant be loaded', async () => {
@@ -59,7 +57,7 @@ describe('Registration', () => {
 
     const ctx = Context.system()
     await expect(
-      eq.register(ctx, plugin, ajs, storage)
+      eq.register(ctx, plugin, ajs)
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"👻"`)
   })
 
@@ -75,7 +73,7 @@ describe('Registration', () => {
     }
 
     const ctx = Context.system()
-    await eq.register(ctx, plugin, ajs, storage)
+    await eq.register(ctx, plugin, ajs)
 
     expect(ctx.logs()[0].level).toEqual('warn')
     expect(ctx.logs()[0].message).toEqual('Failed to load destination')
@@ -95,8 +93,7 @@ describe('Plugin flushing', () => {
         ...testPlugin,
         type: 'before',
       },
-      ajs,
-      storage
+      ajs
     )
 
     const flushed = await eq.dispatch(fruitBasket)
@@ -112,8 +109,7 @@ describe('Plugin flushing', () => {
           throw new Error('aaay')
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const failedFlush: Context = await eq
@@ -141,8 +137,7 @@ describe('Plugin flushing', () => {
           throw new Error('aaay')
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const flushed = await eq.dispatch(
@@ -173,8 +168,8 @@ describe('Plugin flushing', () => {
       type: 'destination',
     }
 
-    await eq.register(Context.system(), amplitude, ajs, storage)
-    await eq.register(Context.system(), fullstory, ajs, storage)
+    await eq.register(Context.system(), amplitude, ajs)
+    await eq.register(Context.system(), fullstory, ajs)
 
     const flushed = await eq.dispatch(
       new Context({
@@ -239,8 +234,8 @@ describe('Plugin flushing', () => {
       type: 'after',
     }
 
-    await eq.register(Context.system(), afterFailed, ajs, storage)
-    await eq.register(Context.system(), after, ajs, storage)
+    await eq.register(Context.system(), afterFailed, ajs)
+    await eq.register(Context.system(), after, ajs)
 
     const flushed = await eq.dispatch(
       new Context({
@@ -300,8 +295,7 @@ describe('Plugin flushing', () => {
           return ctx
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     await eq.register(
@@ -315,8 +309,7 @@ describe('Plugin flushing', () => {
           return ctx
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     await eq.register(
@@ -330,8 +323,7 @@ describe('Plugin flushing', () => {
           return ctx
         },
       },
-      ajs,
-      storage
+      ajs
     )
 
     const flushed = await eq.dispatch(
@@ -400,7 +392,7 @@ describe('Plugin flushing', () => {
     // shuffle plugins so we can verify order
     const plugins = shuffle([before, enrichment, enrichmentTwo, destination])
     for (const xt of plugins) {
-      await eq.register(Context.system(), xt, ajs, storage)
+      await eq.register(Context.system(), xt, ajs)
     }
 
     await eq.dispatch(

--- a/packages/browser/src/core/queue/event-queue.ts
+++ b/packages/browser/src/core/queue/event-queue.ts
@@ -9,7 +9,6 @@ import { Integrations, JSONObject } from '../events'
 import { Plugin } from '../plugin'
 import { createTaskGroup, TaskGroup } from '../task/task-group'
 import { attempt, ensure } from './delivery'
-import { UniversalStorage } from '../user'
 
 type PluginsByType = {
   before: Plugin[]
@@ -43,10 +42,9 @@ export class EventQueue extends Emitter {
   async register(
     ctx: Context,
     plugin: Plugin,
-    instance: Analytics,
-    storage: UniversalStorage
+    instance: Analytics
   ): Promise<void> {
-    await Promise.resolve(plugin.load(ctx, instance, { storage }))
+    await Promise.resolve(plugin.load(ctx, instance))
       .then(() => {
         this.plugins.push(plugin)
       })


### PR DESCRIPTION
I think the old style where we pass down the storage as an argument to each plugin wasn't elegant. Exposing it via the analytics object have few benefits: 
- We don't have to change the way we register plugins
- We don't have to make changes to action destination runtime to pass storage as a new parameter, and hence changing docs, etc. 
- Makes storage more accessible for future use  

[] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).