### PR TITLE
Fix 'Promise is undefined' error that breaks ie11 auto-polyfill

### DIFF
--- a/.changeset/khaki-spoons-laugh.md
+++ b/.changeset/khaki-spoons-laugh.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix 'Promise is undefined' issue with ie11 polyfill

--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -31,15 +31,14 @@ import {
 
 let ajsIdentifiedCSP = false
 
-const sendErrorMetrics = (() => {
+const sendErrorMetrics = (tags: string[]) => {
+  // this should not be instantied at the root, or it will break ie11.
   const metrics = new RemoteMetrics()
-  return (tags: string[]) => {
-    metrics.increment('analytics_js.invoke.error', [
-      ...tags,
-      `wk:${embeddedWriteKey()}`,
-    ])
-  }
-})()
+  metrics.increment('analytics_js.invoke.error', [
+    ...tags,
+    `wk:${embeddedWriteKey()}`,
+  ])
+}
 
 function onError(err?: unknown) {
   console.error('[analytics.js]', 'Failed to load Analytics.js', err)


### PR DESCRIPTION
I accidentally introduced an ie11 regression when adding some CSP logic. Who knew eagerly instantiating RemoteMetrics would be the problem?

PS: Another data point for why we want webdriver tests that run browsers via a device farm (like I set up with action-destinations.)