### PR TITLE
fix: fetch-dispatcher to set fetch within dispatch

### DIFF
--- a/packages/browser/src/plugins/segmentio/fetch-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/fetch-dispatcher.ts
@@ -1,14 +1,13 @@
 import unfetch from 'unfetch'
 
-let fetch = unfetch
-if (typeof window !== 'undefined') {
-  fetch = window.fetch || unfetch
-}
-
 export type Dispatcher = (url: string, body: object) => Promise<unknown>
 
 export default function (): { dispatch: Dispatcher } {
   function dispatch(url: string, body: object): Promise<unknown> {
+    let fetch = unfetch
+    if (typeof window !== 'undefined') {
+      fetch = window.fetch || unfetch
+    }
     return fetch(url, {
       headers: { 'Content-Type': 'text/plain' },
       method: 'post',


### PR DESCRIPTION
The purpose of this PR is to make our tracking testable by webdriverio. 
With the fix, it is able to report on the Segment network calls.

[0-0] Number of network requests at firstpagecall = 9
[0-0] https://segment.intuitcdn.net/v1/projects/NSfYSMcSLpa4rH2wm2VxshxHRk3hJQE8/settings
[0-0] https://eventbus-e2e.intuit.com/v2/segment/sbseg-qbo-clickstream/p

and we are able to verify that all the properties are getting populated correctly in our application, like the extract below. 
[0-0] {
[0-0]     "timestamp": "2022-12-29T08:34:40.840Z",
[0-0]     "integrations": {
[0-0]         "Adobe Analytics": {
[0-0]             "marketingCloudVisitorId": "16444118304720754581986161952403509320",
[0-0]             "imsregion": 9
[0-0]         }
[0-0]     },
[0-0]     "anonymousId": "08c030f2-545c-4cff-86a3-d2ea3432a4e8",
[0-0]     "type": "page",
[0-0]     "properties": {
[0-0]         "path": "/trackstar-test.html",

This is an internal change, so no change-set created, per contribution guidelines
