### PR TITLE
Do not throw error when analytics are disabled.

### DIFF
--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -43,7 +43,7 @@ export interface AnalyticsSettings {
 }
 
 export const validateSettings = (settings: AnalyticsSettings) => {
-  if (!settings.writeKey) {
+  if (!settings.writeKey && !settings.disable) {
     throw new ValidationError('writeKey', 'writeKey is missing.')
   }
 }


### PR DESCRIPTION
Imagine the following case where you disable segment in your code.

const { Analytics } = require('@segment/analytics-node');
new Analytics({ writeKey: processe.env.WRITE_KEY || '', disable: true });

If WRITE_KEY is not present, but your analytics are disabled this still throws an error.

This would simplify local setups and do not force them to have a truthy string as write key