### PR TITLE
Fix query string bug

### DIFF
--- a/packages/browser/src/plugins/segmentio/normalize.ts
+++ b/packages/browser/src/plugins/segmentio/normalize.ts
@@ -131,7 +131,7 @@ export function normalize(
   const ctx = json.context
 
   // This guard against missing ctx.page should not be neccessary, since context.page is always defined
-  const query: string = ctx.page?.search || ''
+  const query: string | any = ctx.page?.search || ''
 
   delete json.options
   json.writeKey = settings?.apiKey
@@ -160,7 +160,7 @@ export function normalize(
     }
   }
 
-  if (query && !ctx.campaign) {
+  if (query && typeof query === 'string' && !ctx.campaign) {
     ctx.campaign = utm(query)
   }
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

Since we started looking at the ctx object for the query string, if a user passed in an object for the 'search' key an error would be thrown from trying to parse a string. This was causing these events to be dropped.

[] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).