### PR TITLE
Add ability to pass custom http client into node

### DIFF
--- a/.changeset/nervous-chefs-talk.md
+++ b/.changeset/nervous-chefs-talk.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-node': minor
+---
+
+Add `httpClient` setting. This allow users to override default HTTP client with a custom one.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
-    "@types/node": "^16"
+    "@types/node": "^16",
+    "axios": "^1.4.0"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/packages/node/src/__tests__/callback.test.ts
+++ b/packages/node/src/__tests__/callback.test.ts
@@ -1,17 +1,11 @@
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
-import { createError, createSuccess } from './test-helpers/factories'
 import { createTestAnalytics } from './test-helpers/create-test-analytics'
 import { Context } from '../app/context'
 
 describe('Callback behavior', () => {
-  beforeEach(() => {
-    fetcher.mockReturnValue(createSuccess())
-  })
-
   it('should handle success', async () => {
-    const ajs = createTestAnalytics({ maxEventsInBatch: 1 })
+    const ajs = createTestAnalytics({
+      maxEventsInBatch: 1,
+    })
     const ctx = await new Promise<Context>((resolve, reject) =>
       ajs.track(
         {
@@ -29,8 +23,12 @@ describe('Callback behavior', () => {
   })
 
   it('should handle errors', async () => {
-    fetcher.mockReturnValue(createError())
-    const ajs = createTestAnalytics({ maxEventsInBatch: 1 })
+    const ajs = createTestAnalytics(
+      {
+        maxEventsInBatch: 1,
+      },
+      { withError: true }
+    )
     const [err, ctx] = await new Promise<[any, Context]>((resolve) =>
       ajs.track(
         {

--- a/packages/node/src/__tests__/disable.integration.test.ts
+++ b/packages/node/src/__tests__/disable.integration.test.ts
@@ -5,9 +5,9 @@ import {
 
 describe('disable', () => {
   const httpClient = new TestFetchClient()
-  const mockSend = jest.spyOn(httpClient, 'send')
+  const makeReqSpy = jest.spyOn(httpClient, 'makeRequest')
 
-  it('should dispatch callbacks and emit an http request, even if disabled', async () => {
+  it('should not emit an http request if disabled', async () => {
     const analytics = createTestAnalytics({
       disable: true,
     })
@@ -16,7 +16,7 @@ describe('disable', () => {
     await new Promise((resolve) =>
       analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
     )
-    expect(emitterCb).toBeCalledTimes(1)
+    expect(emitterCb).not.toBeCalled()
   })
 
   it('should call .send if disabled is false', async () => {
@@ -27,7 +27,7 @@ describe('disable', () => {
     await new Promise((resolve) =>
       analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
     )
-    expect(mockSend).toBeCalledTimes(1)
+    expect(makeReqSpy).toBeCalledTimes(1)
   })
   it('should not call .send if disabled is true', async () => {
     const analytics = createTestAnalytics({
@@ -37,6 +37,6 @@ describe('disable', () => {
     await new Promise((resolve) =>
       analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
     )
-    expect(mockSend).not.toBeCalled()
+    expect(makeReqSpy).not.toBeCalled()
   })
 })

--- a/packages/node/src/__tests__/disable.integration.test.ts
+++ b/packages/node/src/__tests__/disable.integration.test.ts
@@ -1,9 +1,12 @@
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
-import { createTestAnalytics } from './test-helpers/create-test-analytics'
+import {
+  createTestAnalytics,
+  TestFetchClient,
+} from './test-helpers/create-test-analytics'
 
 describe('disable', () => {
+  const httpClient = new TestFetchClient()
+  const mockSend = jest.spyOn(httpClient, 'send')
+
   it('should dispatch callbacks and emit an http request, even if disabled', async () => {
     const analytics = createTestAnalytics({
       disable: true,
@@ -16,22 +19,24 @@ describe('disable', () => {
     expect(emitterCb).toBeCalledTimes(1)
   })
 
-  it('should call fetch if disabled is false', async () => {
+  it('should call .send if disabled is false', async () => {
     const analytics = createTestAnalytics({
       disable: false,
+      httpClient: httpClient,
     })
     await new Promise((resolve) =>
       analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
     )
-    expect(fetcher).toBeCalled()
+    expect(mockSend).toBeCalledTimes(1)
   })
-  it('should not call fetch if disabled is true', async () => {
+  it('should not call .send if disabled is true', async () => {
     const analytics = createTestAnalytics({
       disable: true,
+      httpClient: httpClient,
     })
     await new Promise((resolve) =>
       analytics.track({ anonymousId: 'foo', event: 'bar' }, resolve)
     )
-    expect(fetcher).not.toBeCalled()
+    expect(mockSend).not.toBeCalled()
   })
 })

--- a/packages/node/src/__tests__/emitter.integration.test.ts
+++ b/packages/node/src/__tests__/emitter.integration.test.ts
@@ -1,13 +1,8 @@
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
-import { createError, createSuccess } from './test-helpers/factories'
 import { createTestAnalytics } from './test-helpers/create-test-analytics'
 import { assertHttpRequestEmittedEvent } from './test-helpers/assert-shape'
 
 describe('http_request', () => {
   it('emits an http_request event if success', async () => {
-    fetcher.mockReturnValue(createSuccess())
     const analytics = createTestAnalytics()
     const fn = jest.fn()
     analytics.on('http_request', fn)
@@ -19,8 +14,12 @@ describe('http_request', () => {
   })
 
   it('emits an http_request event if error', async () => {
-    fetcher.mockReturnValue(createError())
-    const analytics = createTestAnalytics({ maxRetries: 0 })
+    const analytics = createTestAnalytics(
+      {
+        maxRetries: 0,
+      },
+      { withError: true }
+    )
     const fn = jest.fn()
     analytics.on('http_request', fn)
     await new Promise((resolve) =>
@@ -30,8 +29,12 @@ describe('http_request', () => {
   })
 
   it('if error, emits an http_request event on every retry', async () => {
-    fetcher.mockReturnValue(createError())
-    const analytics = createTestAnalytics({ maxRetries: 2 })
+    const analytics = createTestAnalytics(
+      {
+        maxRetries: 2,
+      },
+      { withError: true }
+    )
     const fn = jest.fn()
     analytics.on('http_request', fn)
     await new Promise((resolve) =>

--- a/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
+++ b/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
@@ -14,7 +14,7 @@ const testPlugin: Plugin = {
 }
 
 const testClient = new TestFetchClient()
-const sendSpy = jest.spyOn(testClient, 'send')
+const sendSpy = jest.spyOn(testClient, 'makeRequest')
 
 describe('Ability for users to exit without losing events', () => {
   let ajs!: Analytics

--- a/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
+++ b/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
@@ -1,9 +1,5 @@
-import { createSuccess } from './test-helpers/factories'
+import { TestFetchClient } from './test-helpers/create-test-analytics'
 import { performance as perf } from 'perf_hooks'
-
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
 import { Analytics } from '../app/analytics-node'
 import { sleep } from './test-helpers/sleep'
 import { Plugin, SegmentEvent } from '../app/types'
@@ -17,22 +13,25 @@ const testPlugin: Plugin = {
   isLoaded: () => true,
 }
 
+const testClient = new TestFetchClient()
+const sendSpy = jest.spyOn(testClient, 'send')
+
 describe('Ability for users to exit without losing events', () => {
   let ajs!: Analytics
   beforeEach(async () => {
-    fetcher.mockReturnValue(createSuccess())
     ajs = new Analytics({
       writeKey: 'abc123',
       maxEventsInBatch: 1,
+      httpClient: testClient,
     })
   })
   const _helpers = {
-    getFetchCalls: (mockedFetchFn = fetcher) =>
-      mockedFetchFn.mock.calls.map(([url, request]) => ({
+    getFetchCalls: () =>
+      sendSpy.mock.calls.map(([url, request]) => ({
         url,
         method: request.method,
         headers: request.headers,
-        body: JSON.parse(request.body),
+        body: JSON.parse(request.body!),
       })),
     makeTrackCall: (analytics = ajs, cb?: (...args: any[]) => void) => {
       analytics.track({ userId: 'foo', event: 'Thing Updated' }, cb)
@@ -89,6 +88,7 @@ describe('Ability for users to exit without losing events', () => {
       ajs = new Analytics({
         writeKey: 'abc123',
         flushInterval,
+        httpClient: testClient,
       })
       const closeAndFlushTimeout = ajs['_closeAndFlushDefaultTimeout']
       expect(closeAndFlushTimeout).toBe(flushInterval * 1.25)
@@ -190,6 +190,7 @@ describe('Ability for users to exit without losing events', () => {
         writeKey: 'foo',
         flushInterval: 10000,
         maxEventsInBatch: 15,
+        httpClient: testClient,
       })
       _helpers.makeTrackCall(analytics)
       _helpers.makeTrackCall(analytics)
@@ -220,6 +221,7 @@ describe('Ability for users to exit without losing events', () => {
         writeKey: 'foo',
         flushInterval: 10000,
         maxEventsInBatch: 15,
+        httpClient: testClient,
       })
       await analytics.register(_testPlugin)
       _helpers.makeTrackCall(analytics)

--- a/packages/node/src/__tests__/http-client.integration.test.ts
+++ b/packages/node/src/__tests__/http-client.integration.test.ts
@@ -1,8 +1,8 @@
 import { HTTPFetchFn } from '..'
+import { AbortSignal as AbortSignalShim } from '../lib/abort'
 import { httpClientOptionsBodyMatcher } from './test-helpers/assert-shape/segment-http-api'
 import { createTestAnalytics } from './test-helpers/create-test-analytics'
 import { createSuccess } from './test-helpers/factories'
-
 const testFetch: jest.MockedFn<HTTPFetchFn> = jest
   .fn()
   .mockResolvedValue(createSuccess())
@@ -18,7 +18,13 @@ const assertFetchCallRequest = (
   })
   expect(options.method).toBe('POST')
 
-  expect(options.signal).toBeInstanceOf(AbortSignal)
+  // @ts-ignore
+  if (typeof AbortSignal !== 'undefined') {
+    // @ts-ignore
+    expect(options.signal).toBeInstanceOf(AbortSignal)
+  } else {
+    expect(options.signal).toBeInstanceOf(AbortSignalShim)
+  }
 }
 const getLastBatch = (): any[] => {
   const [, options] = testFetch.mock.lastCall

--- a/packages/node/src/__tests__/http-client.integration.test.ts
+++ b/packages/node/src/__tests__/http-client.integration.test.ts
@@ -1,0 +1,44 @@
+import { HTTPFetchFn } from '..'
+import { httpClientOptionsBodyMatcher } from './test-helpers/assert-shape/segment-http-api'
+import { createTestAnalytics } from './test-helpers/create-test-analytics'
+import { createSuccess } from './test-helpers/factories'
+
+const testFetch: jest.MockedFn<HTTPFetchFn> = jest
+  .fn()
+  .mockResolvedValue(createSuccess())
+
+const assertFetchCallRequest = (url: string, options: RequestInit) => {
+  expect(url).toBe('https://api.segment.io/v1/batch')
+  expect(options.headers).toEqual({
+    Authorization: 'Basic Zm9vOg==',
+    'Content-Type': 'application/json',
+    'User-Agent': 'analytics-node-next/latest',
+  })
+  expect(options.method).toBe('POST')
+
+  expect(options.signal).toBeInstanceOf(AbortSignal)
+}
+describe('HTTP Client', () => {
+  it('should accept a custom fetch function', async () => {
+    const analytics = createTestAnalytics({ httpClient: testFetch })
+    expect(testFetch).toHaveBeenCalledTimes(0)
+    await new Promise((resolve) =>
+      analytics.track({ event: 'foo', userId: 'bar' }, resolve)
+    )
+    expect(testFetch).toHaveBeenCalledTimes(1)
+    assertFetchCallRequest(...testFetch.mock.lastCall)
+    const [, options] = testFetch.mock.lastCall
+    const batch = JSON.parse(options.body!).batch
+    expect(batch.length).toBe(1)
+    expect(batch[0]).toEqual({
+      ...httpClientOptionsBodyMatcher,
+      timestamp: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      ),
+      properties: {},
+      type: 'track',
+      userId: 'bar',
+      event: 'foo',
+    })
+  })
+})

--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -33,7 +33,7 @@ describe('Method Smoke Tests', () => {
   let scope: nock.Scope
   let ajs: Analytics
   beforeEach(async () => {
-    ajs = createTestAnalytics()
+    ajs = createTestAnalytics({}, { useRealHTTPClient: true })
   })
 
   describe('Metadata', () => {
@@ -333,10 +333,13 @@ describe('Client: requestTimeout', () => {
   })
   it('should timeout immediately if request timeout is set to 0', async () => {
     jest.useRealTimers()
-    const ajs = createTestAnalytics({
-      maxEventsInBatch: 1,
-      httpRequestTimeout: 0,
-    })
+    const ajs = createTestAnalytics(
+      {
+        maxEventsInBatch: 1,
+        httpRequestTimeout: 0,
+      },
+      { useRealHTTPClient: true }
+    )
     ajs.track({ event: 'foo', userId: 'foo', properties: { hello: 'world' } })
     try {
       await resolveCtx(ajs, 'track')

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -12,7 +12,7 @@ jest.setTimeout(10000)
 const timestamp = new Date()
 
 const testClient = new TestFetchClient()
-const sendSpy = jest.spyOn(testClient, 'send')
+const sendSpy = jest.spyOn(testClient, 'makeRequest')
 
 describe('Settings / Configuration Init', () => {
   it('throws if no writeKey', () => {

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -12,7 +12,7 @@ jest.setTimeout(10000)
 const timestamp = new Date()
 
 const testClient = new TestFetchClient()
-const sendSpy = jest.spyOn(testClient, 'makeRequest')
+const makeReqSpy = jest.spyOn(testClient, 'makeRequest')
 
 describe('Settings / Configuration Init', () => {
   it('throws if no writeKey', () => {
@@ -32,7 +32,7 @@ describe('Settings / Configuration Init', () => {
     const track = resolveCtx(analytics, 'track')
     analytics.track({ event: 'foo', userId: 'sup' })
     await track
-    expect(sendSpy.mock.calls[0][0]).toBe('http://foo.com/bar')
+    expect(makeReqSpy.mock.calls[0][0].url).toBe('http://foo.com/bar')
   })
 
   it('throws if host / path is bad', async () => {

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -1,19 +1,18 @@
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
 import { Plugin } from '../app/types'
 import { resolveCtx } from './test-helpers/resolve-ctx'
 import { testPlugin } from './test-helpers/test-plugin'
-import { createSuccess, createError } from './test-helpers/factories'
-import { createTestAnalytics } from './test-helpers/create-test-analytics'
+import { createError } from './test-helpers/factories'
+import {
+  createTestAnalytics,
+  TestFetchClient,
+} from './test-helpers/create-test-analytics'
 
 const writeKey = 'foo'
 jest.setTimeout(10000)
 const timestamp = new Date()
 
-beforeEach(() => {
-  fetcher.mockReturnValue(createSuccess())
-})
+const testClient = new TestFetchClient()
+const sendSpy = jest.spyOn(testClient, 'send')
 
 describe('Settings / Configuration Init', () => {
   it('throws if no writeKey', () => {
@@ -28,11 +27,12 @@ describe('Settings / Configuration Init', () => {
     const analytics = createTestAnalytics({
       host: 'http://foo.com',
       path: '/bar',
+      httpClient: testClient,
     })
     const track = resolveCtx(analytics, 'track')
     analytics.track({ event: 'foo', userId: 'sup' })
     await track
-    expect(fetcher.mock.calls[0][0]).toBe('http://foo.com/bar')
+    expect(sendSpy.mock.calls[0][0]).toBe('http://foo.com/bar')
   })
 
   it('throws if host / path is bad', async () => {
@@ -53,10 +53,14 @@ describe('Error handling', () => {
   })
 
   it('should emit on an error', async () => {
-    const analytics = createTestAnalytics({ maxRetries: 0 })
-    fetcher.mockReturnValue(
-      createError({ statusText: 'Service Unavailable', status: 503 })
-    )
+    const err = createError({
+      statusText: 'Service Unavailable',
+      status: 503,
+    })
+    const analytics = createTestAnalytics({
+      maxRetries: 0,
+      httpClient: new TestFetchClient({ response: err }),
+    })
     try {
       const promise = resolveCtx(analytics, 'track')
       analytics.track({ event: 'foo', userId: 'sup' })

--- a/packages/node/src/__tests__/plugins.test.ts
+++ b/packages/node/src/__tests__/plugins.test.ts
@@ -1,14 +1,6 @@
-const fetcher = jest.fn()
-jest.mock('../lib/fetch', () => ({ fetch: fetcher }))
-
-import { createSuccess } from './test-helpers/factories'
 import { createTestAnalytics } from './test-helpers/create-test-analytics'
 
 describe('Plugins', () => {
-  beforeEach(() => {
-    fetcher.mockReturnValue(createSuccess())
-  })
-
   describe('Initialize', () => {
     it('loads analytics-node-next plugin', async () => {
       const analytics = createTestAnalytics()

--- a/packages/node/src/__tests__/test-helpers/assert-shape/http-request-event.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/http-request-event.ts
@@ -4,7 +4,7 @@ type HttpRequestEmitterEvent = NodeEmitterEvents['http_request'][0]
 export const assertHttpRequestEmittedEvent = (
   event: HttpRequestEmitterEvent
 ) => {
-  const body = JSON.parse(event.body)
+  const body = event.body
   expect(Array.isArray(body.batch)).toBeTruthy()
   expect(body.batch.length).toBe(1)
   expect(typeof event.headers).toBe('object')

--- a/packages/node/src/__tests__/test-helpers/assert-shape/index.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/index.ts
@@ -1,1 +1,2 @@
 export * from './http-request-event'
+export * from './segment-http-api'

--- a/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
@@ -1,5 +1,5 @@
 import { Context } from '../../../app/context'
-import { HTTPRequestOptions } from '../../../lib/http-client'
+import { HTTPClientRequestOptions } from '../../../lib/http-client'
 
 /**
  * These map to the data properties of the HTTPClient options (the input value of 'makeRequest')
@@ -18,7 +18,7 @@ export const httpClientOptionsBodyMatcher = {
 }
 
 export function assertHTTPRequestOptions(
-  { data, headers, method, url }: HTTPRequestOptions,
+  { data, headers, method, url }: HTTPClientRequestOptions,
   contexts: Context[]
 ) {
   expect(url).toBe('https://api.segment.io/v1/batch')

--- a/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
@@ -1,5 +1,5 @@
 import { Context } from '../../../app/context'
-import { HTTPClientRequestOptions } from '../../../lib/http-client'
+import { HTTPClientRequest } from '../../../lib/http-client'
 
 /**
  * These map to the data properties of the HTTPClient options (the input value of 'makeRequest')
@@ -18,7 +18,7 @@ export const httpClientOptionsBodyMatcher = {
 }
 
 export function assertHTTPRequestOptions(
-  { data, headers, method, url }: HTTPClientRequestOptions,
+  { data, headers, method, url }: HTTPClientRequest,
   contexts: Context[]
 ) {
   expect(url).toBe('https://api.segment.io/v1/batch')

--- a/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
+++ b/packages/node/src/__tests__/test-helpers/assert-shape/segment-http-api.ts
@@ -1,7 +1,10 @@
-import { Context } from '../../../../app/context'
-import { HTTPRequestOptions } from '../../../../lib/http-client'
+import { Context } from '../../../app/context'
+import { HTTPRequestOptions } from '../../../lib/http-client'
 
-export const bodyPropertyMatchers = {
+/**
+ * These map to the data properties of the HTTPClient options (the input value of 'makeRequest')
+ */
+export const httpClientOptionsBodyMatcher = {
   messageId: expect.stringMatching(/^node-next-\d*-\w*-\w*-\w*-\w*-\w*/),
   timestamp: expect.any(Date),
   _metadata: expect.any(Object),
@@ -33,7 +36,7 @@ export function assertHTTPRequestOptions(
   for (const context of contexts) {
     expect(data.batch[idx]).toEqual({
       ...context.event,
-      ...bodyPropertyMatchers,
+      ...httpClientOptionsBodyMatcher,
     })
     idx += 1
   }

--- a/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
+++ b/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
@@ -1,6 +1,6 @@
 import { Analytics } from '../../app/analytics-node'
 import { AnalyticsSettings } from '../../app/settings'
-import { AnalyticsHTTPClientDELETE, HTTPClient } from '../../lib/http-client'
+import { FetchHTTPClient, HTTPFetchFn } from '../../lib/http-client'
 import { createError, createSuccess } from './factories'
 
 export const createTestAnalytics = (
@@ -29,17 +29,14 @@ export type TestFetchClientOptions = {
 /**
  * Test http client. By default, it will return a successful response.
  */
-export class TestFetchClient implements HTTPClient {
-  private withError?: TestFetchClientOptions['withError']
-  private response?: TestFetchClientOptions['response']
+export class TestFetchClient extends FetchHTTPClient {
   constructor({ withError, response }: TestFetchClientOptions = {}) {
-    this.withError = withError
-    this.response = response
-  }
-  makeRequest() {
-    if (this.response) {
-      return Promise.resolve(this.response)
+    const _mockFetch: HTTPFetchFn = (..._args) => {
+      if (response) {
+        return Promise.resolve(response)
+      }
+      return Promise.resolve(withError ? createError() : createSuccess())
     }
-    return Promise.resolve(this.withError ? createError() : createSuccess())
+    super(_mockFetch)
   }
 }

--- a/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
+++ b/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
@@ -1,6 +1,6 @@
 import { Analytics } from '../../app/analytics-node'
 import { AnalyticsSettings } from '../../app/settings'
-import { AnalyticsHTTPClientDELETE } from '../../lib/http-client'
+import { AnalyticsHTTPClientDELETE, HTTPClient } from '../../lib/http-client'
 import { createError, createSuccess } from './factories'
 
 export const createTestAnalytics = (
@@ -29,14 +29,14 @@ export type TestFetchClientOptions = {
 /**
  * Test http client. By default, it will return a successful response.
  */
-export class TestFetchClient implements AnalyticsHTTPClientDELETE {
+export class TestFetchClient implements HTTPClient {
   private withError?: TestFetchClientOptions['withError']
   private response?: TestFetchClientOptions['response']
   constructor({ withError, response }: TestFetchClientOptions = {}) {
     this.withError = withError
     this.response = response
   }
-  send(..._args: Parameters<AnalyticsHTTPClientDELETE['send']>) {
+  makeRequest() {
     if (this.response) {
       return Promise.resolve(this.response)
     }

--- a/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
+++ b/packages/node/src/__tests__/test-helpers/create-test-analytics.ts
@@ -1,8 +1,45 @@
 import { Analytics } from '../../app/analytics-node'
 import { AnalyticsSettings } from '../../app/settings'
+import { AnalyticsHTTPClientDELETE } from '../../lib/http-client'
+import { createError, createSuccess } from './factories'
 
 export const createTestAnalytics = (
-  settings: Partial<AnalyticsSettings> = {}
+  settings: Partial<AnalyticsSettings> = {},
+  {
+    withError,
+    useRealHTTPClient,
+  }: TestFetchClientOptions & { useRealHTTPClient?: boolean } = {}
 ) => {
-  return new Analytics({ writeKey: 'foo', flushInterval: 100, ...settings })
+  return new Analytics({
+    writeKey: 'foo',
+    flushInterval: 100,
+    ...(useRealHTTPClient
+      ? {}
+      : { httpClient: new TestFetchClient({ withError }) }),
+    ...settings,
+  })
+}
+
+export type TestFetchClientOptions = {
+  withError?: boolean
+  /** override response (if needed) */
+  response?: Response | Promise<Response>
+}
+
+/**
+ * Test http client. By default, it will return a successful response.
+ */
+export class TestFetchClient implements AnalyticsHTTPClientDELETE {
+  private withError?: TestFetchClientOptions['withError']
+  private response?: TestFetchClientOptions['response']
+  constructor({ withError, response }: TestFetchClientOptions = {}) {
+    this.withError = withError
+    this.response = response
+  }
+  send(..._args: Parameters<AnalyticsHTTPClientDELETE['send']>) {
+    if (this.response) {
+      return Promise.resolve(this.response)
+    }
+    return Promise.resolve(this.withError ? createError() : createSuccess())
+  }
 }

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import axios from 'axios'
 import {
   Analytics,
   Context,
@@ -7,6 +8,8 @@ import {
   GroupTraits,
   HTTPClient,
   FetchHTTPClient,
+  HTTPFetchFn,
+  HTTPClientRequest,
 } from '../'
 
 /**
@@ -22,12 +25,6 @@ export default {
     // @ts-expect-error - should not be possible
     analytics.VERSION = 'foo'
   },
-
-  'httpClient setting should be compatible with standard fetch and node-fetch interface, as well as functions':
-    () => {
-      new Analytics({ writeKey: 'foo', httpClient: require('node-fetch') })
-      new Analytics({ writeKey: 'foo', httpClient: globalThis.fetch })
-    },
 
   'Analytics should accept an entire HTTP Client': () => {
     class CustomClient implements HTTPClient {
@@ -91,5 +88,26 @@ export default {
   'traits should be exported': () => {
     console.log({} as GroupTraits)
     console.log({} as UserTraits)
+  },
+
+  'HTTPFetchFn should be compatible with standard fetch and node-fetch interface, as well as functions':
+    () => {
+      const fetch: HTTPFetchFn = require('node-fetch')
+      new Analytics({ writeKey: 'foo', httpClient: fetch })
+      new Analytics({ writeKey: 'foo', httpClient: globalThis.fetch })
+    },
+
+  'httpClient setting should be compatible with axios': () => {
+    new (class implements HTTPClient {
+      async makeRequest(options: HTTPClientRequest) {
+        return axios({
+          url: options.url,
+          method: options.method,
+          data: options.data,
+          headers: options.headers,
+          timeout: options.timeout,
+        })
+      }
+    })()
   },
 }

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -1,4 +1,11 @@
-import { Analytics, Context, Plugin, UserTraits, GroupTraits } from '../'
+import {
+  Analytics,
+  Context,
+  Plugin,
+  UserTraits,
+  GroupTraits,
+  AnalyticsHTTPClientDELETE,
+} from '../'
 
 /**
  * These are general typescript definition tests;
@@ -13,6 +20,19 @@ export default {
     // @ts-expect-error - should not be possible
     analytics.VERSION = 'foo'
   },
+
+  'httpClient setting should be compatible with standard fetch and node-fetch interface':
+    () => {
+      const nodeFetchClient: AnalyticsHTTPClientDELETE = {
+        send: require('node-fetch'),
+      }
+      new Analytics({ writeKey: 'foo', httpClient: nodeFetchClient })
+
+      const standardFetchClient: AnalyticsHTTPClientDELETE = {
+        send: fetch,
+      }
+      new Analytics({ writeKey: 'foo', httpClient: standardFetchClient })
+    },
 
   'track/id/pg/screen/grp calls should require either userId or anonymousId':
     () => {

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -43,6 +43,11 @@ export default {
       writeKey: 'foo',
       httpClient: new FetchHTTPClient(globalThis.fetch),
     })
+
+    new Analytics({
+      writeKey: 'foo',
+      httpClient: new FetchHTTPClient(),
+    })
   },
 
   'track/id/pg/screen/grp calls should require either userId or anonymousId':

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -97,6 +97,13 @@ export default {
       new Analytics({ writeKey: 'foo', httpClient: globalThis.fetch })
     },
 
+  'HTTPFetchFn options should be the expected type': () => {
+    type BadFetch = (url: string, requestInit: { _bad_object?: string }) => any
+
+    // @ts-expect-error
+    new Analytics({ writeKey: 'foo', httpClient: {} as BadFetch })
+  },
+
   'httpClient setting should be compatible with axios': () => {
     new (class implements HTTPClient {
       async makeRequest(options: HTTPClientRequest) {

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -1,10 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 import {
   Analytics,
   Context,
   Plugin,
   UserTraits,
   GroupTraits,
-  AnalyticsHTTPClientDELETE,
+  HTTPClient,
+  FetchHTTPClient,
 } from '../'
 
 /**
@@ -21,18 +23,27 @@ export default {
     analytics.VERSION = 'foo'
   },
 
-  'httpClient setting should be compatible with standard fetch and node-fetch interface':
+  'httpClient setting should be compatible with standard fetch and node-fetch interface, as well as functions':
     () => {
-      const nodeFetchClient: AnalyticsHTTPClientDELETE = {
-        send: require('node-fetch'),
-      }
-      new Analytics({ writeKey: 'foo', httpClient: nodeFetchClient })
-
-      const standardFetchClient: AnalyticsHTTPClientDELETE = {
-        send: fetch,
-      }
-      new Analytics({ writeKey: 'foo', httpClient: standardFetchClient })
+      new Analytics({ writeKey: 'foo', httpClient: require('node-fetch') })
+      new Analytics({ writeKey: 'foo', httpClient: globalThis.fetch })
     },
+
+  'Analytics should accept an entire HTTP Client': () => {
+    class CustomClient implements HTTPClient {
+      makeRequest = () => Promise.resolve({} as Response)
+    }
+
+    new Analytics({
+      writeKey: 'foo',
+      httpClient: new CustomClient(),
+    })
+
+    new Analytics({
+      writeKey: 'foo',
+      httpClient: new FetchHTTPClient(globalThis.fetch),
+    })
+  },
 
   'track/id/pg/screen/grp calls should require either userId or anonymousId':
     () => {

--- a/packages/node/src/__tests__/typedef-tests.ts
+++ b/packages/node/src/__tests__/typedef-tests.ts
@@ -105,7 +105,7 @@ export default {
           method: options.method,
           data: options.data,
           headers: options.headers,
-          timeout: options.timeout,
+          timeout: options.httpRequestTimeout,
         })
       }
     })()

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -16,6 +16,7 @@ import {
 } from './types'
 import { Context } from './context'
 import { NodeEventQueue } from './event-queue'
+import { FetchHTTPClient } from '../lib/http-client'
 import { fetch } from '../lib/fetch'
 
 export class Analytics extends NodeEmitter implements CoreAnalytics {
@@ -52,7 +53,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         httpRequestTimeout: settings.httpRequestTimeout,
         disable: settings.disable,
         flushInterval,
-        httpFetchFn: settings.httpClient ?? fetch,
+        httpClient: settings.httpClient ?? new FetchHTTPClient(fetch),
       },
       this as NodeEmitter
     )

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -53,7 +53,10 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         httpRequestTimeout: settings.httpRequestTimeout,
         disable: settings.disable,
         flushInterval,
-        httpClient: settings.httpClient ?? new FetchHTTPClient(fetch),
+        httpClient:
+          typeof settings.httpClient === 'function'
+            ? new FetchHTTPClient(settings.httpClient)
+            : settings.httpClient ?? new FetchHTTPClient(fetch),
       },
       this as NodeEmitter
     )

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -16,6 +16,7 @@ import {
 } from './types'
 import { Context } from './context'
 import { NodeEventQueue } from './event-queue'
+import { fetch } from '../lib/fetch'
 
 export class Analytics extends NodeEmitter implements CoreAnalytics {
   private readonly _eventFactory: NodeEventFactory
@@ -51,6 +52,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         httpRequestTimeout: settings.httpRequestTimeout,
         disable: settings.disable,
         flushInterval,
+        httpFetchFn: settings.httpClient ?? fetch,
       },
       this as NodeEmitter
     )

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -17,7 +17,6 @@ import {
 import { Context } from './context'
 import { NodeEventQueue } from './event-queue'
 import { FetchHTTPClient } from '../lib/http-client'
-import { fetch } from '../lib/fetch'
 
 export class Analytics extends NodeEmitter implements CoreAnalytics {
   private readonly _eventFactory: NodeEventFactory
@@ -56,7 +55,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         httpClient:
           typeof settings.httpClient === 'function'
             ? new FetchHTTPClient(settings.httpClient)
-            : settings.httpClient ?? new FetchHTTPClient(fetch),
+            : settings.httpClient ?? new FetchHTTPClient(),
       },
       this as NodeEmitter
     )

--- a/packages/node/src/app/emitter.ts
+++ b/packages/node/src/app/emitter.ts
@@ -14,7 +14,7 @@ export type NodeEmitterEvents = CoreEmitterContract<Context> & {
       url: string
       method: string
       headers: Record<string, string>
-      body: any
+      body: Record<string, unknown>
     }
   ]
   drained: []

--- a/packages/node/src/app/emitter.ts
+++ b/packages/node/src/app/emitter.ts
@@ -14,7 +14,7 @@ export type NodeEmitterEvents = CoreEmitterContract<Context> & {
       url: string
       method: string
       headers: Record<string, string>
-      body: Record<string, unknown>
+      body: Record<string, any>
     }
   ]
   drained: []

--- a/packages/node/src/app/emitter.ts
+++ b/packages/node/src/app/emitter.ts
@@ -14,7 +14,7 @@ export type NodeEmitterEvents = CoreEmitterContract<Context> & {
       url: string
       method: string
       headers: Record<string, string>
-      body: string
+      body: any
     }
   ]
   drained: []

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -1,4 +1,5 @@
 import { ValidationError } from '@segment/analytics-core'
+import { HTTPFetchFn } from '../lib/http-client'
 
 export interface AnalyticsSettings {
   /**
@@ -34,6 +35,10 @@ export interface AnalyticsSettings {
    * Disable the analytics library. All calls will be a noop. Default: false.
    */
   disable?: boolean
+  /**
+   * Supply a default http client implementation (such as one supporting proxy). Default: The value of globalThis.fetch, with node-fetch as a fallback.
+   */
+  httpClient?: HTTPFetchFn
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -7,7 +7,6 @@ export interface AnalyticsSettings {
    */
   writeKey: string
   /**
-  /**
    * The base URL of the API. Default: "https://api.segment.io"
    */
   host?: string

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '@segment/analytics-core'
-import { HTTPFetchFn } from '../lib/http-client'
+import { HTTPClient } from '../lib/http-client'
 
 export interface AnalyticsSettings {
   /**
@@ -38,7 +38,7 @@ export interface AnalyticsSettings {
   /**
    * Supply a default http client implementation (such as one supporting proxy). Default: The value of globalThis.fetch, with node-fetch as a fallback.
    */
-  httpClient?: HTTPFetchFn
+  httpClient?: HTTPClient
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '@segment/analytics-core'
-import { HTTPClient } from '../lib/http-client'
+import { HTTPClient, HTTPFetchFn } from '../lib/http-client'
 
 export interface AnalyticsSettings {
   /**
@@ -36,9 +36,11 @@ export interface AnalyticsSettings {
    */
   disable?: boolean
   /**
-   * Supply a default http client implementation (such as one supporting proxy). Default: The value of globalThis.fetch, with node-fetch as a fallback.
+   * Supply a default http client implementation (such as one supporting proxy).
+   * Accepts either an HTTPClient instance or a fetch function.
+   * Default: an HTTP client that uses globalThis.fetch, with node-fetch as a fallback.
    */
-  httpClient?: HTTPClient
+  httpClient?: HTTPFetchFn | HTTPClient
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,7 +3,7 @@ export { Context } from './app/context'
 export {
   HTTPClient,
   FetchHTTPClient,
-  FetchHTTPClientOptions,
+  HTTPFetchRequestInit,
   HTTPFetchClientResponse,
   HTTPFetchFn,
   HTTPRequestOptions,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,6 +1,13 @@
 export { Analytics } from './app/analytics-node'
 export { Context } from './app/context'
 export type {
+  FetchHTTPClient,
+  AnalyticsHTTPClientDELETE,
+  HTTPClientOptions,
+  HTTPFetchFn,
+  HTTPFetchClientResponse,
+} from './lib/http-client'
+export type {
   Plugin,
   GroupTraits,
   UserTraits,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,9 +4,9 @@ export {
   HTTPClient,
   FetchHTTPClient,
   HTTPFetchRequest,
-  HTTPFetchResponse,
+  HTTPResponse,
   HTTPFetchFn,
-  HTTPRequestOptions,
+  HTTPClientRequestOptions,
 } from './lib/http-client'
 
 export type {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,11 +1,14 @@
 export { Analytics } from './app/analytics-node'
 export { Context } from './app/context'
-export type {
+export {
+  HTTPClient,
   FetchHTTPClient,
   FetchHTTPClientOptions,
-  HTTPFetchFn,
   HTTPFetchClientResponse,
+  HTTPFetchFn,
+  HTTPRequestOptions,
 } from './lib/http-client'
+
 export type {
   Plugin,
   GroupTraits,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -6,7 +6,7 @@ export {
   HTTPFetchRequest,
   HTTPResponse,
   HTTPFetchFn,
-  HTTPClientRequestOptions,
+  HTTPClientRequest,
 } from './lib/http-client'
 
 export type {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,8 +3,8 @@ export { Context } from './app/context'
 export {
   HTTPClient,
   FetchHTTPClient,
-  HTTPFetchRequestInit,
-  HTTPFetchClientResponse,
+  HTTPFetchRequest,
+  HTTPFetchResponse,
   HTTPFetchFn,
   HTTPRequestOptions,
 } from './lib/http-client'

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -2,8 +2,7 @@ export { Analytics } from './app/analytics-node'
 export { Context } from './app/context'
 export type {
   FetchHTTPClient,
-  AnalyticsHTTPClientDELETE,
-  HTTPClientOptions,
+  FetchHTTPClientOptions,
   HTTPFetchFn,
   HTTPFetchClientResponse,
 } from './lib/http-client'

--- a/packages/node/src/lib/__tests__/abort.test.ts
+++ b/packages/node/src/lib/__tests__/abort.test.ts
@@ -1,7 +1,9 @@
 import { abortSignalAfterTimeout } from '../abort'
 import nock from 'nock'
-import { fetch } from '../fetch'
 import { sleep } from '@segment/analytics-core'
+import { fetch as _fetch } from '../fetch'
+
+const fetch = _fetch as typeof globalThis.fetch
 
 describe(abortSignalAfterTimeout, () => {
   const HOST = 'https://foo.com'

--- a/packages/node/src/lib/__tests__/abort.test.ts
+++ b/packages/node/src/lib/__tests__/abort.test.ts
@@ -1,6 +1,5 @@
 import { abortSignalAfterTimeout } from '../abort'
 import nock from 'nock'
-import { fetch } from '../fetch'
 import { sleep } from '@segment/analytics-core'
 
 describe(abortSignalAfterTimeout, () => {

--- a/packages/node/src/lib/__tests__/abort.test.ts
+++ b/packages/node/src/lib/__tests__/abort.test.ts
@@ -1,5 +1,6 @@
 import { abortSignalAfterTimeout } from '../abort'
 import nock from 'nock'
+import { fetch } from '../fetch'
 import { sleep } from '@segment/analytics-core'
 
 describe(abortSignalAfterTimeout, () => {

--- a/packages/node/src/lib/abort.ts
+++ b/packages/node/src/lib/abort.ts
@@ -7,7 +7,7 @@ import { detectRuntime } from './env'
 /**
  * adapted from: https://www.npmjs.com/package/node-abort-controller
  */
-class AbortSignal {
+export class AbortSignal {
   onabort: globalThis.AbortSignal['onabort'] = null
   aborted = false
   eventEmitter = new Emitter()

--- a/packages/node/src/lib/fetch.ts
+++ b/packages/node/src/lib/fetch.ts
@@ -1,11 +1,13 @@
-export const fetch: typeof globalThis.fetch = async (...args) => {
+import type { HTTPFetchFn } from './http-client'
+
+export const fetch: HTTPFetchFn = async (...args) => {
   if (globalThis.fetch) {
     return globalThis.fetch(...args)
-  } // @ts-ignore
+  }
   // This guard causes is important, as it causes dead-code elimination to be enabled inside this block.
+  // @ts-ignore
   else if (typeof EdgeRuntime !== 'string') {
-    // @ts-ignore
-    return (await import('node-fetch')).default(...args) as Response
+    return (await import('node-fetch')).default(...args)
   } else {
     throw new Error(
       'Invariant: an edge runtime that does not support fetch should not exist'

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -1,7 +1,9 @@
 import { abortSignalAfterTimeout } from './abort'
+import { fetch as defaultFetch } from './fetch'
 
 /**
- * This interface is meant to be compatible with different fetch implementations.
+ * This interface is meant to be compatible with different fetch implementations (node and browser).
+ * Using the ambient fetch type is not possible because the AbortSignal type is not compatible with node-fetch.
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
  */
 export interface HTTPFetchFn {
@@ -60,14 +62,20 @@ export interface HTTPRequestOptions {
   timeout: number
 }
 
+/**
+ * HTTP client interface for making requests.cccccbenidtinulcgklueududltvedrjgeligdefjkfb
+ */
 export interface HTTPClient {
   makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchResponse>
 }
 
+/**
+ * Default HTTP client implementation using fetch.
+ */
 export class FetchHTTPClient implements HTTPClient {
   private _fetch: HTTPFetchFn
-  constructor(fetchFn: HTTPFetchFn) {
-    this._fetch = fetchFn
+  constructor(fetchFn?: HTTPFetchFn) {
+    this._fetch = fetchFn ?? defaultFetch
   }
   async makeRequest(options: HTTPRequestOptions): Promise<HTTPFetchResponse> {
     const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -35,7 +35,7 @@ export interface HTTPResponse {
  * This interface is meant to be a generic interface for making HTTP requests.
  * While it may overlap with fetch's Request interface, it is not coupled to it.
  */
-export interface HTTPClientRequestOptions {
+export interface HTTPClientRequest {
   /**
    * URL to be used for the request
    * @example 'https://api.segment.io/v1/batch'
@@ -66,7 +66,7 @@ export interface HTTPClientRequestOptions {
  * HTTP client interface for making requests
  */
 export interface HTTPClient {
-  makeRequest(_options: HTTPClientRequestOptions): Promise<HTTPResponse>
+  makeRequest(_options: HTTPClientRequest): Promise<HTTPResponse>
 }
 
 /**
@@ -77,7 +77,7 @@ export class FetchHTTPClient implements HTTPClient {
   constructor(fetchFn?: HTTPFetchFn) {
     this._fetch = fetchFn ?? defaultFetch
   }
-  async makeRequest(options: HTTPClientRequestOptions): Promise<HTTPResponse> {
+  async makeRequest(options: HTTPClientRequest): Promise<HTTPResponse> {
     const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)
 
     const requestInit = {

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -4,11 +4,6 @@ export interface HTTPFetchClientResponse {
   ok: boolean
   status: number
   statusText: string
-  /**
-   * Using string, but this is also response type
-   * "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
-   */
-  // type: string
 }
 
 /**
@@ -19,10 +14,6 @@ export interface HTTPFetchFn {
     url: string,
     options: FetchHTTPClientOptions
   ): Promise<HTTPFetchClientResponse>
-}
-
-export interface HTTPClient {
-  makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchClientResponse>
 }
 
 export interface HTTPRequestOptions {
@@ -38,6 +29,10 @@ export interface FetchHTTPClientOptions {
   body?: string
   method?: string
   signal?: any // AbortSignal type does not play nicely with node-fetch
+}
+
+export interface HTTPClient {
+  makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchClientResponse>
 }
 
 export class FetchHTTPClient implements HTTPClient {

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -17,7 +17,7 @@ export interface HTTPFetchFn {
 export interface HTTPFetchRequest {
   headers?: Record<string, string>
   body?: string
-  method?: string
+  method?: HTTPClientRequest['method']
   signal?: any // AbortSignal type does not play nicely with node-fetch
 }
 
@@ -26,7 +26,6 @@ export interface HTTPFetchRequest {
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Response
  */
 export interface HTTPResponse {
-  ok: boolean
   status: number
   statusText: string
 }
@@ -42,10 +41,9 @@ export interface HTTPClientRequest {
    */
   url: string
   /**
-   * HTTP method to be used for the request
-   * @example 'POST'
+   * HTTP method to be used for the request. This will always be a 'POST' request.
    **/
-  method: string
+  method: 'POST'
   /**
    * Headers to be sent with the request
    */

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -33,10 +33,29 @@ export interface HTTPFetchRequestInit {
  * While it may overlap with fetch's Request interface, it is not coupled to it.
  */
 export interface HTTPRequestOptions {
+  /**
+   * URL to be used for the request
+   * @example 'https://api.segment.io/v1/batch'
+   */
   url: string
+  /**
+   * HTTP method to be used for the request
+   * @example 'POST'
+   **/
   method: string
+  /**
+   * Headers to be sent with the request
+   */
   headers: Record<string, string>
+  /**
+   * JSON data to be sent with the request (will be stringified)
+   * @example { "batch": [ ... ]}
+   */
   data: Record<string, any>
+  /**
+   * Timeout in milliseconds
+   * @example 10000
+   */
   timeout: number
 }
 
@@ -46,7 +65,7 @@ export interface HTTPClient {
 
 export class FetchHTTPClient implements HTTPClient {
   private _fetch: HTTPFetchFn
-  constructor(fetchFn: HTTPFetchFn | typeof globalThis.fetch) {
+  constructor(fetchFn: HTTPFetchFn) {
     this._fetch = fetchFn
   }
   async makeRequest(

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -1,31 +1,32 @@
 import { abortSignalAfterTimeout } from './abort'
 
-export interface HTTPFetchClientResponse {
-  ok: boolean
-  status: number
-  statusText: string
-}
-
 /**
  * This interface is meant to be compatible with different fetch implementations.
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
  */
 export interface HTTPFetchFn {
-  (
-    url: string,
-    requestInit: HTTPFetchRequestInit
-  ): Promise<HTTPFetchClientResponse>
+  (url: string, requestInit: HTTPFetchRequest): Promise<HTTPFetchResponse>
 }
 
 /**
- * This interface is meant to conform to the standard Fetch API RequestInit interface.
+ * This interface is meant to he compatible with the Request interface.
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Request
  */
-export interface HTTPFetchRequestInit {
+export interface HTTPFetchRequest {
   headers?: Record<string, string>
   body?: string
   method?: string
   signal?: any // AbortSignal type does not play nicely with node-fetch
+}
+
+/**
+ * This interface is meant to conform to the Fetch API Response interface.
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/Response
+ */
+export interface HTTPFetchResponse {
+  ok: boolean
+  status: number
+  statusText: string
 }
 
 /**
@@ -60,7 +61,7 @@ export interface HTTPRequestOptions {
 }
 
 export interface HTTPClient {
-  makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchClientResponse>
+  makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchResponse>
 }
 
 export class FetchHTTPClient implements HTTPClient {
@@ -68,9 +69,7 @@ export class FetchHTTPClient implements HTTPClient {
   constructor(fetchFn: HTTPFetchFn) {
     this._fetch = fetchFn
   }
-  async makeRequest(
-    options: HTTPRequestOptions
-  ): Promise<HTTPFetchClientResponse> {
+  async makeRequest(options: HTTPRequestOptions): Promise<HTTPFetchResponse> {
     const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)
 
     const requestInit = {

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -54,7 +54,7 @@ export interface HTTPClientRequest {
    */
   data: Record<string, any>
   /**
-   * Specifies the timeout for a HTTP client to get an HTTP response from HTTP server
+   * Specifies the timeout (in milliseconds) for an HTTP client to get an HTTP response from HTTP server
    * @example 10000
    */
   httpRequestTimeout: number

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -1,0 +1,87 @@
+import type { Analytics } from '../app/analytics-node'
+import { NodeEmitter } from '../app/emitter'
+import { abortSignalAfterTimeout } from './abort'
+
+export interface HTTPFetchClientResponse {
+  ok: boolean
+  status: number
+  statusText: string
+  /**
+   * Using string, but this is also response type
+   * "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+   */
+  // type: string
+}
+
+export interface HTTPFetchFn {
+  (
+    url: string | URL,
+    options?: HTTPClientOptions
+  ): Promise<HTTPFetchClientResponse>
+}
+
+export interface HTTPClient {
+  makeRequest(
+    _options: HTTPRequestOptions,
+    emitter: NodeEmitter
+  ): Promise<HTTPFetchClientResponse>
+}
+
+interface HTTPRequestOptions {
+  url: string
+  method: string
+  headers: Record<string, string>
+  data: Record<string, any>
+  timeout: number
+}
+
+export interface HTTPClientOptions {
+  headers?: Record<string, string>
+  body?: string
+  method?: string
+  signal?: any // AbortSignal type does not play nicely with node-fetch
+}
+
+/**
+ * A client that sends http requests.
+ */
+export interface AnalyticsHTTPClientDELETE {
+  /**
+   *  Compatible with the fetch API
+   */
+  send(
+    url: string,
+    options: HTTPClientOptions
+  ): Promise<HTTPFetchClientResponse>
+}
+
+export class FetchHTTPClient implements HTTPClient {
+  private _fetch: HTTPFetchFn
+  constructor(fetchFn: HTTPFetchFn | typeof globalThis.fetch) {
+    this._fetch = fetchFn
+  }
+  async makeRequest(
+    options: HTTPRequestOptions,
+    analytics: Analytics
+  ): Promise<HTTPFetchClientResponse> {
+    const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)
+
+    const requestInit = {
+      url: options.url,
+      method: options.method,
+      headers: options.headers,
+      body: JSON.stringify(options.data),
+      signal: signal,
+    }
+
+    analytics.emit('http_request', {
+      url: requestInit.url,
+      method: requestInit.method,
+      headers: requestInit.headers,
+      body: requestInit.body,
+    })
+    const response = await this._fetch(options.url, requestInit)
+    clearTimeout(timeoutId)
+    return response
+  }
+}

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -8,27 +8,36 @@ export interface HTTPFetchClientResponse {
 
 /**
  * This interface is meant to be compatible with different fetch implementations.
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
  */
 export interface HTTPFetchFn {
   (
     url: string,
-    options: FetchHTTPClientOptions
+    requestInit: HTTPFetchRequestInit
   ): Promise<HTTPFetchClientResponse>
 }
 
+/**
+ * This interface is meant to conform to the standard Fetch API RequestInit interface.
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/Request
+ */
+export interface HTTPFetchRequestInit {
+  headers?: Record<string, string>
+  body?: string
+  method?: string
+  signal?: any // AbortSignal type does not play nicely with node-fetch
+}
+
+/**
+ * This interface is meant to be a generic interface for making HTTP requests.
+ * While it may overlap with fetch's Request interface, it is not coupled to it.
+ */
 export interface HTTPRequestOptions {
   url: string
   method: string
   headers: Record<string, string>
   data: Record<string, any>
   timeout: number
-}
-
-export interface FetchHTTPClientOptions {
-  headers?: Record<string, string>
-  body?: string
-  method?: string
-  signal?: any // AbortSignal type does not play nicely with node-fetch
 }
 
 export interface HTTPClient {

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -54,7 +54,7 @@ export interface HTTPClientRequest {
    */
   data: Record<string, any>
   /**
-   * Specifies the timeout (in milliseconds) for an HTTP client to get an HTTP response from HTTP server
+   * Specifies the timeout (in milliseconds) for an HTTP client to get an HTTP response from the server
    * @example 10000
    */
   httpRequestTimeout: number

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -54,10 +54,10 @@ export interface HTTPClientRequest {
    */
   data: Record<string, any>
   /**
-   * Timeout in milliseconds
+   * Specifies the timeout for a HTTP client to get an HTTP response from HTTP server
    * @example 10000
    */
-  timeout: number
+  httpRequestTimeout: number
 }
 
 /**
@@ -76,7 +76,9 @@ export class FetchHTTPClient implements HTTPClient {
     this._fetch = fetchFn ?? defaultFetch
   }
   async makeRequest(options: HTTPClientRequest): Promise<HTTPResponse> {
-    const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)
+    const [signal, timeoutId] = abortSignalAfterTimeout(
+      options.httpRequestTimeout
+    )
 
     const requestInit = {
       url: options.url,

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -7,11 +7,11 @@ import { fetch as defaultFetch } from './fetch'
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
  */
 export interface HTTPFetchFn {
-  (url: string, requestInit: HTTPFetchRequest): Promise<HTTPFetchResponse>
+  (url: string, requestInit: HTTPFetchRequest): Promise<HTTPResponse>
 }
 
 /**
- * This interface is meant to he compatible with the Request interface.
+ * This interface is meant to be compatible with the Request interface.
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Request
  */
 export interface HTTPFetchRequest {
@@ -22,10 +22,10 @@ export interface HTTPFetchRequest {
 }
 
 /**
- * This interface is meant to conform to the Fetch API Response interface.
+ * This interface is meant to very minimally conform to the Response interface.
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Response
  */
-export interface HTTPFetchResponse {
+export interface HTTPResponse {
   ok: boolean
   status: number
   statusText: string
@@ -35,7 +35,7 @@ export interface HTTPFetchResponse {
  * This interface is meant to be a generic interface for making HTTP requests.
  * While it may overlap with fetch's Request interface, it is not coupled to it.
  */
-export interface HTTPRequestOptions {
+export interface HTTPClientRequestOptions {
   /**
    * URL to be used for the request
    * @example 'https://api.segment.io/v1/batch'
@@ -63,21 +63,21 @@ export interface HTTPRequestOptions {
 }
 
 /**
- * HTTP client interface for making requests.cccccbenidtinulcgklueududltvedrjgeligdefjkfb
+ * HTTP client interface for making requests
  */
 export interface HTTPClient {
-  makeRequest(_options: HTTPRequestOptions): Promise<HTTPFetchResponse>
+  makeRequest(_options: HTTPClientRequestOptions): Promise<HTTPResponse>
 }
 
 /**
- * Default HTTP client implementation using fetch.
+ * Default HTTP client implementation using fetch
  */
 export class FetchHTTPClient implements HTTPClient {
   private _fetch: HTTPFetchFn
   constructor(fetchFn?: HTTPFetchFn) {
     this._fetch = fetchFn ?? defaultFetch
   }
-  async makeRequest(options: HTTPRequestOptions): Promise<HTTPFetchResponse> {
+  async makeRequest(options: HTTPClientRequestOptions): Promise<HTTPResponse> {
     const [signal, timeoutId] = abortSignalAfterTimeout(options.timeout)
 
     const requestInit = {

--- a/packages/node/src/lib/http-client.ts
+++ b/packages/node/src/lib/http-client.ts
@@ -15,10 +15,10 @@ export interface HTTPFetchFn {
  * @link https://developer.mozilla.org/en-US/docs/Web/API/Request
  */
 export interface HTTPFetchRequest {
-  headers?: Record<string, string>
-  body?: string
-  method?: HTTPClientRequest['method']
-  signal?: any // AbortSignal type does not play nicely with node-fetch
+  headers: Record<string, string>
+  body: string
+  method: HTTPClientRequest['method']
+  signal: any // AbortSignal type does not play nicely with node-fetch
 }
 
 /**

--- a/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
@@ -1,5 +1,3 @@
-const fetcher = jest.fn()
-jest.mock('../../../lib/fetch', () => ({ fetch: fetcher }))
 import { NodeEventFactory } from '../../../app/event-factory'
 import { createSuccess } from '../../../__tests__/test-helpers/factories'
 import { createConfiguredNodePlugin } from '../index'
@@ -10,10 +8,24 @@ import {
   bodyPropertyMatchers,
   assertSegmentApiBody,
 } from './test-helpers/segment-http-api'
+import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 
 let emitter: Emitter
-const createTestNodePlugin = (props: PublisherProps) =>
-  createConfiguredNodePlugin(props, emitter)
+const testClient = new TestFetchClient()
+const fetcher = jest.spyOn(testClient, 'send')
+
+const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
+  createConfiguredNodePlugin(
+    {
+      maxRetries: 3,
+      maxEventsInBatch: 1,
+      flushInterval: 1000,
+      writeKey: '',
+      httpFetchFn: testClient,
+      ...props,
+    },
+    emitter
+  )
 
 const validateFetcherInputs = (...contexts: Context[]) => {
   const [url, request] = fetcher.mock.lastCall
@@ -34,6 +46,7 @@ test('alias', async () => {
     maxEventsInBatch: 1,
     flushInterval: 1000,
     writeKey: '',
+    httpFetchFn: testClient,
   })
 
   const event = eventFactory.alias('to', 'from')
@@ -46,7 +59,7 @@ test('alias', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
 
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({
@@ -58,12 +71,7 @@ test('alias', async () => {
 })
 
 test('group', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.group(
     'foo-group-id',
@@ -81,7 +89,7 @@ test('group', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
 
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({
@@ -96,12 +104,7 @@ test('group', async () => {
 })
 
 test('identify', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.identify('foo-user-id', {
     name: 'Chris Radek',
@@ -115,7 +118,7 @@ test('identify', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({
     ...bodyPropertyMatchers,
@@ -128,12 +131,7 @@ test('identify', async () => {
 })
 
 test('page', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.page(
     'Category',
@@ -150,7 +148,7 @@ test('page', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
 
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({
@@ -167,12 +165,7 @@ test('page', async () => {
 })
 
 test('screen', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.screen(
     'Category',
@@ -189,7 +182,7 @@ test('screen', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
 
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({
@@ -205,12 +198,7 @@ test('screen', async () => {
 })
 
 test('track', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.track(
     'test event',
@@ -226,7 +214,7 @@ test('track', async () => {
   validateFetcherInputs(context)
 
   const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body)
+  const body = JSON.parse(request.body!)
 
   expect(body.batch).toHaveLength(1)
   expect(body.batch[0]).toEqual({

--- a/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
@@ -6,7 +6,7 @@ import { Context } from '../../../app/context'
 import { Emitter } from '@segment/analytics-core'
 import {
   bodyPropertyMatchers,
-  assertSegmentApiBody,
+  assertHTTPRequestOptions,
 } from './test-helpers/segment-http-api'
 import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 
@@ -28,8 +28,8 @@ const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   )
 
 const validateFetcherInputs = (...contexts: Context[]) => {
-  const [url, request] = fetcher.mock.lastCall
-  return assertSegmentApiBody(url, request, contexts)
+  const [request] = fetcher.mock.lastCall
+  return assertHTTPRequestOptions(request, contexts)
 }
 
 const eventFactory = new NodeEventFactory()
@@ -41,13 +41,7 @@ beforeEach(() => {
 })
 
 test('alias', async () => {
-  const { plugin: segmentPlugin } = createTestNodePlugin({
-    maxRetries: 3,
-    maxEventsInBatch: 1,
-    flushInterval: 1000,
-    writeKey: '',
-    httpClient: testClient,
-  })
+  const { plugin: segmentPlugin } = createTestNodePlugin()
 
   const event = eventFactory.alias('to', 'from')
   const context = new Context(event)
@@ -58,11 +52,11 @@ test('alias', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
 
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     type: 'alias',
     previousId: 'from',
@@ -88,11 +82,11 @@ test('group', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
 
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     traits: {
       name: 'libraries',
@@ -117,10 +111,10 @@ test('identify', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     traits: {
       name: 'Chris Radek',
@@ -147,11 +141,11 @@ test('page', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
 
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     type: 'page',
     userId: 'foo-user-id',
@@ -181,11 +175,11 @@ test('screen', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
 
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     type: 'screen',
     userId: 'foo-user-id',
@@ -213,11 +207,11 @@ test('track', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1)
   validateFetcherInputs(context)
 
-  const [, request] = fetcher.mock.lastCall
-  const body = JSON.parse(request.body!)
+  const [request] = fetcher.mock.lastCall
+  const data = request.data
 
-  expect(body.batch).toHaveLength(1)
-  expect(body.batch[0]).toEqual({
+  expect(data.batch).toHaveLength(1)
+  expect(data.batch[0]).toEqual({
     ...bodyPropertyMatchers,
     type: 'track',
     event: 'test event',

--- a/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
@@ -12,7 +12,7 @@ import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-ana
 
 let emitter: Emitter
 const testClient = new TestFetchClient()
-const fetcher = jest.spyOn(testClient, 'send')
+const fetcher = jest.spyOn(testClient, 'makeRequest')
 
 const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   createConfiguredNodePlugin(
@@ -21,7 +21,7 @@ const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
       maxEventsInBatch: 1,
       flushInterval: 1000,
       writeKey: '',
-      httpFetchFn: testClient,
+      httpClient: testClient,
       ...props,
     },
     emitter
@@ -46,7 +46,7 @@ test('alias', async () => {
     maxEventsInBatch: 1,
     flushInterval: 1000,
     writeKey: '',
-    httpFetchFn: testClient,
+    httpClient: testClient,
   })
 
   const event = eventFactory.alias('to', 'from')

--- a/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
@@ -5,9 +5,9 @@ import { PublisherProps } from '../publisher'
 import { Context } from '../../../app/context'
 import { Emitter } from '@segment/analytics-core'
 import {
-  bodyPropertyMatchers,
   assertHTTPRequestOptions,
-} from './test-helpers/segment-http-api'
+  httpClientOptionsBodyMatcher,
+} from '../../../__tests__/test-helpers/assert-shape'
 import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 
 let emitter: Emitter
@@ -57,7 +57,7 @@ test('alias', async () => {
 
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     type: 'alias',
     previousId: 'from',
     userId: 'to',
@@ -87,7 +87,7 @@ test('group', async () => {
 
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     traits: {
       name: 'libraries',
     },
@@ -115,7 +115,7 @@ test('identify', async () => {
   const data = request.data
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     traits: {
       name: 'Chris Radek',
     },
@@ -146,7 +146,7 @@ test('page', async () => {
 
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     type: 'page',
     userId: 'foo-user-id',
     name: 'Home',
@@ -180,7 +180,7 @@ test('screen', async () => {
 
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     type: 'screen',
     userId: 'foo-user-id',
     name: 'Home',
@@ -212,7 +212,7 @@ test('track', async () => {
 
   expect(data.batch).toHaveLength(1)
   expect(data.batch[0]).toEqual({
-    ...bodyPropertyMatchers,
+    ...httpClientOptionsBodyMatcher,
     type: 'track',
     event: 'test event',
     userId: 'foo-user-id',

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -14,13 +14,13 @@ import { assertSegmentApiBody } from './test-helpers/segment-http-api'
 
 let emitter: Emitter
 const testClient = new TestFetchClient()
-const fetcher = jest.spyOn(testClient, 'send')
+const fetcher = jest.spyOn(testClient, 'makeRequest')
 
 const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   createConfiguredNodePlugin(
     {
       maxEventsInBatch: 1,
-      httpFetchFn: testClient,
+      httpClient: testClient,
       writeKey: '',
       flushInterval: 1000,
       maxRetries: 3,

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../__tests__/test-helpers/factories'
 import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 import { PublisherProps } from '../publisher'
-import { assertHTTPRequestOptions } from './test-helpers/segment-http-api'
+import { assertHTTPRequestOptions } from '../../../__tests__/test-helpers/assert-shape/segment-http-api'
 
 let emitter: Emitter
 const testClient = new TestFetchClient()

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -308,7 +308,7 @@ describe('error handling', () => {
     `)
   })
 
-  it.only('retries non-400 errors', async () => {
+  it('retries non-400 errors', async () => {
     // Jest kept timing out when using fake timers despite advancing time.
     jest.useRealTimers()
 

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -1,5 +1,3 @@
-const fetcher = jest.fn()
-jest.mock('../../../lib/fetch', () => ({ fetch: fetcher }))
 import { Emitter } from '@segment/analytics-core'
 import { range } from 'lodash'
 import { createConfiguredNodePlugin } from '..'
@@ -10,12 +8,26 @@ import {
   createSuccess,
   createError,
 } from '../../../__tests__/test-helpers/factories'
+import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 import { PublisherProps } from '../publisher'
 import { assertSegmentApiBody } from './test-helpers/segment-http-api'
 
 let emitter: Emitter
-const createTestNodePlugin = (props: PublisherProps) =>
-  createConfiguredNodePlugin(props, emitter)
+const testClient = new TestFetchClient()
+const fetcher = jest.spyOn(testClient, 'send')
+
+const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
+  createConfiguredNodePlugin(
+    {
+      maxEventsInBatch: 1,
+      httpFetchFn: testClient,
+      writeKey: '',
+      flushInterval: 1000,
+      maxRetries: 3,
+      ...props,
+    },
+    emitter
+  )
 
 const validateFetcherInputs = (...contexts: Context[]) => {
   const [url, request] = fetcher.mock.lastCall
@@ -34,8 +46,6 @@ it('supports multiple events in a batch', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
     maxEventsInBatch: 3,
-    flushInterval: 1000,
-    writeKey: '',
   })
 
   // Create 3 events of mixed types to send.
@@ -62,8 +72,6 @@ it('supports waiting a max amount of time before sending', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
     maxEventsInBatch: 3,
-    flushInterval: 1000,
-    writeKey: '',
   })
 
   const context = new Context(eventFactory.alias('to', 'from'))
@@ -90,8 +98,6 @@ it('sends as soon as batch fills up or max time is reached', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
     maxEventsInBatch: 2,
-    flushInterval: 1000,
-    writeKey: '',
   })
 
   const context = new Context(eventFactory.alias('to', 'from'))
@@ -127,7 +133,6 @@ it('sends if batch will exceed max size in bytes when adding event', async () =>
     maxRetries: 3,
     maxEventsInBatch: 20,
     flushInterval: 100,
-    writeKey: '',
   })
 
   const contexts: Context[] = []
@@ -180,10 +185,7 @@ describe('flushAfterClose', () => {
       )
 
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 20,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     publisher.flushAfterClose(3)
@@ -197,10 +199,7 @@ describe('flushAfterClose', () => {
 
   it('continues to flush on each event if batch size is 1', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     publisher.flushAfterClose(3)
@@ -213,10 +212,7 @@ describe('flushAfterClose', () => {
 
   it('sends immediately once there are no pending items, even if pending events exceeds batch size', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 3,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     publisher.flushAfterClose(5)
@@ -228,10 +224,7 @@ describe('flushAfterClose', () => {
 
   it('works if there are previous items in the batch', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 7,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     range(3).forEach(() => segmentPlugin.track(_createTrackCtx())) // should not flush
@@ -244,10 +237,7 @@ describe('flushAfterClose', () => {
 
   it('works if there are previous items in the batch AND pending items > batch size', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 7,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     range(3).forEach(() => segmentPlugin.track(_createTrackCtx())) // should not flush
@@ -266,10 +256,7 @@ describe('flushAfterClose', () => {
 describe('error handling', () => {
   it('excludes events that are too large', async () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     const context = new Context(
@@ -302,10 +289,7 @@ describe('error handling', () => {
     )
 
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     const context = new Context(eventFactory.alias('to', 'from'))
@@ -335,8 +319,6 @@ describe('error handling', () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 2,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     const context = new Context(eventFactory.alias('to', 'from'))
@@ -365,8 +347,6 @@ describe('error handling', () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 2,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     const context = new Context(eventFactory.alias('my', 'from'))
@@ -394,8 +374,6 @@ describe('error handling', () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 0,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     const fn = jest.fn()
@@ -417,10 +395,7 @@ describe('error handling', () => {
 describe('http_request emitter event', () => {
   it('should emit an http_request object', async () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxRetries: 3,
       maxEventsInBatch: 1,
-      flushInterval: 1000,
-      writeKey: '',
     })
 
     fetcher.mockReturnValueOnce(createSuccess())

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../__tests__/test-helpers/factories'
 import { TestFetchClient } from '../../../__tests__/test-helpers/create-test-analytics'
 import { PublisherProps } from '../publisher'
-import { assertSegmentApiBody } from './test-helpers/segment-http-api'
+import { assertHTTPRequestOptions } from './test-helpers/segment-http-api'
 
 let emitter: Emitter
 const testClient = new TestFetchClient()
@@ -30,8 +30,8 @@ const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   )
 
 const validateFetcherInputs = (...contexts: Context[]) => {
-  const [url, request] = fetcher.mock.lastCall
-  return assertSegmentApiBody(url, request, contexts)
+  const [request] = fetcher.mock.lastCall
+  return assertHTTPRequestOptions(request, contexts)
 }
 
 const eventFactory = new NodeEventFactory()
@@ -308,7 +308,7 @@ describe('error handling', () => {
     `)
   })
 
-  it('retries non-400 errors', async () => {
+  it.only('retries non-400 errors', async () => {
     // Jest kept timing out when using fake timers despite advancing time.
     jest.useRealTimers()
 

--- a/packages/node/src/plugins/segmentio/__tests__/test-helpers/segment-http-api.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/test-helpers/segment-http-api.ts
@@ -32,8 +32,8 @@ export function assertHTTPRequestOptions(
   let idx = 0
   for (const context of contexts) {
     expect(data.batch[idx]).toEqual({
-      ...bodyPropertyMatchers,
       ...context.event,
+      ...bodyPropertyMatchers,
     })
     idx += 1
   }

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -5,7 +5,7 @@ import { extractPromiseParts } from '../../lib/extract-promise-parts'
 import { ContextBatch } from './context-batch'
 import { NodeEmitter } from '../../app/emitter'
 import { b64encode } from '../../lib/base-64-encode'
-import { HTTPClient, HTTPClientRequestOptions } from '../../lib/http-client'
+import { HTTPClient, HTTPClientRequest } from '../../lib/http-client'
 
 function sleep(timeoutInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutInMs))
@@ -198,7 +198,7 @@ export class Publisher {
           return batch.resolveEvents()
         }
 
-        const request: HTTPClientRequestOptions = {
+        const request: HTTPClientRequest = {
           timeout: this._httpRequestTimeout,
           url: this._url,
           method: 'POST',

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -5,7 +5,7 @@ import { extractPromiseParts } from '../../lib/extract-promise-parts'
 import { ContextBatch } from './context-batch'
 import { NodeEmitter } from '../../app/emitter'
 import { b64encode } from '../../lib/base-64-encode'
-import { HTTPClient, HTTPRequestOptions } from '../../lib/http-client'
+import { HTTPClient, HTTPClientRequestOptions } from '../../lib/http-client'
 
 function sleep(timeoutInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutInMs))
@@ -198,7 +198,7 @@ export class Publisher {
           return batch.resolveEvents()
         }
 
-        const request: HTTPRequestOptions = {
+        const request: HTTPClientRequestOptions = {
           timeout: this._httpRequestTimeout,
           url: this._url,
           method: 'POST',

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -199,7 +199,6 @@ export class Publisher {
         }
 
         const request: HTTPClientRequest = {
-          timeout: this._httpRequestTimeout,
           url: this._url,
           method: 'POST',
           headers: {
@@ -208,6 +207,7 @@ export class Publisher {
             'User-Agent': 'analytics-node-next/latest',
           },
           data: { batch: events },
+          httpRequestTimeout: this._httpRequestTimeout,
         }
 
         this._emitter.emit('http_request', {

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -219,7 +219,7 @@ export class Publisher {
 
         const response = await this._httpClient.makeRequest(request)
 
-        if (response.ok) {
+        if (response.status >= 200 && response.status < 300) {
           // Successfully sent events, so exit!
           batch.resolveEvents()
           return

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -5,7 +5,7 @@ import { extractPromiseParts } from '../../lib/extract-promise-parts'
 import { ContextBatch } from './context-batch'
 import { NodeEmitter } from '../../app/emitter'
 import { b64encode } from '../../lib/base-64-encode'
-import { FetchHTTPClient, HTTPClient, HTTPFetchFn } from '../../lib/http-client'
+import { HTTPClient } from '../../lib/http-client'
 
 function sleep(timeoutInMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutInMs))
@@ -27,7 +27,7 @@ export interface PublisherProps {
   writeKey: string
   httpRequestTimeout?: number
   disable?: boolean
-  httpFetchFn: HTTPFetchFn
+  httpClient: HTTPClient
 }
 
 /**
@@ -56,7 +56,7 @@ export class Publisher {
       flushInterval,
       writeKey,
       httpRequestTimeout,
-      httpFetchFn,
+      httpClient,
       disable,
     }: PublisherProps,
     emitter: NodeEmitter
@@ -72,7 +72,7 @@ export class Publisher {
     )
     this._httpRequestTimeout = httpRequestTimeout ?? 10000
     this._disable = Boolean(disable)
-    this._httpClient = new FetchHTTPClient(httpFetchFn)
+    this._httpClient = httpClient
   }
 
   private createBatch(): ContextBatch {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,6 +1790,7 @@ __metadata:
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-core": 1.3.0
     "@types/node": ^16
+    axios: ^1.4.0
     buffer: ^6.0.3
     node-fetch: ^2.6.7
     tslib: ^2.4.1
@@ -4609,6 +4610,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "axios@npm:1.4.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^2.2.0":
   version: 2.2.0
   resolution: "axobject-query@npm:2.2.0"
@@ -7394,7 +7406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -11432,7 +11444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:1.1.0":
+"proxy-from-env@npm:1.1.0, proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4


### PR DESCRIPTION
Package: @segment/analytics-node.
<img width="870" alt="image" src="https://github.com/segmentio/analytics-next/assets/5115498/58865a53-5566-4f17-b6ed-4eb25feaa3af">

Please see the types/default implementation here: `packages/node/src/lib/http-client.ts`

This is based on work / research from @MichaelGHSeg!

## Use a custom fetch-like implementation with proxy (simple, recommended)
```ts
import { HTTPFetchFn } from '../lib/http-client'

const httpClient: HTTPFetchFn = async (url, options) => {
  return axios({
    url,
    proxy: {
        protocol: 'http',
        host: 'proxy.example.com',
        port: 8886,
        auth: {
          username: 'user',
          password: 'pass',
        },
      },
    ...options,
  })
}

new Analytics({
  writeKey: '<YOUR_WRITE_KEY',
  httpClient,
})

```

## Augment the default HTTP Client
```ts
import { FetchHTTPClient, HTTPClientRequest  } from '@segment/analytics-node' 
 
class MyClient extends FetchHTTPClient {
  async makeRequest(options: HTTPClientRequest) {
    return super.makeRequest({
         ...options, 
         headers: { ...options.headers, foo: 'bar'  }
      }})
  }
}

const analytics = new Analytics({ 
  writeKey: '<YOUR_WRITE_KEY>', 
  httpClient: new MyClient() 
})
```

## Option 2: Completely override the full HTTPClient (Advanced, you probably don't need to do this)

```ts
import { HTTPClient, HTTPClientRequest } from '@segment/analytics-node'

class CustomClient implements HTTPClient {
  async makeRequest(options: HTTPClientRequest) {
    return someRequestLibrary(options.url, { 
      method: options.method,
      body: JSON.stringify(options.data) // serialize data
      headers: options.headers,
    })
  }
}
const analytics = new Analytics({ 
  writeKey: '<YOUR_WRITE_KEY>', 
  httpClient: new CustomClient() 
})
```
