### PR TITLE
Add useQueryString to InitOptions

### DIFF
--- a/.changeset/fuzzy-baboons-shave.md
+++ b/.changeset/fuzzy-baboons-shave.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-next': minor
+'@segment/analytics-core': patch
+---
+
+Add useQueryString option to InitOptions

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -93,6 +93,15 @@ export interface InitOptions {
   plan?: Plan
   retryQueue?: boolean
   obfuscate?: boolean
+  /**
+   * Disables or sets constraints on processing of query string parameters
+   */
+  useQueryString?:
+    | boolean
+    | {
+        aid?: RegExp
+        uid?: RegExp
+      }
 }
 
 /* analytics-classic stubs */
@@ -421,7 +430,11 @@ export class Analytics
     return this._user.anonymousId(id)
   }
 
-  async queryString(query: string): Promise<Context[]> {
+  async queryString(query: string): Promise<Context[] | void> {
+    if (this.options.useQueryString === false) {
+      return
+    }
+
     const { queryString } = await import(
       /* webpackChunkName: "queryString" */ '../query-string'
     )

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -430,9 +430,9 @@ export class Analytics
     return this._user.anonymousId(id)
   }
 
-  async queryString(query: string): Promise<Context[] | void> {
+  async queryString(query: string): Promise<Context[]> {
     if (this.options.useQueryString === false) {
-      return
+      return []
     }
 
     const { queryString } = await import(

--- a/packages/browser/src/core/query-string/__tests__/useQueryString.test.ts
+++ b/packages/browser/src/core/query-string/__tests__/useQueryString.test.ts
@@ -1,0 +1,60 @@
+import unfetch from 'unfetch'
+import { AnalyticsBrowser } from '../../..'
+import { createSuccess } from '../../../test-helpers/factories'
+
+jest.mock('unfetch')
+jest
+  .mocked(unfetch)
+  .mockImplementation(() => createSuccess({ integrations: {} }))
+
+// @ts-ignore
+delete window.location
+// @ts-ignore
+window.location = new URL(
+  'https://www.example.com?ajs_aid=873832VB&ajs_uid=xcvn7568'
+)
+
+describe('useQueryString configuration option', () => {
+  it('ignores aid and uid from query string when disabled', async () => {
+    const [analyticsAlt] = await AnalyticsBrowser.load(
+      { writeKey: 'abc' },
+      {
+        useQueryString: false,
+      }
+    )
+
+    // not acknowledge the aid provided in the query params, let ajs generate one
+    expect(analyticsAlt.user().anonymousId()).not.toBe('873832VB')
+    expect(analyticsAlt.user().id()).toBe(null)
+  })
+
+  it('ignores uid when it doesnt match the required pattern', async () => {
+    const [analyticsAlt] = await AnalyticsBrowser.load(
+      { writeKey: 'abc' },
+      {
+        useQueryString: {
+          uid: /[A-Z]{6}/,
+        },
+      }
+    )
+
+    // no constraint was set for aid therefore accepted
+    expect(analyticsAlt.user().anonymousId()).toBe('873832VB')
+    expect(analyticsAlt.user().id()).toBe(null)
+  })
+
+  it('accepts both aid and uid from query string when they match the required pattern', async () => {
+    const [analyticsAlt] = await AnalyticsBrowser.load(
+      { writeKey: 'abc' },
+      {
+        useQueryString: {
+          aid: /\d{6}[A-Z]{2}/,
+          uid: /[a-z]{4}\d{4}/,
+        },
+      }
+    )
+
+    expect(analyticsAlt.user().anonymousId()).toBe('873832VB')
+    expect(analyticsAlt.user().id()).toBe('xcvn7568')
+  })
+})

--- a/packages/core/src/utils/__tests__/is-plain-object.test.ts
+++ b/packages/core/src/utils/__tests__/is-plain-object.test.ts
@@ -1,0 +1,27 @@
+// Spec derived from https://github.com/jonschlinkert/is-plain-object/blob/master/test/server.js
+
+import { isPlainObject } from '../is-plain-object'
+
+describe('isPlainObject', () => {
+  it('should return `true` if the object is created by the `Object` constructor.', function () {
+    expect(isPlainObject(Object.create({}))).toBe(true)
+    expect(isPlainObject(Object.create(Object.prototype))).toBe(true)
+    expect(isPlainObject({ foo: 'bar' })).toBe(true)
+    expect(isPlainObject({})).toBe(true)
+    expect(isPlainObject(Object.create(null))).toBe(true)
+  })
+
+  it('should return `false` if the object is not created by the `Object` constructor.', function () {
+    class Foo {
+      abc = {}
+    }
+
+    expect(isPlainObject(/foo/)).toBe(false)
+    expect(isPlainObject(function () {})).toBe(false)
+    expect(isPlainObject(1)).toBe(false)
+    expect(isPlainObject(['foo', 'bar'])).toBe(false)
+    expect(isPlainObject([])).toBe(false)
+    expect(isPlainObject(new Foo())).toBe(false)
+    expect(isPlainObject(null)).toBe(false)
+  })
+})

--- a/packages/core/src/utils/is-plain-object.ts
+++ b/packages/core/src/utils/is-plain-object.ts
@@ -1,0 +1,26 @@
+// Code derived from https://github.com/jonschlinkert/is-plain-object/blob/master/is-plain-object.js
+
+function isObject(o: unknown): o is Object {
+  return Object.prototype.toString.call(o) === '[object Object]'
+}
+
+export function isPlainObject(o: unknown): o is Record<PropertyKey, unknown> {
+  if (isObject(o) === false) return false
+
+  // If has modified constructor
+  const ctor = (o as any).constructor
+  if (ctor === undefined) return true
+
+  // If has modified prototype
+  const prot = ctor.prototype
+  if (isObject(prot) === false) return false
+
+  // If constructor does not have an Object-specific method
+  // eslint-disable-next-line no-prototype-builtins
+  if ((prot as Object).hasOwnProperty('isPrototypeOf') === false) {
+    return false
+  }
+
+  // Most likely a plain Object
+  return true
+}


### PR DESCRIPTION
Fixes #769

New API to control the query param behaviour:


```ts
// Disable query string processing altogether
analytics.load('<WRITE_KEY>', {
  useQueryString: false
})
```

```ts
// OR keep it on, but enforce validation rules
analytics.load('<WRITE_KEY>', {
  useQueryString: {
    // set a pattern for anonymous id 
    aid: /([A-Z]{10})/,
    // set a pattern for user id
    uid: /([A-Z]{6})/
  }
})
```