### PR TITLE
Add ability to use action-destinations from NPM

### DIFF
--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -10,7 +10,11 @@ import { MetricsOptions } from '../core/stats/remote-metrics'
 import { mergedOptions } from '../lib/merged-options'
 import { createDeferred } from '../lib/create-deferred'
 import { pageEnrichment } from '../plugins/page-enrichment'
-import { remoteLoader, RemotePlugin } from '../plugins/remote-loader'
+import {
+  PluginFactory,
+  remoteLoader,
+  RemotePlugin
+} from '../plugins/remote-loader'
 import type { RoutingRule } from '../plugins/routing-middleware'
 import { segmentio, SegmentioSettings } from '../plugins/segmentio'
 import { validation } from '../plugins/validation'
@@ -154,7 +158,8 @@ async function registerPlugins(
   analytics: Analytics,
   opts: InitOptions,
   options: InitOptions,
-  plugins: Plugin[],
+  plugins: Plugin[] = [],
+  pluginSources: PluginFactory[],
   legacyIntegrationSources: ClassicIntegrationSource[]
 ): Promise<Context> {
   const tsubMiddleware = hasTsubMiddleware(legacySettings)
@@ -204,7 +209,8 @@ async function registerPlugins(
     analytics.integrations,
     mergedSettings,
     options.obfuscate,
-    tsubMiddleware
+    tsubMiddleware,
+    pluginSources
   ).catch(() => [])
 
   const toRegister = [
@@ -278,7 +284,16 @@ async function loadAnalytics(
 
   attachInspector(analytics)
 
-  const plugins = settings.plugins ?? []
+  const plugins = settings.plugins?.filter(
+    (pluginLike) => typeof pluginLike === 'object'
+  ) as Plugin[]
+
+  const pluginSources = settings.plugins?.filter(
+    (pluginLike) =>
+      typeof pluginLike === 'function' &&
+      typeof pluginLike.pluginName === 'string'
+  ) as PluginFactory[]
+
   const classicIntegrations = settings.classicIntegrations ?? []
   Stats.initRemoteMetrics(legacySettings.metrics)
 
@@ -291,6 +306,7 @@ async function loadAnalytics(
     opts,
     options,
     plugins,
+    pluginSources,
     classicIntegrations
   )
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -48,6 +48,7 @@ import { version } from '../../generated/version'
 import { PriorityQueue } from '../../lib/priority-queue'
 import { getGlobal } from '../../lib/get-global'
 import { AnalyticsClassic, AnalyticsCore } from './interfaces'
+import { PluginFactory } from '../../plugins/remote-loader'
 
 const deprecationWarning =
   'This is being deprecated and will be not be available in future releases of Analytics JS'
@@ -67,7 +68,7 @@ function createDefaultQueue(retryQueue = false, disablePersistance = false) {
 export interface AnalyticsSettings {
   writeKey: string
   timeout?: number
-  plugins?: Plugin[]
+  plugins?: (Plugin | PluginFactory)[]
   classicIntegrations?: ClassicIntegrationSource[]
 }
 


### PR DESCRIPTION
This pull request is the other half of https://github.com/segmentio/action-destinations/pull/1276.

This patch just adds the necessary moving parts that will let users bring in action-destinations from NPM.