### PR TITLE
 Fix staging-only bug where integrations URL would not respect CDN URL overrides

### DIFF
--- a/.changeset/eight-jokes-poke.md
+++ b/.changeset/eight-jokes-poke.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix staging-only bug where integrations URL would not respect CDN URL overrides

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import * as loader from '../../../lib/load-script'
-import { ActionDestination, remoteLoader, RemotePlugin } from '..'
+import { ActionDestination, remoteLoader } from '..'
 import { AnalyticsBrowser, LegacySettings } from '../../../browser'
 import { InitOptions } from '../../../core/analytics'
 import { Context } from '../../../core/context'
@@ -69,40 +69,47 @@ describe('Remote Loader', () => {
   it('should attempt to load a script from a custom CDN', async () => {
     window.analytics = {}
     window.analytics._cdn = 'foo.com'
-    const remotePlugin: RemotePlugin = {
-      name: 'remote plugin',
-      creationName: 'remote plugin',
-      url: 'https://cdn.segment.com/actions/file.js',
-      libraryName: 'testPlugin',
-      settings: {},
-    }
-    await remoteLoader(
-      {
-        integrations: {},
-        remotePlugins: [
-          { ...remotePlugin, url: 'https://cdn.segment.com/actions/file.js' },
-        ],
-      },
-      {},
-      {}
-    )
-
-    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
-
     await remoteLoader(
       {
         integrations: {},
         remotePlugins: [
           {
-            ...remotePlugin,
-            url: 'https://cdn.segment.build/actions/file.js',
+            name: 'remote plugin',
+            creationName: 'remote plugin',
+            url: 'https://cdn.segment.com/actions/file.js',
+            libraryName: 'testPlugin',
+            settings: {},
           },
         ],
       },
       {},
       {}
     )
+
     expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
+  })
+
+  it('should replace the cdn for staging', async () => {
+    window.analytics = {}
+    window.analytics._cdn = 'foo.com'
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            creationName: 'remote plugin',
+            url: 'https://cdn.segment.build/actions/foo.js',
+            libraryName: 'testPlugin',
+            settings: {},
+          },
+        ],
+      },
+      {},
+      {}
+    )
+
+    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/foo.js')
   })
 
   it('should attempt calling the library', async () => {

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -89,7 +89,9 @@ describe('Remote Loader', () => {
     expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
   })
 
-  it('should replace the cdn for staging', async () => {
+  it('should work if the cdn is staging', async () => {
+    const stagingURL = 'https://cdn.segment.build/actions/foo.js'
+
     window.analytics = {}
     window.analytics._cdn = 'foo.com'
     await remoteLoader(
@@ -99,7 +101,7 @@ describe('Remote Loader', () => {
           {
             name: 'remote plugin',
             creationName: 'remote plugin',
-            url: 'https://cdn.segment.build/actions/foo.js',
+            url: stagingURL,
             libraryName: 'testPlugin',
             settings: {},
           },

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import * as loader from '../../../lib/load-script'
-import { ActionDestination, remoteLoader } from '..'
+import { ActionDestination, remoteLoader, RemotePlugin } from '..'
 import { AnalyticsBrowser, LegacySettings } from '../../../browser'
 import { InitOptions } from '../../../core/analytics'
 import { Context } from '../../../core/context'
@@ -69,23 +69,39 @@ describe('Remote Loader', () => {
   it('should attempt to load a script from a custom CDN', async () => {
     window.analytics = {}
     window.analytics._cdn = 'foo.com'
+    const remotePlugin: RemotePlugin = {
+      name: 'remote plugin',
+      creationName: 'remote plugin',
+      url: 'https://cdn.segment.com/actions/file.js',
+      libraryName: 'testPlugin',
+      settings: {},
+    }
     await remoteLoader(
       {
         integrations: {},
         remotePlugins: [
-          {
-            name: 'remote plugin',
-            creationName: 'remote plugin',
-            url: 'https://cdn.segment.com/actions/file.js',
-            libraryName: 'testPlugin',
-            settings: {},
-          },
+          { ...remotePlugin, url: 'https://cdn.segment.com/actions/file.js' },
         ],
       },
       {},
       {}
     )
 
+    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
+
+    await remoteLoader(
+      {
+        integrations: {},
+        remotePlugins: [
+          {
+            ...remotePlugin,
+            url: 'https://cdn.segment.build/actions/file.js',
+          },
+        ],
+      },
+      {},
+      {}
+    )
     expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
   })
 

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -175,6 +175,7 @@ export async function remoteLoader(
     async (remotePlugin) => {
       if (isPluginDisabled(userIntegrations, remotePlugin)) return
       try {
+        const defaultCdn = new RegExp('https://cdn.segment.(com|build)')
         if (obfuscate) {
           const urlSplit = remotePlugin.url.split('/')
           const name = urlSplit[urlSplit.length - 2]
@@ -183,20 +184,14 @@ export async function remoteLoader(
             btoa(name).replace(/=/g, '')
           )
           try {
-            await loadScript(
-              obfuscatedURL.replace('https://cdn.segment.com', cdn)
-            )
+            await loadScript(obfuscatedURL.replace(defaultCdn, cdn))
           } catch (error) {
             // Due to syncing concerns it is possible that the obfuscated action destination (or requested version) might not exist.
             // We should use the unobfuscated version as a fallback.
-            await loadScript(
-              remotePlugin.url.replace('https://cdn.segment.com', cdn)
-            )
+            await loadScript(remotePlugin.url.replace(defaultCdn, cdn))
           }
         } else {
-          await loadScript(
-            remotePlugin.url.replace('https://cdn.segment.com', cdn)
-          )
+          await loadScript(remotePlugin.url.replace(defaultCdn, cdn))
         }
 
         const libraryName = remotePlugin.libraryName


### PR DESCRIPTION
Fixes a bug where staging CDNUrl is not properly overridden.

repro: https://sethsilesky.com/ajs-cd.html

![image](https://user-images.githubusercontent.com/5115498/221276358-ced26b33-b6c4-48ac-acb6-b41cecf135cf.png)
