### PR TITLE
Generate version to make analytics-node compat. with non-node runtimes

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,12 +2,12 @@
   "name": "@segment/analytics-node",
   "version": "0.0.1-beta.8",
   "private": true,
-  "main": "./dist/cjs/src/index.js",
-  "module": "./dist/esm/src/index.js",
-  "types": "./dist/types/src/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
-    "require": "./dist/cjs/src/index.js",
-    "import": "./dist/esm/src/index.js"
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
   },
   "files": [
     "dist/",
@@ -21,8 +21,9 @@
   "scripts": {
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
-    "build": "yarn concurrently 'yarn:build:*'",
+    "build": "rm -rf dist && yarn version && yarn concurrently 'yarn:build:*'",
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
+    "version": "sh scripts/version.sh",
     "build:esm": "yarn tsc -p tsconfig.build.json",
     "watch": "yarn build:esm --watch",
     "watch:test": "yarn test --watch",

--- a/packages/node/scripts/prerelease.sh
+++ b/packages/node/scripts/prerelease.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 # Run this script on master when ready to publish node.
 
-
 ## Sometimes the latest version gets overwritten by changesets, lets ensure we are using the release uploaded to npm with the latest tag.
 latest_version=$(npm show @segment/analytics-node version)
 echo "latest npm version: $latest_version"
 tmp=$(mktemp)
-jq ".version = \"$latest_version\"" package.json > "$tmp" && mv "$tmp" package.json
+jq ".version = \"$latest_version\"" package.json >"$tmp" && mv "$tmp" package.json
 
 echo "bumping version..." &&
   version=$(npm version prerelease) &&
   git add package.json &&
+  yarn version &&
   git commit -m "Bump node version: $version."
 
 echo "modifying package.json..." &&

--- a/packages/node/scripts/version.sh
+++ b/packages/node/scripts/version.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Generate a version.ts file from the version in the package.json
+
+PKG_VERSION=$(node --eval="process.stdout.write(require('./package.json').version)")
+
+cat <<EOF >src/generated/version.ts
+// This file is generated.
+export const version = '$PKG_VERSION'
+EOF
+
+git add src/generated/version.ts

--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -1,4 +1,4 @@
-import { version } from '../../package.json'
+import { version } from '../generated/version'
 import { Analytics } from '..'
 import { resolveCtx } from './test-helpers/resolve-ctx'
 import { createTestAnalytics } from './test-helpers/create-test-analytics'

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -1,6 +1,6 @@
 import { CoreAnalytics, bindAll, pTimeout } from '@segment/analytics-core'
 import { AnalyticsSettings, validateSettings } from './settings'
-import { version } from '../../package.json'
+import { version } from '../generated/version'
 import { createConfiguredNodePlugin } from '../plugins/segmentio'
 import { NodeEventFactory } from './event-factory'
 import { Callback, dispatchAndEmit } from './dispatch-emit'

--- a/packages/node/src/generated/version.ts
+++ b/packages/node/src/generated/version.ts
@@ -1,0 +1,2 @@
+// This file is generated.
+export const version = '0.0.1-beta.8'

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -1,5 +1,5 @@
 import { Publisher, PublisherProps } from './publisher'
-import { version } from '../../../package.json'
+import { version } from '../../generated/version'
 import { detectRuntime } from '../../lib/env'
 import { Plugin } from '../../app/types'
 import { Context } from '../../app/context'

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "resolveJsonModule": true,
     "module": "esnext",
     "target": "es2020", // node 14
     "moduleResolution": "node",


### PR DESCRIPTION
`resolveJSONModules` creates a dependency on `fs`.