### PR TITLE
Add dts "internal" validation / tests as part of CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,11 @@ steps:
       - echo "+++ Run tests"
       - yarn constraints
       - yarn run test:scripts
+      - yarn run test:check-dts
+    plugins:
+      - ssh://git@github.com/segmentio/cache-buildkite-plugin#v2.0.0:
+          key: "v1.1-cache-dev-{{ checksum 'yarn.lock' }}"
+          paths: ['.yarn/cache/']
 
   - label: '[Browser] Lint + Test'
     key: browser-lint-test

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ reports/*
 /test-results/
 playwright-report/
 playwright/.cache/
+tmp.tsconfig.json

--- a/meta-tests/check-dts.ts
+++ b/meta-tests/check-dts.ts
@@ -1,0 +1,97 @@
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import path from 'path'
+import fs from 'fs'
+
+/**
+ * This script is for extra typechecking of the built .d.ts files in {package_name}/dist/types/*.
+ * Occassionally, "internal" .dts errors can result from oddities in typescript configuration,
+ * such as: https://github.com/segmentio/analytics-next/issues/748.
+ * These errors would only surface for customers with `skipLibCheck` enabled.
+ */
+const execa = promisify(exec)
+
+const allPublicPackageDirNames = ['browser', 'core', 'node'] as const
+
+type PackageDirName = typeof allPublicPackageDirNames[number]
+
+class Tsc {
+  // e.g. packages/browser
+  configPathDir: string
+  // e.g. packages/browser/tsconfig.json
+  configPath: string
+
+  private jsonConfig: string = JSON.stringify({
+    extends: '../../tsconfig.json',
+    include: ['./dist/types/**/*'],
+    compilerOptions: {
+      noEmit: true,
+      skipLibCheck: false,
+    },
+  })
+
+  constructor(packageDirName: PackageDirName) {
+    this.configPathDir = path.join('packages', packageDirName)
+    this.configPath = path.join(this.configPathDir, 'tmp.tsconfig.json')
+  }
+
+  typecheck() {
+    this.writeConfig()
+    const cmd = [
+      `node_modules/.bin/tsc`,
+      `--project ${this.configPath}`,
+      `--pretty false`,
+    ].join(' ')
+    return execa(cmd).finally(() => this.deleteConfig())
+  }
+
+  private deleteConfig() {
+    fs.unlinkSync(this.configPath)
+  }
+
+  private writeConfig() {
+    fs.writeFileSync(this.configPath, this.jsonConfig, {
+      encoding: 'utf8',
+    })
+  }
+}
+
+const checkDts = async (packageDirName: PackageDirName): Promise<void> => {
+  const tsc = new Tsc(packageDirName)
+  try {
+    await tsc.typecheck()
+  } catch (err: any) {
+    if (!err || typeof err !== 'object' || !err.stdout) {
+      throw err
+    }
+    const errors: string[] = err.stdout.toString().split('\n')
+    const relevantErrors = errors.filter((msg) =>
+      msg.includes(tsc.configPathDir)
+    )
+    if (relevantErrors.length) {
+      throw relevantErrors
+    }
+  }
+}
+
+const main = async () => {
+  let hasError = false
+  for (const packageDirName of allPublicPackageDirNames) {
+    try {
+      console.log(`Checking "${packageDirName}/dist/types"...`)
+      await checkDts(packageDirName)
+    } catch (err) {
+      console.error(err)
+      hasError = true
+    }
+  }
+  if (hasError) {
+    console.log('\n Tests failed.')
+    process.exit(1)
+  } else {
+    console.log('\n Tests passed.')
+    process.exit(0)
+  }
+}
+
+void main()

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "test": "jest",
     "test:scripts": "jest --config scripts/jest.config.js",
+    "test:check-dts": "yarn build && yarn ts-node meta-tests/check-dts.ts",
     "test:node-int": "turbo run --filter=node-integration-tests test",
     "lint": "yarn constraints && turbo run lint --continue",
     "build": "turbo run build --filter='./packages/*'",


### PR DESCRIPTION

 This script is for extra typechecking of the built .d.ts files in {package_name}/dist/types/*.
 Occassionally, "internal" .dts errors can result from oddities in typescript configuration,
 such as: https://github.com/segmentio/analytics-next/issues/748.
 
These errors would only surface for customers with `skipLibCheck` enabled.
