### PR TITLE
Add / improve offline integration tests

### DIFF
--- a/packages/browser/src/test-helpers/fetch-parse.ts
+++ b/packages/browser/src/test-helpers/fetch-parse.ts
@@ -1,0 +1,8 @@
+export type FetchCall = [input: RequestInfo, init?: RequestInit | undefined]
+
+export const parseFetchCall = ([url, request]: FetchCall) => ({
+  url,
+  method: request?.method,
+  headers: request?.headers,
+  body: request?.body ? JSON.parse(request.body as any) : undefined,
+})


### PR DESCRIPTION
I had to removed a couple offline tests in the previous large refactoring PR since the event queue is no longer responsible for that logic. I'm adding those scenarios back in integration.