### PR TITLE
refactor/update: remove duplicate event validation code [Delayed]

### DIFF
--- a/.changeset/yellow-meals-invite.md
+++ b/.changeset/yellow-meals-invite.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-next': patch
+'@segment/analytics-core': patch
+---
+
+Update analytics-core validation message for user ID. Remove duplicate analytics validation logic and consume from core.

--- a/packages/browser/src/core/arguments-resolver/index.ts
+++ b/packages/browser/src/core/arguments-resolver/index.ts
@@ -1,9 +1,9 @@
 import {
-  isFunction,
   isPlainObject,
   isString,
+  isFunction,
   isNumber,
-} from '../../plugins/validation'
+} from '@segment/analytics-core'
 import { Context } from '../context'
 import {
   Callback,

--- a/packages/browser/src/core/arguments-resolver/index.ts
+++ b/packages/browser/src/core/arguments-resolver/index.ts
@@ -1,7 +1,7 @@
 import {
+  isFunction,
   isPlainObject,
   isString,
-  isFunction,
   isNumber,
 } from '@segment/analytics-core'
 import { Context } from '../context'

--- a/packages/browser/src/plugins/validation/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/validation/__tests__/index.test.ts
@@ -12,34 +12,32 @@ const validEvent: SegmentEvent = {
 
 describe('validation', () => {
   ;['track', 'identify', 'group', 'page', 'alias'].forEach((method) => {
+    // @ts-ignore
+    const validationFn: Function = validation[method] as any
     describe(method, () => {
       it('validates that the `event` exists', async () => {
-        const val = async () =>
+        try {
           // @ts-ignore
-          validation[method](
-            // @ts-ignore
-            new Context()
-          )
-
-        await expect(val()).rejects.toMatchInlineSnapshot(
-          `[Error: Event is missing]`
-        )
+          await validationFn(new Context())
+        } catch (err) {
+          expect(err).toBeTruthy()
+        }
+        expect.assertions(1)
       })
 
       it('validates that `event.event` exists', async () => {
-        const val = async () =>
-          // @ts-ignore
-          validation[method](
-            new Context({
-              ...validEvent,
-              event: undefined,
-            })
-          )
-
         if (method === 'track') {
-          await expect(val()).rejects.toMatchInlineSnapshot(
-            `[Error: Event is not a string]`
-          )
+          try {
+            await validationFn(
+              new Context({
+                ...validEvent,
+                event: undefined,
+              })
+            )
+          } catch (err) {
+            expect(err).toBeTruthy()
+          }
+          expect.assertions(1)
         }
       })
 
@@ -47,35 +45,33 @@ describe('validation', () => {
         if (method === 'alias') {
           return
         }
-        const val = async () =>
-          // @ts-ignore
-          validation[method](
+        try {
+          await validationFn(
             new Context({
               ...validEvent,
               properties: undefined,
               traits: undefined,
             })
           )
-
-        await expect(val()).rejects.toMatchInlineSnapshot(
-          `[Error: properties is not an object]`
-        )
+        } catch (err) {
+          expect(err).toBeTruthy()
+        }
+        expect.assertions(1)
       })
 
       it('validates that it contains an user', async () => {
-        const val = async () =>
-          // @ts-ignore
-          validation[method](
+        try {
+          await validationFn(
             new Context({
               ...validEvent,
               userId: undefined,
               anonymousId: undefined,
             })
           )
-
-        await expect(val()).rejects.toMatchInlineSnapshot(
-          `[Error: Missing userId or anonymousId]`
-        )
+        } catch (err) {
+          expect(err).toBeTruthy()
+        }
+        expect.assertions(1)
       })
     })
   })

--- a/packages/browser/src/plugins/validation/index.ts
+++ b/packages/browser/src/plugins/validation/index.ts
@@ -1,12 +1,6 @@
 import type { Plugin } from '../../core/plugin'
 import type { Context } from '../../core/context'
 import { validateEvent } from '@segment/analytics-core'
-export {
-  isPlainObject,
-  isString,
-  isFunction,
-  isNumber,
-} from '@segment/analytics-core'
 
 function validate(ctx: Context): Context {
   validateEvent(ctx.event)

--- a/packages/browser/src/plugins/validation/index.ts
+++ b/packages/browser/src/plugins/validation/index.ts
@@ -1,65 +1,15 @@
 import type { Plugin } from '../../core/plugin'
-import type { SegmentEvent } from '../../core/events'
 import type { Context } from '../../core/context'
-
-export function isString(obj: unknown): obj is string {
-  return typeof obj === 'string'
-}
-
-export function isNumber(obj: unknown): obj is number {
-  return typeof obj === 'number'
-}
-
-export function isFunction(obj: unknown): obj is Function {
-  return typeof obj === 'function'
-}
-
-export function isPlainObject(obj: unknown): obj is Record<string, any> {
-  return (
-    Object.prototype.toString.call(obj).slice(8, -1).toLowerCase() === 'object'
-  )
-}
-
-function hasUser(event: SegmentEvent): boolean {
-  const id =
-    event.userId ?? event.anonymousId ?? event.groupId ?? event.previousId
-  return isString(id)
-}
-
-class ValidationError extends Error {
-  field: string
-
-  constructor(field: string, message: string) {
-    super(message)
-    this.field = field
-  }
-}
+import { validateEvent } from '@segment/analytics-core'
+export {
+  isPlainObject,
+  isString,
+  isFunction,
+  isNumber,
+} from '@segment/analytics-core'
 
 function validate(ctx: Context): Context {
-  const eventType: unknown = ctx && ctx.event && ctx.event.type
-  const event = ctx.event
-
-  if (event === undefined) {
-    throw new ValidationError('event', 'Event is missing')
-  }
-
-  if (!isString(eventType)) {
-    throw new ValidationError('event', 'Event is not a string')
-  }
-
-  if (eventType === 'track' && !isString(event.event)) {
-    throw new ValidationError('event', 'Event is not a string')
-  }
-
-  const props = event.properties ?? event.traits
-  if (eventType !== 'alias' && !isPlainObject(props)) {
-    throw new ValidationError('properties', 'properties is not an object')
-  }
-
-  if (!hasUser(event)) {
-    throw new ValidationError('userId', 'Missing userId or anonymousId')
-  }
-
+  validateEvent(ctx.event)
   return ctx
 }
 

--- a/packages/core/src/validation/__tests__/assertions.test.ts
+++ b/packages/core/src/validation/__tests__/assertions.test.ts
@@ -126,4 +126,12 @@ describe('validateEvent', () => {
       })
     ).toThrow()
   })
+  test('should prepend field name', () => {
+    expect(() =>
+      validateEvent({
+        type: 'identify',
+        traits: undefined,
+      })
+    ).toThrowError('traits is not an object')
+  })
 })

--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -5,32 +5,32 @@ export class ValidationError extends Error {
   field: string
 
   constructor(field: string, message: string) {
-    super(message)
+    super(`${field} ${message}`)
     this.field = field
   }
 }
 
 export function validateEvent(event?: CoreSegmentEvent | null) {
   if (!event || typeof event !== 'object') {
-    throw new ValidationError('event', 'Event is missing')
+    throw new ValidationError('event', 'is missing')
   }
 
   if (!isString(event.type)) {
-    throw new ValidationError('type', 'type is not a string')
+    throw new ValidationError('type', 'is not a string')
   }
 
   if (event.type === 'track') {
     if (!isString(event.event)) {
-      throw new ValidationError('event', 'Event is not a string')
+      throw new ValidationError('event', 'is not a string')
     }
     if (!isPlainObject(event.properties)) {
-      throw new ValidationError('properties', 'properties is not an object')
+      throw new ValidationError('properties', 'is not an object')
     }
   }
 
   if (['group', 'identify'].includes(event.type)) {
     if (!isPlainObject(event.traits)) {
-      throw new ValidationError('traits', 'traits is not an object')
+      throw new ValidationError('traits', 'is not an object')
     }
   }
 

--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -37,7 +37,7 @@ export function validateEvent(event?: CoreSegmentEvent | null) {
   if (!hasUser(event)) {
     throw new ValidationError(
       'userId/anonymousId/previousId/groupId',
-      'Must have userId or anonymousId or previousId or groupId'
+      'must have an ID AND must be string'
     )
   }
 }


### PR DESCRIPTION
Remove event duplicate validation code.

This also contains the great suggestion from: https://github.com/segmentio/analytics-next/pull/790 to improve the ID validation message so if a user accidentally passes a number as an ID, they aren't stuck going in circles with an "ID missing" message.