### PR TITLE
node: improve typescript error messages for parameters

### DIFF
--- a/packages/node/src/app/types/params.ts
+++ b/packages/node/src/app/types/params.ts
@@ -39,21 +39,21 @@ export type AliasParams = {
   integrations?: Integrations
 }
 
-export type GroupParams = IdentityOptions & {
+export type GroupParams = {
   groupId: string
   traits?: Traits
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
-}
+} & IdentityOptions
 
-export type IdentifyParams = IdentityOptions & {
+export type IdentifyParams = {
   traits?: Traits
   context?: ExtraContext
   integrations?: Integrations
-}
+} & IdentityOptions
 
-export type PageParams = IdentityOptions & {
+export type PageParams = {
   /*  The category of the page. Useful for cases like ecommerce where many pages might live under a single category. */
   category?: string
   /* The name of the page.*/
@@ -63,12 +63,12 @@ export type PageParams = IdentityOptions & {
   timestamp?: Timestamp
   context?: ExtraContext
   integrations?: Integrations
-}
+} & IdentityOptions
 
-export type TrackParams = IdentityOptions & {
+export type TrackParams = {
   event: string
   properties?: EventProperties
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
-}
+} & IdentityOptions


### PR DESCRIPTION
Currently, the typescript error is misleading 
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/5115498/207789799-728e3981-6a5a-4a6b-a561-933e009de86a.png">


By switching the order of the intersection, the typescript error is correct.
![image](https://user-images.githubusercontent.com/5115498/207789814-cf4b3d26-f003-429a-bf3d-8ce773bae7e5.png)


