### PR TITLE
Fix internal lib error by removing path alias

### DIFF
--- a/.changeset/sixty-mice-brush.md
+++ b/.changeset/sixty-mice-brush.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix internal lib error by removing path alias.

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { cdnSettingsKitchenSink } from '../../test-helpers/fixtures/cdn-settings'
 import { createMockFetchImplementation } from '../../test-helpers/fixtures/create-fetch-method'
-import { Context } from '@/core/context'
-import { Plugin } from '@/core/plugin'
+import { Context } from '../../core/context'
+import { Plugin } from '../../core/plugin'
 import { JSDOM } from 'jsdom'
 import { Analytics, InitOptions } from '../../core/analytics'
 import { LegacyDestination } from '../../plugins/ajs-destination'
@@ -17,7 +17,7 @@ import { PriorityQueue } from '../../lib/priority-queue'
 import { getCDN, setGlobalCDNUrl } from '../../lib/parse-cdn'
 import { clearAjsBrowserStorage } from '../../test-helpers/browser-storage'
 import { parseFetchCall } from '../../test-helpers/fetch-parse'
-import { ActionDestination } from '@/plugins/remote-loader'
+import { ActionDestination } from '../../plugins/remote-loader'
 
 let fetchCalls: ReturnType<typeof parseFetchCall>[] = []
 
@@ -208,7 +208,7 @@ describe('Initialization', () => {
   })
 
   it('calls page if initialpageview is set', async () => {
-    jest.mock('@/core/analytics')
+    jest.mock('../../core/analytics')
     const mockPage = jest.fn().mockImplementation(() => Promise.resolve())
     Analytics.prototype.page = mockPage
 
@@ -218,7 +218,7 @@ describe('Initialization', () => {
   })
 
   it('does not call page if initialpageview is not set', async () => {
-    jest.mock('@/core/analytics')
+    jest.mock('../../core/analytics')
     const mockPage = jest.fn()
     Analytics.prototype.page = mockPage
     await AnalyticsBrowser.load({ writeKey }, { initialPageview: false })

--- a/packages/browser/src/browser/__tests__/query-string.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/query-string.integration.test.ts
@@ -100,7 +100,7 @@ describe('queryString', () => {
   })
 
   it('applies query string logic if window.location.hash is present in different formats', async () => {
-    jest.mock('@/core/analytics')
+    jest.mock('../../core/analytics')
     const mockQueryString = jest
       .fn()
       .mockImplementation(() => Promise.resolve())

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -17,7 +17,7 @@ const register = jest.fn()
 const addSourceMiddleware = jest.fn()
 const on = jest.fn()
 
-jest.mock('@/core/analytics', () => ({
+jest.mock('../../core/analytics', () => ({
   Analytics: (_: unknown, options?: InitOptions): unknown => ({
     track,
     identify,

--- a/packages/browser/src/core/buffer/__tests__/index.test.ts
+++ b/packages/browser/src/core/buffer/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import {
 } from '..'
 import { Analytics } from '../../analytics'
 import { Context } from '../../context'
-import { sleep } from '@/lib/sleep'
+import { sleep } from '../../../lib/sleep'
 import { User } from '../../user'
 
 describe('PreInitMethodCallBuffer', () => {

--- a/packages/browser/src/lib/merged-options.ts
+++ b/packages/browser/src/lib/merged-options.ts
@@ -1,4 +1,4 @@
-import { JSONObject, Options } from '@/core/events/interfaces'
+import { JSONObject, Options } from '../core/events/interfaces'
 import { LegacySettings } from '../browser'
 
 /**

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -1,4 +1,4 @@
-import { Integrations, JSONObject } from '@/core/events'
+import { Integrations, JSONObject } from '../../core/events'
 import { Alias, Facade, Group, Identify, Page, Track } from '@segment/facade'
 import { Analytics, InitOptions } from '../../core/analytics'
 import { LegacySettings } from '../../browser'

--- a/packages/browser/src/plugins/page-enrichment/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/page-enrichment/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Analytics } from '@/core/analytics'
+import { Analytics } from '../../../core/analytics'
 import { pageEnrichment, pageDefaults } from '..'
 
 let ajs: Analytics

--- a/packages/browser/src/plugins/page-enrichment/index.ts
+++ b/packages/browser/src/plugins/page-enrichment/index.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/core/context'
-import type { Plugin } from '@/core/plugin'
+import type { Context } from '../../core/context'
+import type { Plugin } from '../../core/plugin'
 
 interface PageDefault {
   [key: string]: unknown

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -7,9 +7,6 @@
     "resolveJsonModule": true,
     "lib": ["es2020", "DOM", "DOM.Iterable"],
     "baseUrl": "./src",
-    "paths": {
-      "@/*": ["./*"]
-    },
     "keyofStringsOnly": true
   },
   "exclude": ["node_modules", "dist"]

--- a/packages/config/src/jest/get-module-map.js
+++ b/packages/config/src/jest/get-module-map.js
@@ -27,7 +27,6 @@ const getJestModuleMap = ({ skipPackageMap = doNotMapPackages } = {}) => {
   )
 
   return {
-    '@/(.+)': '<rootDir>/src/$1',
     ...(skipPackageMap ? {} : moduleNameMapper),
   }
 }


### PR DESCRIPTION
Fixes #748 

Bug affects a minority of projects with `skipLibCheck: false`.