### PR TITLE
Filter out integrations in consent

### DIFF
--- a/.changeset/rude-wombats-burn.md
+++ b/.changeset/rude-wombats-burn.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-tools': patch
+---
+
+Support classic destinations and locally installed action destinations by removing integrations.

--- a/packages/consent/consent-tools/src/domain/__tests__/assertions/assert-integration-in-cdn-settings.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/assertions/assert-integration-in-cdn-settings.ts
@@ -1,0 +1,37 @@
+import { CDNSettings } from '../../../types'
+
+/**
+ *  Assert integrations/remote plugins contain only the given integrations
+ */
+export const assertIntegrationsContainOnly = (
+  /**
+   * integration creation names
+   */
+  creationNames: string[],
+  /**
+   * mock CDN settings
+   */
+  originalCDNSettings: CDNSettings,
+  /**
+   * updated CDN settings
+   */
+  updatedCDNSettings: CDNSettings
+) => {
+  expect(updatedCDNSettings.remotePlugins).toEqual(
+    originalCDNSettings.remotePlugins?.filter((p) =>
+      // enabled consent
+      creationNames.includes(p.creationName)
+    )
+  )
+
+  // integrations should also be filtered
+  const integrations = Object.fromEntries(
+    Object.entries(originalCDNSettings.integrations).filter(
+      ([creationName]) => {
+        return [...creationNames, 'Segment.io'].includes(creationName)
+      }
+    )
+  )
+
+  expect(updatedCDNSettings.integrations).toEqual(integrations)
+}

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -8,6 +8,7 @@ import type {
   AnalyticsBrowserSettings,
 } from '../../types'
 import { CDNSettingsBuilder } from '@internal/test-helpers'
+import { assertIntegrationsContainOnly } from './assertions/assert-integration-in-cdn-settings'
 
 const DEFAULT_LOAD_SETTINGS = {
   writeKey: 'foo',
@@ -353,19 +354,12 @@ describe(createWrapper, () => {
       const { updatedCDNSettings } = getAnalyticsLoadLastCall()
 
       expect(typeof updatedCDNSettings.remotePlugins).toBe('object')
-      // remote plugins should be filtered based on consent settings
-      expect(updatedCDNSettings.remotePlugins).toEqual(
-        mockCdnSettings.remotePlugins?.filter((p) =>
-          // enabled consent
-          [creationNameNoConsentData, creationNameWithConsentMatch].includes(
-            p.creationName
-          )
-        )
-      )
 
-      // integrations should be untouched
-      expect(updatedCDNSettings.integrations).toEqual(
-        mockCdnSettings.integrations
+      // remote plugins should be filtered based on consent settings
+      assertIntegrationsContainOnly(
+        [creationNameNoConsentData, creationNameWithConsentMatch],
+        mockCdnSettings,
+        updatedCDNSettings
       )
     })
 
@@ -387,10 +381,10 @@ describe(createWrapper, () => {
       expect(analyticsLoadSpy).toBeCalled()
       const { updatedCDNSettings } = getAnalyticsLoadLastCall()
       // remote plugins should be filtered based on consent settings
-      expect(updatedCDNSettings.remotePlugins).toContainEqual(
-        mockCdnSettings.remotePlugins?.find(
-          (p) => p.creationName === 'mockIntegration'
-        )
+      assertIntegrationsContainOnly(
+        ['mockIntegration'],
+        mockCdnSettings,
+        updatedCDNSettings
       )
     })
 
@@ -412,10 +406,10 @@ describe(createWrapper, () => {
       expect(analyticsLoadSpy).toBeCalled()
       const { updatedCDNSettings } = getAnalyticsLoadLastCall()
       // remote plugins should be filtered based on consent settings
-      expect(updatedCDNSettings.remotePlugins).toContainEqual(
-        mockCdnSettings.remotePlugins?.find(
-          (p) => p.creationName === 'mockIntegration'
-        )
+      assertIntegrationsContainOnly(
+        ['mockIntegration'],
+        mockCdnSettings,
+        updatedCDNSettings
       )
     })
 
@@ -436,10 +430,10 @@ describe(createWrapper, () => {
       })
 
       const { updatedCDNSettings } = getAnalyticsLoadLastCall()
-      expect(updatedCDNSettings.remotePlugins).not.toContainEqual(
-        mockCdnSettings.remotePlugins?.find(
-          (p) => p.creationName === 'mockIntegration'
-        )
+      assertIntegrationsContainOnly(
+        ['mockIntegation'],
+        mockCdnSettings,
+        updatedCDNSettings
       )
     })
   })
@@ -558,14 +552,11 @@ describe(createWrapper, () => {
         cdnSettings: mockCdnSettings,
       })
       const { updatedCDNSettings } = getAnalyticsLoadLastCall()
-      const foundIntg = updatedCDNSettings.remotePlugins?.find(
-        (el) => el.creationName === 'ENABLED'
+      assertIntegrationsContainOnly(
+        ['ENABLED'],
+        mockCdnSettings,
+        updatedCDNSettings
       )
-      expect(foundIntg).toBeTruthy()
-      const disabledIntg = updatedCDNSettings.remotePlugins?.find(
-        (el) => el.creationName === disabledDestinationCreationName
-      )
-      expect(disabledIntg).toBeFalsy()
     })
   })
 

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -64,9 +64,6 @@ export interface CreateWrapperSettings {
   shouldEnableIntegration?: (
     integrationCategories: string[],
     categories: Categories,
-    integrationInfo: Pick<
-      CDNSettingsRemotePlugin,
-      'creationName' | 'libraryName'
-    >
+    integrationInfo: Pick<CDNSettingsRemotePlugin, 'creationName'>
   ) => boolean
 }


### PR DESCRIPTION
This was a missed requirement -- we need to prune both the integrations objects and the remotePlugins array. Support classic destinations and locally installed action destinations by removing integrations (as well as remote plugins).