### PR TITLE
remove remote metrics from context, move to stats

### DIFF
--- a/.changeset/pink-insects-appear.md
+++ b/.changeset/pink-insects-appear.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Remove remote metrics from context and move to stats

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -25,6 +25,7 @@ import {
 import { popSnippetWindowBuffer } from '../core/buffer/snippet'
 import { ClassicIntegrationSource } from '../plugins/ajs-destination/types'
 import { attachInspector } from '../core/inspector'
+import { Stats } from '../core/stats'
 
 export interface LegacyIntegrationConfiguration {
   /* @deprecated - This does not indicate browser types anymore */
@@ -279,7 +280,7 @@ async function loadAnalytics(
 
   const plugins = settings.plugins ?? []
   const classicIntegrations = settings.classicIntegrations ?? []
-  Context.initRemoteMetrics(legacySettings.metrics)
+  Stats.initRemoteMetrics(legacySettings.metrics)
 
   // needs to be flushed before plugins are registered
   flushPreBuffer(analytics, preInitBuffer)

--- a/packages/browser/src/core/context/index.ts
+++ b/packages/browser/src/core/context/index.ts
@@ -7,20 +7,15 @@ import {
 } from '@segment/analytics-core'
 import { SegmentEvent } from '../events/interfaces'
 import { Stats } from '../stats'
-import { MetricsOptions, RemoteMetrics } from '../stats/remote-metrics'
-
-let _remoteMetrics: RemoteMetrics
 
 export class Context extends CoreContext<SegmentEvent> {
   static override system() {
     return new this({ type: 'track', event: 'system' })
   }
-  static initRemoteMetrics(options?: MetricsOptions) {
-    _remoteMetrics = new RemoteMetrics(options)
-  }
   constructor(event: SegmentEvent, id?: string) {
-    super(event, id, new Stats(_remoteMetrics))
+    super(event, id, new Stats())
   }
 }
+
 export { ContextCancelation }
 export type { ContextFailedDelivery, SerializedContext, CancelationOptions }

--- a/packages/browser/src/core/stats/__tests__/index.test.ts
+++ b/packages/browser/src/core/stats/__tests__/index.test.ts
@@ -1,12 +1,13 @@
-import { Stats } from '..'
 import { RemoteMetrics } from '../remote-metrics'
+import { Stats } from '..'
+
+const spy = jest.spyOn(RemoteMetrics.prototype, 'increment')
 
 describe(Stats, () => {
   test('forwards increments to remote metrics endpoint', () => {
-    const remote = new RemoteMetrics()
-    const spy = jest.spyOn(remote, 'increment')
+    Stats.initRemoteMetrics()
 
-    const stats = new Stats(remote)
+    const stats = new Stats()
     stats.increment('banana', 1, ['phone:1'])
 
     expect(spy).toHaveBeenCalledWith('banana', ['phone:1'])

--- a/packages/browser/src/core/stats/index.ts
+++ b/packages/browser/src/core/stats/index.ts
@@ -1,12 +1,15 @@
 import { CoreStats } from '@segment/analytics-core'
-import type { RemoteMetrics } from './remote-metrics'
+import { MetricsOptions, RemoteMetrics } from './remote-metrics'
+
+let remoteMetrics: RemoteMetrics | undefined
 
 export class Stats extends CoreStats {
-  constructor(private _remoteMetrics?: RemoteMetrics) {
-    super()
+  static initRemoteMetrics(options?: MetricsOptions) {
+    remoteMetrics = new RemoteMetrics(options)
   }
+
   override increment(metric: string, by?: number, tags?: string[]): void {
     super.increment(metric, by, tags)
-    this._remoteMetrics?.increment(metric, tags ?? [])
+    remoteMetrics?.increment(metric, tags ?? [])
   }
 }


### PR DESCRIPTION
Have RemoteMetrics owned by "Stats" class.