### PR TITLE
fix: support screen events on AJS on Segment Destination

### DIFF
--- a/.changeset/shy-socks-protect.md
+++ b/.changeset/shy-socks-protect.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Added support for `screen` events for Segment destination

--- a/packages/browser/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/index.test.ts
@@ -288,4 +288,38 @@ describe('Segment.io', () => {
       assert(body.to == null)
     })
   })
+
+  describe('#screen', () => {
+    it('should enqueue section, name and properties', async () => {
+      await analytics.screen(
+        'section',
+        'name',
+        { property: true },
+        { opt: true }
+      )
+
+      const [url, params] = spyMock.mock.calls[0]
+      expect(url).toMatchInlineSnapshot(`"https://api.segment.io/v1/s"`)
+
+      const body = JSON.parse(params.body)
+
+      assert(body.name === 'name')
+      assert(body.category === 'section')
+      assert(body.properties.property === true)
+      assert(body.context.opt === true)
+      assert(body.timestamp)
+    })
+
+    it('sets properties when name and category are null', async () => {
+      // @ts-ignore test a valid ajsc page call
+      await analytics.screen(null, { foo: 'bar' })
+
+      const [url, params] = spyMock.mock.calls[0]
+      expect(url).toMatchInlineSnapshot(`"https://api.segment.io/v1/s"`)
+
+      const body = JSON.parse(params.body)
+
+      assert(body.properties.foo === 'bar')
+    })
+  })
 })

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -149,6 +149,7 @@ export async function segmentio(
     page: send,
     alias: send,
     group: send,
+    screen: send,
   }
 
   // Buffer may already have items if they were previously stored in localStorage.


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

Adds `screen` support to Segment's destination.

Previously `screen` events where captured and processed correctly but not sent to Segment.

Added tests.

[✔︎] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).