### PR TITLE
fix: support typescript "NodeNext" module resolution

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "import": "./dist/esm/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Currently typescript cant resolve types when `{ moduleResolution: "NodeNext" }` is in tsconfig.