### PR TITLE
Only enable integration if _all_ consent categories are consented to.

### DIFF
--- a/.changeset/popular-elephants-rush.md
+++ b/.changeset/popular-elephants-rush.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-tools': patch
+---
+
+Change meaning of consent to 'user has consented ALL categories'

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -182,6 +182,7 @@ const omitDisabledRemotePlugins = (
       return true
     }
 
-    const hasUserConsent = categories.some((c) => consentedCategories[c])
+    // Enable if all of its consent categories are consented to
+    const hasUserConsent = categories.every((c) => consentedCategories[c])
     return hasUserConsent
   })

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -50,32 +50,14 @@ export interface CreateWrapperSettings {
   integrationCategoryMappings?: IntegrationCategoryMappings
 
   /**
-   * Predicate function to override default logic around whether or not to load an integration.
-   * @default
-   * ```ts
-   * // consent if user consents to at least one category defined in the integration
-   * (integrationCategories, categories, _info) => {
-   *    if (!integrationCategories.length) return true
-   *    return integrationCategories.some((c) => categories[c])
-   * }
-   * ```
-   *
-   * @example -
-   * ```ts
-   * (integrationCategories, categories, _info) => {
-   * // consent if user consents to _all_ categories defined in the integration
-   *    if (!integrationCategories.length) return true
-   *    return integrationCategories.every((c) => categories[c])
-   * }
-   * ```
-   *
+   * Predicate function to override default logic around whether or not to load an integration. By default, consent requires a user to have all categories enabled for a given integration.
    * @example
    * ```ts
-   * // count consent as usual, but always disable a particular plugin
-   * (integrationCategories, categories, { creationName }) => {
+   * // Always disable a particular plugin
+   * const shouldEnableIntegration = (integrationCategories, categories, { creationName }) => {
    *    if (creationName === 'FullStory') return false
    *    if (!integrationCategories.length) return true
-   *    return integrationCategories.some((c) => categories[c])
+   *    return integrationCategories.every((c) => categories[c])
    * }
    * ```
    */


### PR DESCRIPTION
- Only enable integration if _all_ consent categories are consented to.
- This matches the behavior on ingestion. 