### PR TITLE
Add disable setting to node

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -205,16 +205,13 @@ const appAnalytics = new Analytics({ writeKey: 'APP_WRITE_KEY' });
 ```
 
 ## Development: Disabling Analytics for Tests
-- If you want to intercept / disable analytics for integration tests, you can use something like [nock](https://github.com/nock/nock)
+- Set `disable: true`.
 
 ```ts
-// Note: nock will _not_ work if polyfill fetch with something like undici, as nock uses the http module. Undici has its own interception method.
-import nock from 'nock'
-
-nock('https://api.segment.io')
-  .post('/v1/batch')
-  .reply(201)
-  .persist()
+const analytics = new Analytics({
+  ...
+  disable: process.env.NODE_ENV === 'test'
+})
 ```
 
 
@@ -251,7 +248,7 @@ const analytics = new Analytics({ writeKey: '<MY_WRITE_KEY>' })
 
 Other Differences:
 
-- The `enable` configuration option has been removed-- see "Disabling Analytics" section
+- The configuration option for disabling analytics has changed. `enable: false` ->  `disable: true`
 - the `errorHandler` configuration option has been remove  -- see "Error Handling" section
 - `flushAt` configuration option -> `maxEventsInBatch`.
 - `callback` call signature is different

--- a/packages/node/src/__tests__/disable.integration.test.ts
+++ b/packages/node/src/__tests__/disable.integration.test.ts
@@ -1,0 +1,37 @@
+const fetcher = jest.fn()
+jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
+
+import { createTestAnalytics } from './test-helpers/create-test-analytics'
+
+describe('disable', () => {
+  it('should dispatch callbacks and emit an http request, even if disabled', async () => {
+    const analytics = createTestAnalytics({
+      disable: true,
+    })
+    const emitterCb = jest.fn()
+    analytics.on('http_request', emitterCb)
+    await new Promise((resolve) =>
+      analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
+    )
+    expect(emitterCb).toBeCalledTimes(1)
+  })
+
+  it('should call fetch if disabled is false', async () => {
+    const analytics = createTestAnalytics({
+      disable: false,
+    })
+    await new Promise((resolve) =>
+      analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
+    )
+    expect(fetcher).toBeCalled()
+  })
+  it('should not call fetch if disabled is true', async () => {
+    const analytics = createTestAnalytics({
+      disable: true,
+    })
+    await new Promise((resolve) =>
+      analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
+    )
+    expect(fetcher).not.toBeCalled()
+  })
+})

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -49,6 +49,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         maxRetries: settings.maxRetries ?? 3,
         maxEventsInBatch: settings.maxEventsInBatch ?? 15,
         httpRequestTimeout: settings.httpRequestTimeout,
+        disable: settings.disable,
         flushInterval,
       },
       this as NodeEmitter

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -30,6 +30,10 @@ export interface AnalyticsSettings {
    * The maximum number of milliseconds to wait for an http request. Default: 10000
    */
   httpRequestTimeout?: number
+  /**
+   * Disable the analytics library. All calls will be a noop. Default: false.
+   */
+  disable?: boolean
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -27,6 +27,7 @@ export interface PublisherProps {
   maxRetries: number
   writeKey: string
   httpRequestTimeout?: number
+  disable?: boolean
 }
 
 /**
@@ -44,6 +45,7 @@ export class Publisher {
   private _closeAndFlushPendingItemsCount?: number
   private _httpRequestTimeout: number
   private _emitter: NodeEmitter
+  private _disable: boolean
   constructor(
     {
       host,
@@ -53,6 +55,7 @@ export class Publisher {
       flushInterval,
       writeKey,
       httpRequestTimeout,
+      disable,
     }: PublisherProps,
     emitter: NodeEmitter
   ) {
@@ -66,6 +69,7 @@ export class Publisher {
       path ?? '/v1/batch'
     )
     this._httpRequestTimeout = httpRequestTimeout ?? 10000
+    this._disable = Boolean(disable)
   }
 
   private createBatch(): ContextBatch {
@@ -208,6 +212,11 @@ export class Publisher {
           headers: requestInit.headers,
           body: requestInit.body,
         })
+
+        if (this._disable) {
+          clearTimeout(timeoutId)
+          return batch.resolveEvents()
+        }
 
         const response = await fetch(this._url, requestInit)
 


### PR DESCRIPTION
I decided that we should add back an option to disable analytics. Reason:
- it was available on the old node SDK, so some customer probably wanted it.
- iOS and Android have this option.
- It's easy to implement.
- Most important: Making it as easy as possible for our users not to accidentally hammer our API is in our best interest
https://twilio.slack.com/archives/CALA7QMJQ/p1680281701284099


Set disable: true.
```ts
const analytics = new Analytics({
  ...
  disable: process.env.NODE_ENV === 'test'
})
```
