### PR TITLE
Fix wrong utm parsing by making context.page.search the source of truth for query params.

### DIFF
--- a/.changeset/red-ears-sleep.md
+++ b/.changeset/red-ears-sleep.md
@@ -1,0 +1,10 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fixes a bug where users who override page properties:
+```ts
+analytics.page(undefined, undefined, {search: "?utm_source=123&utm_content=content" )
+analytics.track("foo", {url: "....", search: "?utm_source=123&utm_content=content" )
+```
+...would get the wrong context.campaign object.

--- a/.changeset/red-ears-sleep.md
+++ b/.changeset/red-ears-sleep.md
@@ -2,9 +2,11 @@
 '@segment/analytics-next': patch
 ---
 
-Fixes a bug where users who override page properties:
+Fixes a utm-parameter parsing bug where overridden page.search properties would not be reflected in the context.campaign object
 ```ts
 analytics.page(undefined, undefined, {search: "?utm_source=123&utm_content=content" )
 analytics.track("foo", {url: "....", search: "?utm_source=123&utm_content=content" )
+
+// should result in a context.campaign of:
+{ source: 123, content: 'content'}
 ```
-...would get the wrong context.campaign object.

--- a/packages/browser/src/plugins/segmentio/normalize.ts
+++ b/packages/browser/src/plugins/segmentio/normalize.ts
@@ -126,13 +126,11 @@ export function normalize(
 ): object {
   const user = analytics.user()
 
+  // context should always exist here (see page enrichment)? ... and why would we default to json.options? todo: delete this
   json.context = json.context ?? json.options ?? {}
   const ctx = json.context
 
-  // This guard should not be neccessary -- why would context not exist here? Ditto ^ --
-  // page enrichment should add a context to an event by default.
-  // In any case, adding an empty string 'default'.
-  // We do not use the current search parameters, as they might be stale by this point.
+  // This guard against missing ctx.page should not be neccessary, since context.page is always defined
   const query: string = ctx.page?.search || ''
 
   delete json.options

--- a/packages/browser/src/plugins/segmentio/normalize.ts
+++ b/packages/browser/src/plugins/segmentio/normalize.ts
@@ -125,10 +125,15 @@ export function normalize(
   integrations?: LegacySettings['integrations']
 ): object {
   const user = analytics.user()
-  const query = window.location.search
 
   json.context = json.context ?? json.options ?? {}
   const ctx = json.context
+
+  // This guard should not be neccessary -- why would context not exist here? Ditto ^ --
+  // page enrichment should add a context to an event by default.
+  // In any case, adding an empty string 'default'.
+  // We do not use the current search parameters, as they might be stale by this point.
+  const query: string = ctx.page?.search || ''
 
   delete json.options
   json.writeKey = settings?.apiKey


### PR DESCRIPTION
Fixes a utm-parameter parsing bug where overridden page.search properties would not be reflected in the context.campaign object
```ts
analytics.page(undefined, undefined, {search: "?utm_source=123&utm_content=content" )
analytics.track("foo", {url: "....", search: "?utm_source=123&utm_content=content" )

// should result in a context.campaign of:
{ source: 123, content: 'content'}
```
This fix is part 2 --
See: https://github.com/segmentio/analytics-next/pull/838
