### PR TITLE
improve !hasUser error message

### DIFF
--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -37,7 +37,7 @@ export function validateEvent(event?: CoreSegmentEvent | null) {
   if (!hasUser(event)) {
     throw new ValidationError(
       'userId/anonymousId/previousId/groupId',
-      'Must have userId or anonymousId or previousId or groupId'
+      'Must have userId or anonymousId or previousId or groupId and must be of type string'
     )
   }
 }


### PR DESCRIPTION
I was sending the `userId` as a number (because that is how they are stored in our database) and was receiving an error that the `userId` was missing. This led me on a wild goose chase that could have been easily solved if the error message had also included the information that it must be a string.

If the `hasUser` error check is going to fail if `userId` is not a string, then it should be included in the error message when it fails.