### PR TITLE
Fix consent package build error in NextJS 

### DIFF
--- a/.changeset/long-buses-clap.md
+++ b/.changeset/long-buses-clap.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-consent-tools': patch
+'@segment/analytics-consent-wrapper-onetrust': patch
+---
+
+Make package work with next 12 and next 13 without transpiling.

--- a/packages/consent/consent-tools/package.json
+++ b/packages/consent/consent-tools/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@segment/analytics-consent-tools",
   "version": "0.0.1",
-  "main": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist/",
     "src/",
@@ -13,9 +14,10 @@
   "scripts": {
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
-    "build": "rm -rf dist && yarn build:esm",
-    "build...": "yarn run -T turbo run build --filter=@segment/analytics-consent-tools",
+    "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
+    "build...": "yarn run -T turbo run build --filter=@segment/analytics-consent-wrapper-onetrust",
     "build:esm": "yarn tsc -p tsconfig.build.json",
+    "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "watch": "yarn build:esm --watch",
     "watch:test": "yarn test --watch",
     "tsc": "yarn run -T tsc",

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@segment/analytics-consent-wrapper-onetrust",
   "version": "0.0.1",
-  "main": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist/",
     "src/",
@@ -12,9 +13,10 @@
   ],
   "scripts": {
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
-    "build": "rm -rf dist && yarn build:esm",
+    "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build...": "yarn run -T turbo run build --filter=@segment/analytics-consent-wrapper-onetrust",
     "build:esm": "yarn tsc -p tsconfig.build.json",
+    "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "watch": "yarn build:esm --watch",
     "watch:test": "yarn test --watch",
     "tsc": "yarn run -T tsc",


### PR DESCRIPTION
![image](https://github.com/segmentio/analytics-next/assets/5115498/a7d62984-087d-4616-bbed-8b8b15ec0012)

Currently, I get the following error in NextJS 13 (I'm only able to repro this using npm pack, not using our linked workspace) -- it doesn't seem to matter if I use `use-client` or not.

The only way around this is to tell people to use this: https://nextjs.org/blog/next-13-1#built-in-module-transpilation-stable

Which seems ugly, as we don't require it for analytics-next.
