### PR TITLE
Validate categories during consent stamping

### DIFF
--- a/.changeset/olive-trains-remain.md
+++ b/.changeset/olive-trains-remain.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-tools': patch
+---
+
+Validate categories for consent stamping

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -601,7 +601,7 @@ describe(createWrapper, () => {
         })
         .build()
 
-      mockCdnSettings.consentSettings = {
+      ;(mockCdnSettings as any).consentSettings = {
         allCategories: ['Foo', 'Bar'],
       }
 

--- a/packages/consent/consent-tools/src/domain/consent-stamping.ts
+++ b/packages/consent/consent-tools/src/domain/consent-stamping.ts
@@ -1,7 +1,7 @@
 import { AnyAnalytics, Categories } from '../types'
 
 type CreateConsentMw = (
-  getCategories: () => Promise<Categories | undefined>
+  getCategories: () => Promise<Categories>
 ) => AnyAnalytics['addSourceMiddleware']
 
 /**
@@ -11,10 +11,6 @@ export const createConsentStampingMiddleware: CreateConsentMw =
   (getCategories) =>
   async ({ payload, next }) => {
     const categories = await getCategories()
-    if (!categories) {
-      console.error('Skipping consent stamping because categories are empty')
-      return next(payload)
-    }
     payload.obj.context.consent = {
       ...payload.obj.context.consent,
       categoryPreferences: categories,

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -96,8 +96,8 @@ export const createWrapper: CreateWrapper = (createWrapperOptions) => {
         }
 
         const categories = await getCategories()
-
         validateCategories(categories)
+
         return pick(categories, allCategories)
       }
 


### PR DESCRIPTION
This is work based on previous discussion with @oscb and @chrisradek.
- Add validation error if no categories are found
- Validate categories for consent stamping
- Improve tests

