### PR TITLE
Check that window variable is available before using it to detect cookies

### DIFF
--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -63,7 +63,10 @@ const ONE_YEAR = 365
 
 export class Cookie extends Store {
   static available(): boolean {
-    let cookieEnabled = window && window.navigator.cookieEnabled
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    let cookieEnabled = window.navigator.cookieEnabled
 
     if (!cookieEnabled) {
       jar.set('ajs:cookies', 'test')

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -63,7 +63,7 @@ const ONE_YEAR = 365
 
 export class Cookie extends Store {
   static available(): boolean {
-    let cookieEnabled = window.navigator.cookieEnabled
+    let cookieEnabled = window && window.navigator.cookieEnabled
 
     if (!cookieEnabled) {
       jar.set('ajs:cookies', 'test')


### PR DESCRIPTION
Version 1.48.0 introduces a breaking change that did not exist in 1.47.0. It assumes that the window variable is available and uses it to access `window.navigator.cookieEnabled` to determine whether the cookie storage mechanism exists. However, on environments that do not have the window variable (like node), this causes it to crash, causing issues such as https://github.com/segmentio/analytics-next/issues/735. A minor version upgrade IMHO should not break existing implementations (which used to be part of the readme) or require people to refactor their codebase to import a different package (which also has slightly different method signatures, so it's not a search-and-replace refactor).

This PR attempts to fix the specific breakage by checking the existence of the window variable in `Cookie.available()` method and assuming that cookies are disabled if it does not exist.