### PR TITLE
Attempting to refactor schema filter functionality

### DIFF
--- a/packages/browser/src/core/context/index.ts
+++ b/packages/browser/src/core/context/index.ts
@@ -49,6 +49,7 @@ export class Context implements AbstractContext {
   public stats: Stats
   private _id: string
   private _failedDelivery?: ContextFailedDelivery
+  private _disabledIntegrations: Set<string> = new Set()
 
   constructor(event: SegmentEvent, id?: string) {
     this._attempts = 0
@@ -91,6 +92,16 @@ export class Context implements AbstractContext {
 
   public set event(evt: SegmentEvent) {
     this._event = evt
+  }
+
+  public get disabledIntegrations(): Set<string> {
+    return this._disabledIntegrations
+  }
+
+  addDisabledIntegrations(integrations: string[]) {
+    integrations.forEach((integration) =>
+      this._disabledIntegrations.add(integration)
+    )
   }
 
   public get attempts(): number {

--- a/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
@@ -53,6 +53,7 @@ const settings: LegacySettings = {
 }
 
 const trackEvent: Plugin = {
+  alternativeNames: ['Braze Web Mode (Actions)'],
   name: 'Braze Web Mode (Actions) trackEvent',
   type: 'destination',
   version: '1.0',
@@ -74,21 +75,25 @@ const trackEvent: Plugin = {
 
 const trackPurchase: Plugin = {
   ...trackEvent,
+  alternativeNames: ['Braze Web Mode (Actions)'],
   name: 'Braze Web Mode (Actions) trackPurchase',
 }
 
 const updateUserProfile: Plugin = {
   ...trackEvent,
+  alternativeNames: ['Braze Web Mode (Actions)'],
   name: 'Braze Web Mode (Actions) updateUserProfile',
 }
 
 const amplitude: Plugin = {
   ...trackEvent,
+  alternativeNames: [],
   name: 'amplitude',
 }
 
 const fullstory: Plugin = {
   ...trackEvent,
+  alternativeNames: ['Fullstory'],
   name: 'Fullstory (Actions) trackEvent',
 }
 
@@ -275,7 +280,6 @@ describe('schema filter', () => {
       expect(trackEvent.track).toHaveBeenCalled()
       expect(trackPurchase.track).toHaveBeenCalled()
       expect(updateUserProfile.track).toHaveBeenCalled()
-
       expect(amplitude.track).not.toHaveBeenCalled()
     })
 

--- a/packages/browser/src/plugins/schema-filter/index.ts
+++ b/packages/browser/src/plugins/schema-filter/index.ts
@@ -51,19 +51,17 @@ export function schemaFilter(
   function filter(ctx: Context): Context {
     const plan = track
     const ev = ctx.event.event
-
     if (plan && ev) {
       const planEvent = plan[ev]
       if (!isPlanEventEnabled(plan, planEvent)) {
+        ctx.addDisabledIntegrations(Object.keys(settings.integrations))
         ctx.updateEvent('integrations', {
-          ...ctx.event.integrations,
-          All: false,
           'Segment.io': true,
         })
         return ctx
       } else {
         const disabledActions = disabledActionDestinations(planEvent, settings)
-
+        ctx.addDisabledIntegrations(Object.keys(disabledActions))
         ctx.updateEvent('integrations', {
           ...ctx.event.integrations,
           ...planEvent?.integrations,
@@ -71,7 +69,6 @@ export function schemaFilter(
         })
       }
     }
-
     return ctx
   }
 


### PR DESCRIPTION
This is the point where the least amount of failing tests occur. None of the failures are surprising to me given the changes (you can pull and run tests if you'd like to see which are failing).

I've been trying to find a way to restore the intended schema filtering functionality throughout our application, and I'm wondering if we should be taking a different approach for this problem. 

For a brief description of the problem, schema filtering should not affect cloud-mode destinations. I've tried a number of different filtering approaches, including: filtering the destinations array before mapping it to attempt delivery of analytics calls, only filtering before enrichment, only filtering after enrichment, and various hierarchy re-arrangements within `availableExtensions` .

I'm wondering if the solution here should look similar to how schema filter is currently implemented, but with a different format for `All: false`. Perhaps we want to enable and disable certain integrations based on whether or not they are device mode destinations when unplanned events are blocked? Either way, it sounds like there's a desire to move away from relyign on `All: false` at all.