### PR TITLE
Consent: Change default behavior to not prune unmapped categories from payload; put setting behind flag.

### DIFF
--- a/.changeset/ten-rabbits-draw.md
+++ b/.changeset/ten-rabbits-draw.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-tools': patch
+---
+
+Remove default behavior that prunes unmapped categories from context.contest payload. As such, by default, `allKeys` will no longer be used. Add ability to turn pruning back on via an `pruneUnmappedCategories` setting.

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -526,6 +526,45 @@ describe(createWrapper, () => {
       expect(analyticsLoadSpy).not.toBeCalled()
     })
   })
+  test.each([
+    {
+      getCategories: () =>
+        ({
+          invalidCategory: 'hello',
+        } as any),
+      returnVal: 'Categories',
+    },
+    {
+      getCategories: () =>
+        Promise.resolve({
+          invalidCategory: 'hello',
+        }) as any,
+      returnVal: 'Promise<Categories>',
+    },
+  ])(
+    'should throw an error if getCategories() returns invalid categories during consent stamping ($returnVal))',
+    async ({ getCategories }) => {
+      const fn = jest.spyOn(ConsentStamping, 'createConsentStampingMiddleware')
+      const mockCdnSettings = settingsBuilder.build()
+
+      wrapTestAnalytics({
+        getCategories,
+        shouldLoad: () => {
+          // on first load, we should not get an error because this is a valid category setting
+          return { invalidCategory: true }
+        },
+      })
+      await analytics.load({
+        ...DEFAULT_LOAD_SETTINGS,
+        cdnSettings: mockCdnSettings,
+      })
+
+      const getCategoriesFn = fn.mock.lastCall[0]
+      await expect(getCategoriesFn()).rejects.toMatchInlineSnapshot(
+        `[ValidationError: [Validation] Consent Categories should be {[categoryName: string]: boolean} (Received: {"invalidCategory":"hello"})]`
+      )
+    }
+  )
 
   describe('shouldEnableIntegration', () => {
     it('should let user customize the logic that determines whether or not a destination is enabled', async () => {
@@ -601,6 +640,7 @@ describe(createWrapper, () => {
         })
       }
     )
+
     describe('pruneUnmappedCategories', () => {
       it('should throw an error if there are no configured categories', async () => {
         const fn = jest.spyOn(

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -102,14 +102,16 @@ export const createWrapper: CreateWrapper = (createWrapperOptions) => {
         pruneUnmappedCategories
           ? getPrunedCategories.bind(
               this,
-              initializeCDNSettingsEventListener(analytics)
+              new Promise<CDNSettings>((resolve) =>
+                analytics.on('initialize', resolve)
+              )
             )
-          : async () => getCategories(),
-        (categories) => {
-          validateCategories(categories)
+          : getCategories,
+        async (categories) => {
+          validateCategories(await categories)
           return categories
         }
-      )
+      ) as () => Promise<Categories>
 
       // register listener to stamp all events with latest consent information
       analytics.addSourceMiddleware(
@@ -216,12 +218,4 @@ const disableIntegrations = (
     }
   )
   return results
-}
-
-const initializeCDNSettingsEventListener = (
-  analytics: AnyAnalytics
-): Promise<CDNSettings> => {
-  return new Promise<CDNSettings>((resolve) =>
-    analytics.on('initialize', resolve)
-  )
 }

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -66,4 +66,24 @@ export interface CreateWrapperSettings {
     categories: Categories,
     integrationInfo: Pick<CDNSettingsRemotePlugin, 'creationName'>
   ) => boolean
+
+  /**
+   * Prune consent categories from the `context.consent.categoryPreferences` payload if that category is not mapped to any integration in your Segment.io source.
+   * This is helpful if you want to save on bytes sent to Segment and do need the complete list of CMP's categories for debugging or other reasons.
+   * By default, all consent categories returned by `getCategories()` are sent to Segment.
+   * @default false
+   * ### Example Behavior
+   * You have the following categories mappings defined:
+   * ```
+   * FullStory -> 'CAT002',
+   * Braze -> 'CAT003'
+   * ```
+   * ```ts
+   * // pruneUnmappedCategories = false (default)
+   * { CAT0001: true, CAT0002: true, CAT0003: true }
+   * // pruneUnmappedCategories = true
+   * { CAT0002: true, CAT0003: true  } // pruneUnmappedCategories = true
+   * ```
+   */
+  pruneUnmappedCategories?: boolean
 }


### PR DESCRIPTION
- Add setting to prune unmapped categories, and turn off behavior by default.

