### PR TITLE
Refactor page enrichment plugin

### DIFF
--- a/.changeset/quiet-islands-kneel.md
+++ b/.changeset/quiet-islands-kneel.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Refactor page enrichment to only call page defaults once, and simplify logic

--- a/packages/browser/src/lib/__tests__/pick.test.ts
+++ b/packages/browser/src/lib/__tests__/pick.test.ts
@@ -1,0 +1,34 @@
+import { pick } from '../pick'
+
+describe(pick, () => {
+  it.each([
+    {
+      obj: { a: 1, b: '2', c: 3 },
+      keys: ['a', 'c'],
+      expected: { a: 1, c: 3 },
+    },
+    {
+      obj: { a: 1, '0': false, c: 3 },
+      keys: ['a', '0'],
+      expected: { a: 1, '0': false },
+    },
+    { obj: { a: 1, b: '2', c: 3 }, keys: [], expected: {} },
+    {
+      obj: { a: undefined, b: null, c: 1 },
+      keys: ['a', 'b'],
+      expected: { a: undefined, b: null },
+    },
+  ])('.pick($obj, $keys)', ({ obj, keys, expected }) => {
+    expect(pick(obj, keys as (keyof typeof obj)[])).toEqual(expected)
+  })
+  it('does not mutate object reference', () => {
+    const e = {
+      obj: { a: 1, '0': false, c: 3 },
+      keys: ['a', '0'] as const,
+      expected: { a: 1, '0': false },
+    }
+    const ogObj = { ...e.obj }
+    pick(e.obj, e.keys)
+    expect(e.obj).toEqual(ogObj)
+  })
+})

--- a/packages/browser/src/lib/pick.ts
+++ b/packages/browser/src/lib/pick.ts
@@ -1,0 +1,17 @@
+/**
+ * @example
+ * pick({ 'a': 1, 'b': '2', 'c': 3 }, ['a', 'c'])
+ * => { 'a': 1, 'c': 3 }
+ */
+export const pick = <T, K extends keyof T>(
+  object: T,
+  keys: readonly K[]
+): Pick<T, K> =>
+  Object.assign(
+    {},
+    ...keys.map((key) => {
+      if (object && Object.prototype.hasOwnProperty.call(object, key)) {
+        return { [key]: object[key] }
+      }
+    })
+  )

--- a/packages/browser/src/plugins/page-enrichment/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/page-enrichment/__tests__/index.test.ts
@@ -51,28 +51,41 @@ describe('Page Enrichment', () => {
     )
 
     expect(ctx.event.context?.page).toMatchInlineSnapshot(`
-    Object {
-      "path": "/",
-      "referrer": "",
-      "search": "",
-      "title": "",
-      "url": "not-localhost",
-    }
-  `)
+          Object {
+            "path": "/",
+            "referrer": "",
+            "search": "",
+            "title": "",
+            "url": "not-localhost",
+          }
+      `)
   })
-
   test('enriches page events using properties', async () => {
     const ctx = await ajs.page('My event', { banana: 'phone', referrer: 'foo' })
 
     expect(ctx.event.context?.page).toMatchInlineSnapshot(`
-    Object {
-      "path": "/",
-      "referrer": "foo",
-      "search": "",
-      "title": "",
-      "url": "http://localhost/",
-    }
-  `)
+          Object {
+            "path": "/",
+            "referrer": "foo",
+            "search": "",
+            "title": "",
+            "url": "http://localhost/",
+          }
+      `)
+  })
+
+  test('in page events, event.name overrides event.properties.name', async () => {
+    const ctx = await ajs.page('My Event', undefined, undefined, {
+      name: 'some propery name',
+    })
+    expect(ctx.event.properties!.name).toBe('My Event')
+  })
+
+  test('in non-page events, event.name does not override event.properties.name', async () => {
+    const ctx = await ajs.track('My Event', {
+      name: 'some propery name',
+    })
+    expect(ctx.event.properties!.name).toBe('some propery name')
   })
 
   test('enriches identify events with the page context', async () => {
@@ -146,5 +159,11 @@ describe('pageDefaults', () => {
     document.body.appendChild(el)
     const defs = pageDefaults()
     expect(defs.url).toEqual('http://www.segment.local?test=true')
+  })
+
+  it('if canonical does not exist, returns fallback', () => {
+    document.body.appendChild(el)
+    const defs = pageDefaults()
+    expect(defs.url).toEqual(window.location.href)
   })
 })

--- a/packages/browser/src/plugins/page-enrichment/index.ts
+++ b/packages/browser/src/plugins/page-enrichment/index.ts
@@ -1,3 +1,4 @@
+import { pick } from '../../lib/pick'
 import type { Context } from '../../core/context'
 import type { Plugin } from '../../core/plugin'
 
@@ -12,20 +13,12 @@ interface PageDefault {
 
 /**
  * Get the current page's canonical URL.
- *
- * @return {string|undefined}
  */
-function canonical(): string {
-  const tags = document.getElementsByTagName('link')
-  let canon: string | null = ''
-
-  Array.prototype.slice.call(tags).forEach((tag) => {
-    if (tag.getAttribute('rel') === 'canonical') {
-      canon = tag.getAttribute('href')
-    }
-  })
-
-  return canon
+function canonical(): string | undefined {
+  const canon = document.querySelector("link[rel='canonical']")
+  if (canon) {
+    return canon.getAttribute('href') || undefined
+  }
 }
 
 /**
@@ -79,24 +72,25 @@ export function pageDefaults(): PageDefault {
 function enrichPageContext(ctx: Context): Context {
   const event = ctx.event
   event.context = event.context || {}
-  let pageContext = pageDefaults()
-  const pageProps = event.properties ?? {}
 
-  Object.keys(pageContext).forEach((key) => {
-    if (pageProps[key]) {
-      pageContext[key] = pageProps[key]
-    }
-  })
+  const defaultPageContext = pageDefaults()
 
-  if (event.context.page) {
-    pageContext = Object.assign({}, pageContext, event.context.page)
+  const pageContextFromEventProps =
+    event.properties && pick(event.properties, Object.keys(defaultPageContext))
+
+  event.context.page = {
+    ...defaultPageContext,
+    ...pageContextFromEventProps,
+    ...event.context.page,
   }
 
-  event.context = Object.assign({}, event.context, {
-    page: pageContext,
-  })
-
-  ctx.event = event
+  if (event.type === 'page') {
+    event.properties = {
+      ...defaultPageContext,
+      ...event.properties,
+      ...(event.name ? { name: event.name } : {}),
+    }
+  }
 
   return ctx
 }
@@ -107,21 +101,7 @@ export const pageEnrichment: Plugin = {
   isLoaded: () => true,
   load: () => Promise.resolve(),
   type: 'before',
-
-  page: (ctx) => {
-    ctx.event.properties = Object.assign(
-      {},
-      pageDefaults(),
-      ctx.event.properties
-    )
-
-    if (ctx.event.name) {
-      ctx.event.properties.name = ctx.event.name
-    }
-
-    return enrichPageContext(ctx)
-  },
-
+  page: enrichPageContext,
   alias: enrichPageContext,
   track: enrichPageContext,
   identify: enrichPageContext,


### PR DESCRIPTION
Page Enrichment plugin was messy and written in a very imperative style, and and was hard to grok with so much overriding. This is a major improvement in readability by using a functional style.

-  pageDefault() was called twice for every page() call, now it's called once
- canonical() is now type safe and uses `querySelector` rather than `getElementsByTagName`
- passing page properties with an empty string should now properly override fields (tests in other PR -- related to semantics of the pick function).

This work is related to the work around fixing stale / wrong UTM params / page properties, but I want to keep my branches clean if possible.

 