### PR TITLE
fix: sentAt set at batch upload time

### DIFF
--- a/.changeset/odd-nails-collect.md
+++ b/.changeset/odd-nails-collect.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+`sentAt` is not set at batch upload time once per the whole batch. Individual event `sentAt` property is stripped when doing batch uploading.

--- a/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
@@ -49,7 +49,9 @@ describe('Batching', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     jest.restoreAllMocks()
-    jest.useFakeTimers()
+    jest.useFakeTimers({
+      now: new Date('9 Jun 1993 00:00:00Z').getTime(),
+    })
   })
 
   afterEach(() => {
@@ -92,7 +94,7 @@ describe('Batching', () => {
       Array [
         "https://https://api.segment.io/b",
         Object {
-          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"},{\\"event\\":\\"second\\"},{\\"event\\":\\"third\\"}]}",
+          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"},{\\"event\\":\\"second\\"},{\\"event\\":\\"third\\"}],\\"sentAt\\":\\"1993-06-09T00:00:00.000Z\\"}",
           "headers": Object {
             "Content-Type": "text/plain",
           },
@@ -150,7 +152,7 @@ describe('Batching', () => {
       Array [
         "https://https://api.segment.io/b",
         Object {
-          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"},{\\"event\\":\\"second\\"}]}",
+          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"},{\\"event\\":\\"second\\"}],\\"sentAt\\":\\"1993-06-09T00:00:10.000Z\\"}",
           "headers": Object {
             "Content-Type": "text/plain",
           },
@@ -185,7 +187,7 @@ describe('Batching', () => {
       Array [
         "https://https://api.segment.io/b",
         Object {
-          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"}]}",
+          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"}],\\"sentAt\\":\\"1993-06-09T00:00:10.000Z\\"}",
           "headers": Object {
             "Content-Type": "text/plain",
           },
@@ -199,7 +201,38 @@ describe('Batching', () => {
       Array [
         "https://https://api.segment.io/b",
         Object {
-          "body": "{\\"batch\\":[{\\"event\\":\\"second\\"}]}",
+          "body": "{\\"batch\\":[{\\"event\\":\\"second\\"}],\\"sentAt\\":\\"1993-06-09T00:00:21.000Z\\"}",
+          "headers": Object {
+            "Content-Type": "text/plain",
+          },
+          "keepalive": false,
+          "method": "post",
+        },
+      ]
+    `)
+  })
+
+  it('removes sentAt from individual events', async () => {
+    const { dispatch } = batch(`https://api.segment.io`, {
+      size: 2,
+    })
+
+    await dispatch(`https://api.segment.io/v1/t`, {
+      event: 'first',
+      sentAt: new Date('11 Jun 1993 00:01:00Z'),
+    })
+
+    await dispatch(`https://api.segment.io/v1/t`, {
+      event: 'second',
+      sentAt: new Date('11 Jun 1993 00:02:00Z'),
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://https://api.segment.io/b",
+        Object {
+          "body": "{\\"batch\\":[{\\"event\\":\\"first\\"},{\\"event\\":\\"second\\"}],\\"sentAt\\":\\"1993-06-09T00:00:00.000Z\\"}",
           "headers": Object {
             "Content-Type": "text/plain",
           },

--- a/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
@@ -60,13 +60,23 @@ export default function batch(
 
     const writeKey = (batch[0] as SegmentEvent)?.writeKey
 
+    // Remove sentAt from every event as batching only needs a single timestamp
+    const updatedBatch = batch.map((event) => {
+      const { sentAt, ...newEvent } = event as SegmentEvent
+      return newEvent
+    })
+
     return fetch(`https://${apiHost}/b`, {
       keepalive: pageUnloaded,
       headers: {
         'Content-Type': 'text/plain',
       },
       method: 'post',
-      body: JSON.stringify({ batch, writeKey }),
+      body: JSON.stringify({
+        writeKey,
+        batch: updatedBatch,
+        sentAt: new Date().toISOString(),
+      }),
     })
   }
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

`sentAt` is not set at batch upload time once per the whole batch. Individual event `sentAt` property is stripped when doing batch uploading.

- [✔︎] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
