### PR TITLE
Treat C001 as a regular category in OneTrust consent wrapper.

### DIFF
--- a/.changeset/swift-falcons-wonder.md
+++ b/.changeset/swift-falcons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-wrapper-onetrust': patch
+---
+
+Remove strictly neccessary cookie logic

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -7,7 +7,6 @@ import {
 } from '@segment/analytics-consent-tools'
 
 import {
-  isAllTrackingDisabled,
   getConsentedGroupIds,
   getGroupData,
   getOneTrustGlobal,
@@ -22,7 +21,7 @@ export const oneTrust = (
   options: OneTrustOptions = {}
 ) =>
   createWrapper({
-    shouldLoad: async (ctx) => {
+    shouldLoad: async () => {
       await resolveWhen(() => {
         const oneTrustGlobal = getOneTrustGlobal()
         return (
@@ -31,16 +30,8 @@ export const oneTrust = (
           oneTrustGlobal.IsAlertBoxClosed()
         )
       }, 500)
-
-      const trackingDisabled = isAllTrackingDisabled(getConsentedGroupIds())
-      if (trackingDisabled) {
-        ctx.abort({
-          loadSegmentNormally: false,
-        })
-      }
     },
     getCategories: (): Categories => {
-      // TODO: Do we check if *all* the destination's mapped cookie categories are consented by the user in the browser.?
       // so basically, if a user has 2 categories defined in the UI: [Functional, Advertising],
       // we need _all_ those categories to be valid
 
@@ -51,7 +42,6 @@ export const oneTrust = (
       // - if the user has selected categories this session
       // - if user has no categories selected because they deliberately do not consent to anything and the popup was dismissed in a previous session
       const { userSetConsentGroups, userDeniedConsentGroups } = getGroupData()
-      // TODO: filter by relevent categories
       const consentedCategories = userSetConsentGroups.reduce<Categories>(
         (acc, c) => {
           return {

--- a/packages/consent/consent-wrapper-onetrust/src/lib/onetrust-api.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/onetrust-api.ts
@@ -85,13 +85,3 @@ export const getGroupData = (): UserConsentGroupData => {
 
   return userConsentGroupData
 }
-
-/**
- * The website needs these cookies in order to function properly (example: identify items placed into a shopping cart).
- * This category is enabled by default, even if user has not made a selection.
- */
-const STRICTLY_NECCESSARY_CATEGORY = 'C0001'
-
-export const isAllTrackingDisabled = (groupIds: string[]): boolean => {
-  return groupIds.length === 1 && groupIds[0] === STRICTLY_NECCESSARY_CATEGORY
-}


### PR DESCRIPTION
Remove strictly necessary cookie check.

Reasoning:
- If Segment is being used for critical workflows, or loads critical plugins, `C001` (Strictly neccessary) is the right category to use. 

[✔️ ] I've included a changeset 