### PR TITLE
node: add ability to subscribe to http requests 

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -15,7 +15,7 @@ yarn add @segment/analytics-node
 pnpm install @segment/analytics-node
 ```
 
-### Usage 
+### Usage
 Assuming some express-like web framework.
 ```ts
 import { Analytics } from '@segment/analytics-node'
@@ -148,13 +148,32 @@ console.log(unflushedEvents) // all events that came in after closeAndFlush was 
 ```
 
 ## Event Emitter Interface
+You can see the complete list of emitted events in [emitter.ts](src/app/emitter.ts)
 ```ts
 analytics.on('error', (err) => console.error(err))
 
 analytics.on('identify', (ctx) => console.log(ctx))
 
 analytics.on('track', (ctx) => console.log(ctx))
+
 ```
+#### You can use the emitter to log all HTTP Requests
+```ts
+analytics.on('http_request', (event) => console.log(event))
+
+// when triggered, emits an event of the shape:
+{
+    url: 'https://api.segment.io/v1/batch',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...
+    },
+    body: '...',
+}
+
+```
+
 
 ## Multiple Clients
 Different parts of your application may require different types of batching, or even sending to multiple Segment sources. In that case, you can initialize multiple instances of Analytics with different settings:

--- a/packages/node/src/__tests__/emitter.integration.test.ts
+++ b/packages/node/src/__tests__/emitter.integration.test.ts
@@ -1,0 +1,39 @@
+const fetcher = jest.fn()
+jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
+
+import { createError, createSuccess } from './test-helpers/factories'
+import { createTestAnalytics } from './test-helpers/create-test-analytics'
+import { assertHttpRequestEmittedEvent } from './test-helpers/assert-shape'
+
+describe('Emitter tests', () => {
+  it('emits an http_request event if success', async () => {
+    fetcher.mockReturnValue(createSuccess())
+    const analytics = createTestAnalytics()
+    const fn = jest.fn()
+    analytics.on('http_request', fn)
+    await new Promise((resolve) =>
+      analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
+    )
+    expect(fn).toBeCalledTimes(1)
+    const [req] = fn.mock.lastCall
+    console.log(req)
+    const body = JSON.parse(req.body)
+    expect(Array.isArray(body.batch)).toBeTruthy()
+    expect(body.batch.length).toBe(1)
+    expect(typeof req.headers).toBe('object')
+    expect(typeof req.method).toBe('string')
+    expect(typeof req.url).toBe('string')
+  })
+
+  it('emits an http_request event if error', async () => {
+    fetcher.mockReturnValue(createError())
+    const analytics = createTestAnalytics({ maxRetries: 0 })
+    const fn = jest.fn()
+    analytics.on('http_request', fn)
+    await new Promise((resolve) =>
+      analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
+    )
+    expect(fn).toBeCalledTimes(1)
+    assertHttpRequestEmittedEvent(fn.mock.lastCall[0])
+  })
+})

--- a/packages/node/src/__tests__/test-helpers/assert-shape/http-request-event.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/http-request-event.ts
@@ -1,0 +1,13 @@
+import { NodeEmitterEvents } from '../../../app/emitter'
+type HttpRequestEmitterEvent = NodeEmitterEvents['http_request'][0]
+
+export const assertHttpRequestEmittedEvent = (
+  event: HttpRequestEmitterEvent
+) => {
+  const body = JSON.parse(event.body)
+  expect(Array.isArray(body.batch)).toBeTruthy()
+  expect(body.batch.length).toBe(1)
+  expect(typeof event.headers).toBe('object')
+  expect(typeof event.method).toBe('string')
+  expect(typeof event.url).toBe('string')
+}

--- a/packages/node/src/__tests__/test-helpers/assert-shape/index.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/index.ts
@@ -1,0 +1,1 @@
+export * from './http-request-event'

--- a/packages/node/src/__tests__/test-helpers/resolve-emitter.ts
+++ b/packages/node/src/__tests__/test-helpers/resolve-emitter.ts
@@ -1,0 +1,11 @@
+import { NodeEmitter, NodeEmitterEvents } from '../../app/emitter'
+
+/** Tester helper that resolves args from emitter event */
+export const resolveEmitterEvent = <EventName extends keyof NodeEmitterEvents>(
+  emitter: NodeEmitter,
+  eventName: EventName
+): Promise<NodeEmitterEvents[EventName]> => {
+  return new Promise<NodeEmitterEvents[EventName]>((resolve) => {
+    emitter.once(eventName, (...args) => resolve(args))
+  })
+}

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -41,15 +41,18 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
 
     this._closeAndFlushDefaultTimeout = flushInterval * 1.25 // add arbitrary multiplier in case an event is in a plugin.
 
-    const { plugin, publisher } = createConfiguredNodePlugin({
-      writeKey: settings.writeKey,
-      host: settings.host,
-      path: settings.path,
-      maxRetries: settings.maxRetries ?? 3,
-      maxEventsInBatch: settings.maxEventsInBatch ?? 15,
-      httpRequestTimeout: settings.httpRequestTimeout,
-      flushInterval,
-    })
+    const { plugin, publisher } = createConfiguredNodePlugin(
+      {
+        writeKey: settings.writeKey,
+        host: settings.host,
+        path: settings.path,
+        maxRetries: settings.maxRetries ?? 3,
+        maxEventsInBatch: settings.maxEventsInBatch ?? 15,
+        httpRequestTimeout: settings.httpRequestTimeout,
+        flushInterval,
+      },
+      this as NodeEmitter
+    )
     this._publisher = publisher
     this.ready = this.register(plugin).then(() => undefined)
 

--- a/packages/node/src/app/emitter.ts
+++ b/packages/node/src/app/emitter.ts
@@ -10,7 +10,12 @@ export type NodeEmitterEvents = CoreEmitterContract<Context> & {
   initialize: [AnalyticsSettings]
   call_after_close: [SegmentEvent] // any event that did not get dispatched due to close
   http_request: [
-    { url: string; body: string; method: string; headers: Record<string, any> }
+    {
+      url: string
+      method: string
+      headers: Record<string, string>
+      body: string
+    }
   ]
   drained: []
 }

--- a/packages/node/src/app/emitter.ts
+++ b/packages/node/src/app/emitter.ts
@@ -6,9 +6,12 @@ import { SegmentEvent } from './types'
 /**
  * Map of emitter event names to method args.
  */
-type NodeEmitterEvents = CoreEmitterContract<Context> & {
+export type NodeEmitterEvents = CoreEmitterContract<Context> & {
   initialize: [AnalyticsSettings]
   call_after_close: [SegmentEvent] // any event that did not get dispatched due to close
+  http_request: [
+    { url: string; body: string; method: string; headers: Record<string, any> }
+  ]
   drained: []
 }
 

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -3,6 +3,7 @@ import { version } from '../../generated/version'
 import { detectRuntime } from '../../lib/env'
 import { Plugin } from '../../app/types'
 import { Context } from '../../app/context'
+import { NodeEmitter } from '../../app/emitter'
 
 function normalizeEvent(ctx: Context) {
   ctx.updateEvent('context.library.name', 'AnalyticsNode')
@@ -52,8 +53,11 @@ export function createNodePlugin(publisher: Publisher): SegmentNodePlugin {
   }
 }
 
-export const createConfiguredNodePlugin = (props: ConfigureNodePluginProps) => {
-  const publisher = new Publisher(props)
+export const createConfiguredNodePlugin = (
+  props: ConfigureNodePluginProps,
+  emitter: NodeEmitter
+) => {
+  const publisher = new Publisher(props, emitter)
   return {
     publisher: publisher,
     plugin: createNodePlugin(publisher),

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -203,9 +203,9 @@ export class Publisher {
 
         this._emitter.emit('http_request', {
           url: this._url,
-          body: requestInit.body,
-          headers: requestInit.headers,
           method: requestInit.method,
+          headers: requestInit.headers,
+          body: requestInit.body,
         })
 
         const response = await fetch(this._url, requestInit)


### PR DESCRIPTION
```ts
analytics.on('http_request', (req) => console.log(req)) // logs 
```
logs:
```sh
    {
      url: 'https://api.segment.io/v1/batch',
      body: '{"batch":[{"timestamp":"2023-01-06T23:26:44.953Z","integrations":{},"event":"bar","type":"track","properties":{},"context":{"library":{"name":"AnalyticsNode","version":"0.0.1-beta.9"}},"anonymousId":"foo","messageId":"node-next-1673047604953-f6e414cd-4b1d-4df4-8327-0c3dcdf82317","_metadata":{"nodeVersion":"16.16.0","runtime":"node"}}]}',
      headers: {
        'Content-Type': 'application/json',
        Authorization: 'Basic Zm9vOg==',
        'User-Agent': 'analytics-node-next/latest'
      },
      method: 'POST'
    }
```