### PR TITLE
Consent consent changed event

### DIFF
--- a/.changeset/mean-geese-wash.md
+++ b/.changeset/mean-geese-wash.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-consent-tools': minor
+'@segment/analytics-consent-wrapper-onetrust': minor
+---
+
+Add consent changed event

--- a/packages/consent/consent-tools-integration-tests/package.json
+++ b/packages/consent/consent-tools-integration-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@internal/consent-tools-integration-tests",
   "private": true,
   "scripts": {
-    ".": "yarn -T turbo run --filter=@internal/consent-tools-integration-tests",
+    ".": "yarn run -T turbo run --filter=@internal/consent-tools-integration-tests...",
     "dev": "yarn concurrently 'yarn watch' 'yarn build serve --open'",
     "build": "webpack",
     "watch": "yarn build --watch",

--- a/packages/consent/consent-tools-integration-tests/src/page-bundles/onetrust/index.ts
+++ b/packages/consent/consent-tools-integration-tests/src/page-bundles/onetrust/index.ts
@@ -10,7 +10,6 @@ oneTrust(analytics, {
     'Actions Amplitude': ['C0004'],
   },
 })
-console.log('loaded?')
 ;(window as any).analytics = analytics
 
 analytics.load({ writeKey: '9lSrez3BlfLAJ7NOChrqWtILiATiycoc' })

--- a/packages/consent/consent-tools-integration-tests/src/page-bundles/onetrust/index.ts
+++ b/packages/consent/consent-tools-integration-tests/src/page-bundles/onetrust/index.ts
@@ -4,11 +4,13 @@ import { oneTrust } from '@segment/analytics-consent-wrapper-onetrust'
 export const analytics = new AnalyticsBrowser()
 
 oneTrust(analytics, {
+  disableConsentChangedEvent: false,
   integrationCategoryMappings: {
     Fullstory: ['C0001'],
     'Actions Amplitude': ['C0004'],
   },
 })
+console.log('loaded?')
 ;(window as any).analytics = analytics
 
 analytics.load({ writeKey: '9lSrez3BlfLAJ7NOChrqWtILiATiycoc' })

--- a/packages/consent/consent-tools/README.md
+++ b/packages/consent/consent-tools/README.md
@@ -1,16 +1,17 @@
 # @segment/analytics-consent-tools
 
-
-
 ## Quick Start
+
 ```ts
 // wrapper.js
 import { createWrapper, resolveWhen } from '@segment/analytics-consent-tools'
 
 export const withCMP = createWrapper({
   shouldLoad: (ctx) => {
-    await resolveWhen(() => 
-      window.CMP !== undefined && !window.CMP.popUpVisible(), 500)
+    await resolveWhen(
+      () => window.CMP !== undefined && !window.CMP.popUpVisible(),
+      500
+    )
 
     if (noConsentNeeded) {
       ctx.abort({ loadSegmentNormally: true })
@@ -18,23 +19,24 @@ export const withCMP = createWrapper({
       ctx.abort({ loadSegmentNormally: false })
     }
   },
-  getCategories: () => { 
+  getCategories: () => {
     // e.g. { Advertising: true, Functional: false }
-    return normalizeCategories(window.CMP.consentedCategories()) 
-  }
+    return normalizeCategories(window.CMP.consentedCategories())
+  },
 })
 ```
 
-
 ## Wrapper Usage API
+
 ## `npm`
+
 ```js
 import { withCMP } from './wrapper'
 import { AnalyticsBrowser } from '@segment/analytics-next'
 
 export const analytics = new AnalyticsBrowser()
 
-withCmp(analytics)
+withCMP(analytics)
 
 analytics.load({
   writeKey: '<MY_WRITE_KEY'>
@@ -43,6 +45,7 @@ analytics.load({
 ```
 
 ## Snippet users (window.analytics)
+
 1. Delete the `analytics.load()` line from the snippet
 
 ```diff
@@ -50,29 +53,33 @@ analytics.load({
 ```
 
 2. Import Analytics
+
 ```js
 import { withCMP } from './wrapper'
 
-withCmp(window.analytics)
+withCMP(window.analytics)
 
 window.analytics.load('<MY_WRITE_KEY')
 ```
 
 ## Wrapper Examples
+
 - [OneTrust](../consent-wrapper-onetrust) (beta)
 
 ## Settings / Options / Configuration
+
 See the complete list of settings in the **[Settings interface](src/types/settings.ts)**
 
 ## Development
+
 1. Build this package + all dependencies
+
 ```sh
 yarn . build
 ```
 
 2. Run tests
+
 ```
 yarn test
 ```
-
-

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -1,4 +1,5 @@
 import * as ConsentStamping from '../consent-stamping'
+import * as ConsentChanged from '../consent-changed'
 import { createWrapper } from '../create-wrapper'
 import { AbortLoadError, LoadContext } from '../load-cancellation'
 import type {
@@ -6,6 +7,7 @@ import type {
   AnyAnalytics,
   CDNSettings,
   AnalyticsBrowserSettings,
+  Categories,
 } from '../../types'
 import { CDNSettingsBuilder } from '@internal/test-helpers'
 import { assertIntegrationsContainOnly } from './assertions/integrations-assertions'
@@ -29,6 +31,7 @@ const mockGetCategories: jest.MockedFn<CreateWrapperSettings['getCategories']> =
 const analyticsLoadSpy: jest.MockedFn<AnyAnalytics['load']> = jest.fn()
 const addSourceMiddlewareSpy = jest.fn()
 let analyticsOnSpy: jest.MockedFn<AnyAnalytics['on']>
+const analyticsTrackSpy: jest.MockedFn<AnyAnalytics['track']> = jest.fn()
 let consoleErrorSpy: jest.SpiedFunction<typeof console['error']>
 
 const getAnalyticsLoadLastCall = () => {
@@ -61,6 +64,7 @@ beforeEach(() => {
   })
 
   class MockAnalytics implements AnyAnalytics {
+    track = analyticsTrackSpy
     on = analyticsOnSpy
     load = analyticsLoadSpy
     addSourceMiddleware = addSourceMiddlewareSpy
@@ -300,8 +304,16 @@ describe(createWrapper, () => {
     )
   })
 
-  describe('Validation', () => {
-    it('should throw an error if categories are in the wrong format', async () => {
+  describe('Settings Validation', () => {
+    /* NOTE: This test suite is meant to be minimal -- please see validation/__tests__ */
+
+    test('createWrapper should throw if user-defined settings/configuration/options are invalid', () => {
+      expect(() =>
+        wrapTestAnalytics({ getCategories: {} as any })
+      ).toThrowError(/validation/i)
+    })
+
+    test('analytics.load should reject if categories are in the wrong format', async () => {
       wrapTestAnalytics({
         shouldLoad: () => Promise.resolve('sup' as any),
       })
@@ -310,7 +322,7 @@ describe(createWrapper, () => {
       )
     })
 
-    it('should throw an error if categories are undefined', async () => {
+    test('analytics.load should reject if categories are undefined', async () => {
       wrapTestAnalytics({
         getCategories: () => undefined as any,
         shouldLoad: () => undefined,
@@ -734,6 +746,62 @@ describe(createWrapper, () => {
         const getCategoriesFn = fn.mock.lastCall[0]
         await expect(getCategoriesFn()).resolves.toEqual({ Foo: true })
       })
+    })
+  })
+
+  describe('registerOnConsentChanged', () => {
+    const sendConsentChangedEventSpy = jest.spyOn(
+      ConsentChanged,
+      'sendConsentChangedEvent'
+    )
+
+    let categoriesChangedCb: (categories: Categories) => void = () => {
+      throw new Error('Not implemented')
+    }
+
+    const registerOnConsentChanged = jest.fn(
+      (consentChangedCb: (c: Categories) => void) => {
+        // simulate a OneTrust.onConsentChanged event callback
+        categoriesChangedCb = jest.fn((categories: Categories) =>
+          consentChangedCb(categories)
+        )
+      }
+    )
+    it('should expect a callback', async () => {
+      wrapTestAnalytics({
+        registerOnConsentChanged: registerOnConsentChanged,
+      })
+      await analytics.load(DEFAULT_LOAD_SETTINGS)
+
+      expect(sendConsentChangedEventSpy).not.toBeCalled()
+      expect(registerOnConsentChanged).toBeCalledTimes(1)
+      categoriesChangedCb({ C0001: true, C0002: false })
+      expect(registerOnConsentChanged).toBeCalledTimes(1)
+      expect(sendConsentChangedEventSpy).toBeCalledTimes(1)
+
+      // if OnConsentChanged callback is called with categories, it should send event
+      expect(analyticsTrackSpy).toBeCalledWith(
+        'Segment Consent Preference',
+        undefined,
+        { consent: { categoryPreferences: { C0001: true, C0002: false } } }
+      )
+    })
+    it('should throw an error if categories are invalid', async () => {
+      consoleErrorSpy.mockImplementationOnce(() => undefined)
+
+      wrapTestAnalytics({
+        registerOnConsentChanged: registerOnConsentChanged,
+      })
+
+      await analytics.load(DEFAULT_LOAD_SETTINGS)
+      expect(consoleErrorSpy).not.toBeCalled()
+      categoriesChangedCb(['OOPS'] as any)
+      expect(consoleErrorSpy).toBeCalledTimes(1)
+      const err = consoleErrorSpy.mock.lastCall[0]
+      expect(err.toString()).toMatch(/validation/i)
+      // if OnConsentChanged callback is called with categories, it should send event
+      expect(sendConsentChangedEventSpy).not.toBeCalled()
+      expect(analyticsTrackSpy).not.toBeCalled()
     })
   })
 })

--- a/packages/consent/consent-tools/src/domain/__tests__/typedef-tests.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/typedef-tests.ts
@@ -2,10 +2,17 @@ import type {
   AnalyticsSnippet,
   AnalyticsBrowser,
 } from '@segment/analytics-next'
-import { createWrapper } from '../../index'
+import { createWrapper, AnyAnalytics } from '../../index'
+
+type Extends<T, U> = T extends U ? true : false
 
 {
   const wrap = createWrapper({ getCategories: () => ({ foo: true }) })
   wrap({} as AnalyticsBrowser)
   wrap({} as AnalyticsSnippet)
+
+  // see AnalyticsSnippet and AnalyticsBrowser extend AnyAnalytics
+  const f: Extends<AnalyticsSnippet, AnyAnalytics> = true
+  const g: Extends<AnalyticsBrowser, AnyAnalytics> = true
+  console.log(f, g)
 }

--- a/packages/consent/consent-tools/src/domain/consent-changed.ts
+++ b/packages/consent/consent-tools/src/domain/consent-changed.ts
@@ -1,0 +1,36 @@
+import { AnyAnalytics, Categories } from '../types'
+
+/**
+ * Dispatch an event that looks like:
+ * ```ts
+ * {
+ * "type": "track",
+ *  "event": "Segment Consent Preference",
+ *  "context": {
+ *    "consent": {
+ *      "categoryPreferences" : {
+ *         "C0001": true,
+ *         "C0002": false,
+ *    }
+ *  }
+ * ...
+ * ```
+ */
+export const sendConsentChangedEvent = (
+  analytics: AnyAnalytics,
+  categories: Categories
+): void => {
+  analytics.track(
+    CONSENT_CHANGED_EVENT,
+    undefined,
+    createConsentChangedCtxDto(categories)
+  )
+}
+
+const CONSENT_CHANGED_EVENT = 'Segment Consent Preference'
+
+const createConsentChangedCtxDto = (categories: Categories) => ({
+  consent: {
+    categoryPreferences: categories,
+  },
+})

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -125,18 +125,16 @@ export const createWrapper: CreateWrapper = (createWrapperOptions) => {
         createConsentStampingMiddleware(getValidCategoriesForConsentStamping)
       )
 
-      if (registerOnConsentChanged) {
-        // whenever consent changes, dispatch a new event with the latest consent information
-        registerOnConsentChanged((categories) => {
-          try {
-            validateCategories(categories)
-            sendConsentChangedEvent(analytics, categories)
-          } catch (err) {
-            // Not sure if there's a better way to handle this, but this makes testing a bit easier.
-            console.error(err)
-          }
-        })
-      }
+      // whenever consent changes, dispatch a new event with the latest consent information
+      registerOnConsentChanged?.((categories) => {
+        try {
+          validateCategories(categories)
+          sendConsentChangedEvent(analytics, categories)
+        } catch (err) {
+          // Not sure if there's a better way to handle this, but this makes testing a bit easier.
+          console.error(err)
+        }
+      })
 
       const updateCDNSettings: InitOptions['updateCDNSettings'] = (
         cdnSettings

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -6,7 +6,11 @@ import {
   CreateWrapperSettings,
   CDNSettings,
 } from '../types'
-import { validateCategories, validateSettings } from './validation'
+import {
+  validateAnalyticsInstance,
+  validateCategories,
+  validateSettings,
+} from './validation'
 import { createConsentStampingMiddleware } from './consent-stamping'
 import { pipe, pick, uniq } from '../utils'
 import { AbortLoadError, LoadContext } from './load-cancellation'
@@ -28,7 +32,7 @@ export const createWrapper: CreateWrapper = (createWrapperOptions) => {
   } = createWrapperOptions
 
   return (analytics) => {
-    assertAnalyticsInstance(analytics)
+    validateAnalyticsInstance(analytics)
     const ogLoad = analytics.load
 
     const loadWithConsent: AnyAnalytics['load'] = async (
@@ -234,19 +238,4 @@ const disableIntegrations = (
     }
   )
   return results
-}
-
-function assertAnalyticsInstance(
-  analytics: unknown
-): asserts analytics is AnyAnalytics {
-  if (
-    analytics &&
-    typeof analytics === 'object' &&
-    'load' in analytics &&
-    'on' in analytics &&
-    'addSourceMiddleware' in analytics
-  ) {
-    return
-  }
-  throw new Error('analytics is not an Analytics instance')
 }

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -13,21 +13,6 @@ import { AbortLoadError, LoadContext } from './load-cancellation'
 import { ValidationError } from './validation/validation-error'
 import { sendConsentChangedEvent } from './consent-changed'
 
-function assertAnalyticsInstance(
-  analytics: unknown
-): asserts analytics is AnyAnalytics {
-  if (
-    analytics &&
-    typeof analytics === 'object' &&
-    'load' in analytics &&
-    'on' in analytics &&
-    'addSourceMiddleware' in analytics
-  ) {
-    return
-  }
-  throw new Error('analytics is not an Analytics instance')
-}
-
 export const createWrapper: CreateWrapper = (createWrapperOptions) => {
   validateSettings(createWrapperOptions)
 
@@ -249,4 +234,19 @@ const disableIntegrations = (
     }
   )
   return results
+}
+
+function assertAnalyticsInstance(
+  analytics: unknown
+): asserts analytics is AnyAnalytics {
+  if (
+    analytics &&
+    typeof analytics === 'object' &&
+    'load' in analytics &&
+    'on' in analytics &&
+    'addSourceMiddleware' in analytics
+  ) {
+    return
+  }
+  throw new Error('analytics is not an Analytics instance')
 }

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -13,6 +13,21 @@ import { AbortLoadError, LoadContext } from './load-cancellation'
 import { ValidationError } from './validation/validation-error'
 import { sendConsentChangedEvent } from './consent-changed'
 
+function assertAnalyticsInstance(
+  analytics: unknown
+): asserts analytics is AnyAnalytics {
+  if (
+    analytics &&
+    typeof analytics === 'object' &&
+    'load' in analytics &&
+    'on' in analytics &&
+    'addSourceMiddleware' in analytics
+  ) {
+    return
+  }
+  throw new Error('analytics is not an Analytics instance')
+}
+
 export const createWrapper: CreateWrapper = (createWrapperOptions) => {
   validateSettings(createWrapperOptions)
 
@@ -28,6 +43,7 @@ export const createWrapper: CreateWrapper = (createWrapperOptions) => {
   } = createWrapperOptions
 
   return (analytics) => {
+    assertAnalyticsInstance(analytics)
     const ogLoad = analytics.load
 
     const loadWithConsent: AnyAnalytics['load'] = async (

--- a/packages/consent/consent-tools/src/domain/validation/__tests__/options-validators.test.ts
+++ b/packages/consent/consent-tools/src/domain/validation/__tests__/options-validators.test.ts
@@ -1,35 +1,51 @@
-import { validateCategories, validateOptions } from '../options-validators'
+import { CreateWrapperSettings } from '../../../types'
+import { validateCategories, validateSettings } from '../options-validators'
 import { ValidationError } from '../validation-error'
 
-describe(validateOptions, () => {
+const DEFAULT_OPTIONS: CreateWrapperSettings = {
+  getCategories: () => ({}),
+}
+
+describe(validateSettings, () => {
   it('should throw if options is not a plain object', () => {
-    expect(() => validateOptions(null as any)).toThrow()
-    expect(() => validateOptions(undefined as any)).toThrow()
-    expect(() => validateOptions('hello' as any)).toThrow()
+    expect(() => validateSettings(null as any)).toThrow()
+    expect(() => validateSettings(undefined as any)).toThrow()
+    expect(() => validateSettings('hello' as any)).toThrow()
   })
 
   it('should throw an instance of ValidationError', () => {
-    expect(() => validateOptions(null as any)).toThrowError(ValidationError)
+    expect(() => validateSettings(null as any)).toThrowError(ValidationError)
   })
 
   it('should throw with the expected error', () => {
     expect(() =>
-      validateOptions(null as any)
+      validateSettings(null as any)
     ).toThrowErrorMatchingInlineSnapshot(
       `"[Validation] Options should be an object (Received: null)"`
     )
   })
 
   it('should throw if required property(s) are not included', () => {
-    expect(() => validateOptions({} as any)).toThrow()
+    expect(() => validateSettings({} as any)).toThrow()
   })
 
   it('should throw if getCategories() is not a function', () => {
     expect(() =>
-      validateOptions({
+      validateSettings({
         getCategories: {},
       })
     ).toThrow()
+  })
+
+  it('should throw if registerOnChanged() is not a function', () => {
+    expect(() =>
+      validateSettings({
+        ...DEFAULT_OPTIONS,
+        registerOnConsentChanged: {} as any,
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[Validation] registerOnConsentChanged is not a function (Received: {})"`
+    )
   })
 })
 

--- a/packages/consent/consent-tools/src/domain/validation/common-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/common-validators.ts
@@ -11,7 +11,7 @@ export function assertIsFunction(
 
 export function assertIsObject(
   val: unknown,
-  variableName: string
+  variableName = 'value'
 ): asserts val is object {
   if (val === null || typeof val !== 'object') {
     throw new ValidationError(`${variableName} is not an object`, val)

--- a/packages/consent/consent-tools/src/domain/validation/common-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/common-validators.ts
@@ -11,7 +11,7 @@ export function assertIsFunction(
 
 export function assertIsObject(
   val: unknown,
-  variableName = 'value'
+  variableName: string
 ): asserts val is object {
   if (val === null || typeof val !== 'object') {
     throw new ValidationError(`${variableName} is not an object`, val)

--- a/packages/consent/consent-tools/src/domain/validation/options-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/options-validators.ts
@@ -62,7 +62,7 @@ export function validateSettings(options: {
 export function validateAnalyticsInstance(
   analytics: unknown
 ): asserts analytics is AnyAnalytics {
-  assertIsObject(analytics)
+  assertIsObject(analytics, 'analytics')
   if (
     'load' in analytics &&
     'on' in analytics &&

--- a/packages/consent/consent-tools/src/domain/validation/options-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/options-validators.ts
@@ -23,7 +23,7 @@ export function validateCategories(
   }
 }
 
-export function validateOptions(options: {
+export function validateSettings(options: {
   [k in keyof CreateWrapperSettings]: unknown
 }): asserts options is CreateWrapperSettings {
   if (typeof options !== 'object' || !options) {
@@ -50,5 +50,11 @@ export function validateOptions(options: {
     assertIsObject(
       options.integrationCategoryMappings,
       'integrationCategoryMappings'
+    )
+
+  options.registerOnConsentChanged &&
+    assertIsFunction(
+      options.registerOnConsentChanged,
+      'registerOnConsentChanged'
     )
 }

--- a/packages/consent/consent-tools/src/domain/validation/options-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/options-validators.ts
@@ -1,4 +1,4 @@
-import { Categories, CreateWrapperSettings } from '../../types'
+import { AnyAnalytics, Categories, CreateWrapperSettings } from '../../types'
 import { assertIsFunction, assertIsObject } from './common-validators'
 import { ValidationError } from './validation-error'
 
@@ -57,4 +57,18 @@ export function validateSettings(options: {
       options.registerOnConsentChanged,
       'registerOnConsentChanged'
     )
+}
+
+export function validateAnalyticsInstance(
+  analytics: unknown
+): asserts analytics is AnyAnalytics {
+  assertIsObject(analytics)
+  if (
+    'load' in analytics &&
+    'on' in analytics &&
+    'addSourceMiddleware' in analytics
+  ) {
+    return
+  }
+  throw new ValidationError('analytics is not an Analytics instance', analytics)
 }

--- a/packages/consent/consent-tools/src/domain/validation/validation-error.ts
+++ b/packages/consent/consent-tools/src/domain/validation/validation-error.ts
@@ -4,7 +4,7 @@ export class ValidationError extends AnalyticsConsentError {
   constructor(message: string, received?: any) {
     if (arguments.length === 2) {
       // to ensure that explicitly passing undefined as second argument still works
-      message += `(Received: ${JSON.stringify(received)})`
+      message += ` (Received: ${JSON.stringify(received)})`
     }
     super('ValidationError', `[Validation] ${message}`)
   }

--- a/packages/consent/consent-tools/src/domain/validation/validation-error.ts
+++ b/packages/consent/consent-tools/src/domain/validation/validation-error.ts
@@ -1,10 +1,11 @@
 import { AnalyticsConsentError } from '../../types/errors'
 
 export class ValidationError extends AnalyticsConsentError {
-  constructor(message: string, received: any) {
-    super(
-      'ValidationError',
-      `[Validation] ${message} (${`Received: ${JSON.stringify(received)})`}`
-    )
+  constructor(message: string, received?: any) {
+    if (arguments.length === 2) {
+      // to ensure that explicitly passing undefined as second argument still works
+      message += `(Received: ${JSON.stringify(received)})`
+    }
+    super('ValidationError', `[Validation] ${message}`)
   }
 }

--- a/packages/consent/consent-tools/src/types/errors.ts
+++ b/packages/consent/consent-tools/src/types/errors.ts
@@ -1,12 +1,12 @@
 /**
- * Base consent
+ * Base Consent Error
  */
 export abstract class AnalyticsConsentError extends Error {
   /**
    *
    * @param name - Pass the name explicitly to work around the limitation that 'name' is automatically set to the parent class.
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends#using_extends
-   * @param message
+   * @param message - Error message
    */
   constructor(public name: string, message: string) {
     super(message)

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -35,7 +35,7 @@ export interface CreateWrapperSettings {
    * @example
    * ```ts
    * (categoriesChangedCb) => {
-   *   window.MyCMP.OnConsentChanged((ctg) => categoriesChangedCb(normalizeCategories(ctg))
+   *   window.MyCMP.OnConsentChanged((event.detail) => categoriesChangedCb(normalizeCategories(event.detail))
    * }
    *
    * /* event payload

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -28,6 +28,36 @@ export interface CreateWrapperSettings {
   getCategories: () => Categories | Promise<Categories>
 
   /**
+   * Programatically send a "Segment Consent Preference" event to Segment when consent preferences change.
+   * An event will be sent to Segment whenever this function is called.
+   *
+   * #### Note: The callback requires the categories to be in the shape of { "C0001": true, "C0002": false }, so some normalization may be needed.
+   * @example
+   * ```ts
+   * (categoriesChangedCb) => {
+   *   window.MyCMP.OnConsentChanged((ctg) => categoriesChangedCb(normalizeCategories(ctg))
+   * }
+   *
+   * /* event payload
+   * {
+   *  "type": "track",
+   *  "event": "Segment Consent Preference",
+   *  "context": {
+   *    "consent": {
+   *      "version": 2,
+   *      "categoryPreferences" : {
+   *         "C0001": true,
+   *         "C0002": false,
+   *    }
+   *  }
+   * ..
+   * ```
+   */
+  registerOnConsentChanged?: (
+    categoriesChangedCb: (categories: Categories) => void
+  ) => void
+
+  /**
    * This permanently disables any consent requirement (i.e device mode gating, event pref stamping).
    * Called on wrapper initialization. **shouldLoad will never be called**
    **/

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -28,8 +28,7 @@ export interface CreateWrapperSettings {
   getCategories: () => Categories | Promise<Categories>
 
   /**
-   * Programatically send a "Segment Consent Preference" event to Segment when consent preferences change.
-   * An event will be sent to Segment whenever this function is called.
+   * Function to register a listener for consent changes to programatically send a "Segment Consent Preference" event to Segment when consent preferences change.
    *
    * #### Note: The callback requires the categories to be in the shape of { "C0001": true, "C0002": false }, so some normalization may be needed.
    * @example

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -44,7 +44,7 @@ export type Wrapper = (analyticsInstance: object) => void
 /**
  * Create a function which wraps analytics instances to add consent management.
  */
-export type CreateWrapper = (options: CreateWrapperSettings) => Wrapper
+export type CreateWrapper = (settings: CreateWrapperSettings) => Wrapper
 
 export interface Categories {
   [category: string]: boolean

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -39,7 +39,7 @@ export interface AnyAnalytics {
  * This function modifies an analytics instance to add consent management.
  * This is an analytics instance (either window.analytics, new AnalyticsBrowser(), or the instance returned by `AnalyticsBrowser.load({...})`
  **/
-// The chance of a false positive is higher than the chance that someone will pass in an object that is not an analytics instance.
+// Why type this as 'object' rather than 'AnyAnalytics'? IMO, the chance of a false positive is much higher than the chance that someone will pass in an object that is not an analytics instance.
 // We have an assertion function that throws an error if the analytics instance is not compatible.
 export type Wrapper = (analyticsInstance: object) => void
 

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -39,6 +39,8 @@ export interface AnyAnalytics {
  * This function modifies an analytics instance to add consent management.
  * This is an analytics instance (either window.analytics, new AnalyticsBrowser(), or the instance returned by `AnalyticsBrowser.load({...})`
  **/
+// The chance of a false positive is higher than the chance that someone will pass in an object that is not an analytics instance.
+// We have an assertion function that throws an error if the analytics instance is not compatible.
 export type Wrapper = (analyticsInstance: object) => void
 
 /**

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -36,19 +36,15 @@ export interface AnyAnalytics {
 }
 
 /**
- * This function returns a "wrapped" version of analytics.
- */
-export interface Wrapper {
-  // Returns void rather than analytics to emphasize that this function replaces the .load function of the underlying instance.
-  (analytics: AnyAnalytics): void
-}
+ * This function modifies an analytics instance to add consent management.
+ * This is an analytics instance (either window.analytics, new AnalyticsBrowser(), or the instance returned by `AnalyticsBrowser.load({...})`
+ **/
+export type Wrapper = (analyticsInstance: object) => void
 
 /**
- * This function returns a function which returns a "wrapped" version of analytics
+ * Create a function which wraps analytics instances to add consent management.
  */
-export interface CreateWrapper {
-  (options: CreateWrapperSettings): Wrapper
-}
+export type CreateWrapper = (options: CreateWrapperSettings) => Wrapper
 
 export interface Categories {
   [category: string]: boolean

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -23,6 +23,7 @@ export interface InitOptions {
 export interface AnyAnalytics {
   addSourceMiddleware(...args: any[]): any
   on(event: 'initialize', callback: (settings: CDNSettings) => void): void
+  track(event: string, properties?: unknown, ...args: any[]): void
 
   /**
    * This interface is meant to be compatible with both the snippet (`window.analytics.load`)

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -6,9 +6,11 @@
   "types": "./dist/types/index.d.ts",
   "sideEffects": false,
   "files": [
+    "LICENSE",
     "dist/",
     "src/",
     "!**/__tests__/**",
+    "!**/test-helpers/**",
     "!*.tsbuildinfo"
   ],
   "scripts": {

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -14,7 +14,7 @@
     "!*.tsbuildinfo"
   ],
   "scripts": {
-    ".": "yarn run -T turbo run --filter=@segment/analytics-consent-wrapper-onetrust",
+    ".": "yarn run -T turbo run --filter=@segment/analytics-consent-wrapper-onetrust...",
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",

--- a/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
@@ -129,7 +129,7 @@ describe('High level "integration" tests', () => {
       const onConsentChangedArg =
         OneTrustMockGlobal.OnConsentChanged.mock.lastCall[0]
       onConsentChangedArg(
-        new CustomEvent('foo', {
+        new CustomEvent('', {
           detail: [
             grpFixture.StrictlyNeccessary.CustomGroupId,
             grpFixture.Performance.CustomGroupId,

--- a/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
@@ -2,7 +2,7 @@ import * as ConsentTools from '@segment/analytics-consent-tools'
 import * as OneTrustAPI from '../../lib/onetrust-api'
 import { sleep } from '@internal/test-helpers'
 import { oneTrust } from '../wrapper'
-import { OneTrustMockGlobal } from '../../test-helpers/mocks'
+import { OneTrustMockGlobal, analyticsMock } from '../../test-helpers/mocks'
 
 const throwNotImplemented = (): never => {
   throw new Error('not implemented')
@@ -69,7 +69,7 @@ describe('High level "integration" tests', () => {
     })
 
     it('should be resolved successfully', async () => {
-      oneTrust({} as any)
+      oneTrust(analyticsMock)
       OneTrustMockGlobal.GetDomainData.mockReturnValueOnce({
         Groups: [grpFixture.StrictlyNeccessary, grpFixture.Performance],
       })
@@ -92,7 +92,7 @@ describe('High level "integration" tests', () => {
 
   describe('getCategories', () => {
     it('should get categories successfully', async () => {
-      oneTrust({} as any)
+      oneTrust(analyticsMock)
       OneTrustMockGlobal.GetDomainData.mockReturnValue({
         Groups: [
           grpFixture.StrictlyNeccessary,
@@ -115,7 +115,7 @@ describe('High level "integration" tests', () => {
 
   describe('Consent changed', () => {
     it('should enable consent changed by default', async () => {
-      oneTrust({} as any)
+      oneTrust(analyticsMock)
       OneTrustMockGlobal.GetDomainData.mockReturnValue({
         Groups: [
           grpFixture.StrictlyNeccessary,

--- a/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/__tests__/wrapper.test.ts
@@ -128,10 +128,14 @@ describe('High level "integration" tests', () => {
       onCategoriesChangedCb()
       const onConsentChangedArg =
         OneTrustMockGlobal.OnConsentChanged.mock.lastCall[0]
-      onConsentChangedArg([
-        grpFixture.StrictlyNeccessary.CustomGroupId,
-        grpFixture.Performance.CustomGroupId,
-      ])
+      onConsentChangedArg(
+        new CustomEvent('foo', {
+          detail: [
+            grpFixture.StrictlyNeccessary.CustomGroupId,
+            grpFixture.Performance.CustomGroupId,
+          ],
+        })
+      )
       // expect to be normalized!
       expect(onCategoriesChangedCb.mock.lastCall[0]).toEqual({
         [grpFixture.StrictlyNeccessary.CustomGroupId]: true,

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -1,5 +1,4 @@
 import {
-  AnyAnalytics,
   createWrapper,
   CreateWrapperSettings,
   resolveWhen,
@@ -12,13 +11,18 @@ import {
   getOneTrustGlobal,
 } from '../lib/onetrust-api'
 
-interface OneTrustSettings {
+export interface OneTrustSettings {
   integrationCategoryMappings?: CreateWrapperSettings['integrationCategoryMappings']
   disableConsentChangedEvent?: boolean
 }
 
+/**
+ *
+ * @param analyticsInstance - An analytics instance. Either `window.analytics`, or the instance returned by `new AnalyticsBrowser()` or `AnalyticsBrowser.load({...})`
+ * @param settings - Optional settings for configuring your OneTrust wrapper
+ */
 export const oneTrust = (
-  analytics: AnyAnalytics,
+  analyticsInstance: object,
   settings: OneTrustSettings = {}
 ) => {
   createWrapper({
@@ -46,5 +50,5 @@ export const oneTrust = (
             onCategoriesChangedCb(normalizedCategories)
           }),
     integrationCategoryMappings: settings.integrationCategoryMappings,
-  })(analytics)
+  })(analyticsInstance)
 }

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -1,25 +1,26 @@
 import {
   AnyAnalytics,
-  Categories,
   createWrapper,
   CreateWrapperSettings,
   resolveWhen,
 } from '@segment/analytics-consent-tools'
 
 import {
+  getNormalizedCategoriesFromGroupData,
+  getNormalizedCategoriesFromGroupIds,
   getConsentedGroupIds,
-  getGroupData,
   getOneTrustGlobal,
 } from '../lib/onetrust-api'
 
-interface OneTrustOptions {
+interface OneTrustSettings {
   integrationCategoryMappings?: CreateWrapperSettings['integrationCategoryMappings']
+  disableConsentChangedEvent?: boolean
 }
 
 export const oneTrust = (
   analytics: AnyAnalytics,
-  options: OneTrustOptions = {}
-) =>
+  settings: OneTrustSettings = {}
+) => {
   createWrapper({
     shouldLoad: async () => {
       await resolveWhen(() => {
@@ -31,37 +32,18 @@ export const oneTrust = (
         )
       }, 500)
     },
-    getCategories: (): Categories => {
-      // so basically, if a user has 2 categories defined in the UI: [Functional, Advertising],
-      // we need _all_ those categories to be valid
-
-      // Scenarios:
-      // - if the user is being asked to select categories, so the popup is still visible
-      // - if user has no categories selected because they deliberately do not consent to anything and the popup has been dismissed in this session
-      // - if user has selected categories in a past session
-      // - if the user has selected categories this session
-      // - if user has no categories selected because they deliberately do not consent to anything and the popup was dismissed in a previous session
-      const { userSetConsentGroups, userDeniedConsentGroups } = getGroupData()
-      const consentedCategories = userSetConsentGroups.reduce<Categories>(
-        (acc, c) => {
-          return {
-            ...acc,
-            [c.groupId]: true,
-          }
-        },
-        {}
-      )
-
-      const deniedCategories = userDeniedConsentGroups.reduce<Categories>(
-        (acc, c) => {
-          return {
-            ...acc,
-            [c.groupId]: false,
-          }
-        },
-        {}
-      )
-      return { ...consentedCategories, ...deniedCategories }
+    getCategories: () => {
+      const results = getNormalizedCategoriesFromGroupData()
+      return results
     },
-    integrationCategoryMappings: options.integrationCategoryMappings,
+    registerOnConsentChanged: settings.disableConsentChangedEvent
+      ? undefined
+      : (onCategoriesChangedCb) =>
+          getOneTrustGlobal()?.OnConsentChanged((categories) => {
+            const normalizedCategories =
+              getNormalizedCategoriesFromGroupIds(categories)
+            onCategoriesChangedCb(normalizedCategories)
+          }),
+    integrationCategoryMappings: settings.integrationCategoryMappings,
   })(analytics)
+}

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -22,7 +22,7 @@ export interface OneTrustSettings {
  * @param settings - Optional settings for configuring your OneTrust wrapper
  */
 export const oneTrust = (
-  analyticsInstance: object,
+  analyticsInstance: object, // typing this as 'object', rather than AnyAnalytics to avoid misc type mismatches. createWrapper will throw an error if the analytics instance is not compatible.
   settings: OneTrustSettings = {}
 ) => {
   createWrapper({

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -39,9 +39,10 @@ export const oneTrust = (
     registerOnConsentChanged: settings.disableConsentChangedEvent
       ? undefined
       : (onCategoriesChangedCb) =>
-          getOneTrustGlobal()?.OnConsentChanged((categories) => {
-            const normalizedCategories =
-              getNormalizedCategoriesFromGroupIds(categories)
+          getOneTrustGlobal()?.OnConsentChanged((event) => {
+            const normalizedCategories = getNormalizedCategoriesFromGroupIds(
+              event.detail
+            )
             onCategoriesChangedCb(normalizedCategories)
           }),
     integrationCategoryMappings: settings.integrationCategoryMappings,

--- a/packages/consent/consent-wrapper-onetrust/src/index.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/index.ts
@@ -3,3 +3,4 @@
  * We avoid using splat (*) exports so that we can control what is exposed.
  */
 export { oneTrust } from './domain/wrapper'
+export type { OneTrustSettings } from './domain/wrapper'

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -98,7 +98,7 @@ describe(getOneTrustActiveGroups, () => {
   it('should throw an error if OneTrustActiveGroups is invalid', () => {
     // @ts-ignore
     window.OnetrustActiveGroups = []
-    expect(() => getOneTrustActiveGroups()).toThrow()
+    expect(() => getOneTrustActiveGroups()).toThrow(OneTrustApiValidationError)
   })
 })
 

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -1,7 +1,16 @@
 import '../../test-helpers/onetrust-globals.d.ts'
 
-import { getConsentedGroupIds, getGroupDataFromGroupIds } from '../onetrust-api'
+import {
+  getConsentedGroupIds,
+  getGroupDataFromGroupIds,
+  getNormalizedCategoriesFromGroupData,
+  getOneTrustActiveGroups,
+  getNormalizedCategoriesFromGroupIds,
+  getOneTrustGlobal,
+  getAllGroups,
+} from '../onetrust-api'
 import { OneTrustMockGlobal } from '../../test-helpers/mocks'
+import { OneTrustApiValidationError } from '../validation'
 
 beforeEach(() => {
   // @ts-ignore
@@ -10,31 +19,101 @@ beforeEach(() => {
   delete window.OneTrust
 })
 
-describe(getConsentedGroupIds, () => {
-  it('should return formatted groups', () => {
-    window.OnetrustActiveGroups = ',C0001,C0004,C0003,STACK42,'
-    expect(getConsentedGroupIds()).toEqual([
-      'C0001',
-      'C0004',
-      'C0003',
-      'STACK42',
-    ])
-  })
-  it('should work even without the strange leading/trailing commas that onetrust adds', () => {
-    window.OnetrustActiveGroups = 'C0001,C0004'
-    expect(getConsentedGroupIds()).toEqual(['C0001', 'C0004'])
+describe(getOneTrustGlobal, () => {
+  it('should get the global', () => {
+    ;(window as any).OneTrust = OneTrustMockGlobal
+    expect(getOneTrustGlobal()).toEqual(OneTrustMockGlobal)
   })
 
-  it('should return an array with only 1 active group if that is the only one consented', () => {
-    window.OnetrustActiveGroups = ',C0001,'
-    expect(getConsentedGroupIds()).toEqual(['C0001'])
+  it('should throw an error if the global is missing fields', () => {
+    ;(window as any).OneTrust = {}
+    expect(() => getOneTrustGlobal()).toThrow(OneTrustApiValidationError)
+  })
+})
+
+describe(getAllGroups, () => {
+  it('works if OneTrust global is not available', () => {
+    ;(window as any).OneTrust = undefined
+    expect(getAllGroups()).toEqual([])
+  })
+  it('get the normalized groups', () => {
+    ;(window as any).OneTrust = OneTrustMockGlobal
+    window.OneTrust = {
+      ...OneTrustMockGlobal,
+      GetDomainData: () => ({
+        Groups: [
+          {
+            CustomGroupId: 'C0001',
+          },
+          {
+            CustomGroupId: 'C0004',
+          },
+          {
+            CustomGroupId: '  C0005',
+          },
+          {
+            CustomGroupId: 'C0006  ',
+          },
+        ],
+      }),
+    }
+    expect(getAllGroups()).toEqual([
+      { groupId: 'C0001' },
+      { groupId: 'C0004' },
+      { groupId: 'C0005' },
+      { groupId: 'C0006' },
+    ])
+  })
+})
+
+describe(getNormalizedCategoriesFromGroupData, () => {
+  it('should return a set of groups', () => {
+    expect(
+      getNormalizedCategoriesFromGroupData({
+        userSetConsentGroups: [{ groupId: 'C0003' }],
+        userDeniedConsentGroups: [{ groupId: 'C0001' }, { groupId: 'C0002' }],
+      })
+    ).toEqual({ C0003: true, C0001: false, C0002: false })
+  })
+})
+
+describe(getOneTrustActiveGroups, () => {
+  it('should return the global string', () => {
+    window.OnetrustActiveGroups = 'hello'
+    expect(getOneTrustActiveGroups()).toBe('hello')
+  })
+  it('should return undefined if no groups are defined', () => {
+    // @ts-ignore
+    window.OnetrustActiveGroups = undefined
+    expect(getOneTrustActiveGroups()).toBe(undefined)
+
+    // @ts-ignore
+    window.OnetrustActiveGroups = null
+    expect(getOneTrustActiveGroups()).toBe(undefined)
+
+    window.OnetrustActiveGroups = ''
+    expect(getOneTrustActiveGroups()).toBe(undefined)
+  })
+
+  it('should throw an error if OneTrustActiveGroups is invalid', () => {
+    // @ts-ignore
+    window.OnetrustActiveGroups = []
+    expect(() => getOneTrustActiveGroups()).toThrow()
+  })
+})
+
+describe(getConsentedGroupIds, () => {
+  it('should normalize groupIds', () => {
+    expect(getConsentedGroupIds(',C0001,')).toEqual(['C0001'])
+    expect(getConsentedGroupIds('C0001,C0004')).toEqual(['C0001', 'C0004'])
+    expect(getConsentedGroupIds(',C0001,C0004')).toEqual(['C0001', 'C0004'])
+    expect(getConsentedGroupIds(',')).toEqual([])
+    expect(getConsentedGroupIds(',,')).toEqual([])
+    expect(getConsentedGroupIds('')).toEqual([])
+    expect(getConsentedGroupIds(',,')).toEqual([])
   })
 
   it('should return an empty array if no groups are defined', () => {
-    window.OnetrustActiveGroups = ',,'
-    expect(getConsentedGroupIds()).toEqual([])
-    window.OnetrustActiveGroups = ','
-    expect(getConsentedGroupIds()).toEqual([])
     // @ts-ignore
     window.OnetrustActiveGroups = undefined
     expect(getConsentedGroupIds()).toEqual([])
@@ -76,5 +155,28 @@ describe(getGroupDataFromGroupIds, () => {
         groupId: 'SOME_OTHER_GROUP',
       },
     ])
+  })
+})
+
+describe(getNormalizedCategoriesFromGroupIds, () => {
+  it('should get normalized categories', () => {
+    window.OneTrust = {
+      ...OneTrustMockGlobal,
+      GetDomainData: () => ({
+        Groups: [
+          {
+            CustomGroupId: 'C0001',
+          },
+          {
+            CustomGroupId: 'C0004',
+          },
+          {
+            CustomGroupId: 'SOME_OTHER_GROUP',
+          },
+        ],
+      }),
+    }
+    const ids = getNormalizedCategoriesFromGroupIds(['C0001'])
+    expect(ids).toEqual({ C0001: true, C0004: false, SOME_OTHER_GROUP: false })
   })
 })

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -1,4 +1,4 @@
-import '../../test-helpers/onetrust-globals.js'
+import '../../test-helpers/onetrust-globals.d.ts'
 
 import { getConsentedGroupIds, getGroupDataFromGroupIds } from '../onetrust-api'
 import { OneTrustMockGlobal } from '../../test-helpers/mocks'

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -1,6 +1,7 @@
-import './onetrust-globals.d.ts'
+import '../../test-helpers/onetrust-globals.js'
 
-import { getConsentedGroupIds, getGroupData } from '../onetrust-api'
+import { getConsentedGroupIds, getGroupDataFromGroupIds } from '../onetrust-api'
+import { OneTrustMockGlobal } from '../../test-helpers/mocks'
 
 beforeEach(() => {
   // @ts-ignore
@@ -40,11 +41,11 @@ describe(getConsentedGroupIds, () => {
   })
 })
 
-describe(getGroupData, () => {
+describe(getGroupDataFromGroupIds, () => {
   it('should partition groups into consent/deny', () => {
     window.OnetrustActiveGroups = ',C0001,C0004'
     window.OneTrust = {
-      ...window.OneTrust,
+      ...OneTrustMockGlobal,
       GetDomainData: () => ({
         Groups: [
           {
@@ -59,7 +60,7 @@ describe(getGroupData, () => {
         ],
       }),
     }
-    const data = getGroupData()
+    const data = getGroupDataFromGroupIds()
 
     expect(data.userSetConsentGroups).toEqual([
       {

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -108,7 +108,6 @@ describe(getConsentedGroupIds, () => {
     expect(getConsentedGroupIds('C0001,C0004')).toEqual(['C0001', 'C0004'])
     expect(getConsentedGroupIds(',C0001,C0004')).toEqual(['C0001', 'C0004'])
     expect(getConsentedGroupIds(',')).toEqual([])
-    expect(getConsentedGroupIds(',,')).toEqual([])
     expect(getConsentedGroupIds('')).toEqual([])
     expect(getConsentedGroupIds(',,')).toEqual([])
   })

--- a/packages/consent/consent-wrapper-onetrust/src/lib/onetrust-api.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/onetrust-api.ts
@@ -57,7 +57,7 @@ export const getOneTrustGlobal = (): OneTrustGlobal | undefined => {
   )
 }
 
-const getOneTrustActiveGroups = (): string | undefined => {
+export const getOneTrustActiveGroups = (): string | undefined => {
   const groups = (window as any).OnetrustActiveGroups
   if (!groups) return undefined
   if (typeof groups !== 'string') {
@@ -69,8 +69,9 @@ const getOneTrustActiveGroups = (): string | undefined => {
   return groups
 }
 
-export const getConsentedGroupIds = (): ConsentGroupIds => {
-  const groups = getOneTrustActiveGroups()
+export const getConsentedGroupIds = (
+  groups = getOneTrustActiveGroups()
+): ConsentGroupIds => {
   if (!groups) {
     return []
   }
@@ -88,7 +89,7 @@ const normalizeGroupInfo = (groupInfo: GroupInfoDto): GroupInfo => ({
 /**
  * get *all* groups / categories, not just active ones
  */
-const getAllGroups = (): GroupInfo[] => {
+export const getAllGroups = (): GroupInfo[] => {
   const oneTrustGlobal = getOneTrustGlobal()
   if (!oneTrustGlobal) return []
   return oneTrustGlobal.GetDomainData().Groups.map(normalizeGroupInfo)

--- a/packages/consent/consent-wrapper-onetrust/src/lib/validation/index.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './onetrust-api-error'

--- a/packages/consent/consent-wrapper-onetrust/src/lib/validation/onetrust-api-error.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/validation/onetrust-api-error.ts
@@ -1,0 +1,11 @@
+/**
+ * An Errot that represents that the OneTrust API is not in the expected format.
+ * This is not something that could happen unless our API types are wrong and something is very wonky.
+ * Not a recoverable error.
+ */
+export class OneTrustApiValidationError extends Error {
+  name = 'OtConsentWrapperValidationError'
+  constructor(message: string, received: any) {
+    super(`Invariant: ${message} (Received: ${JSON.stringify(received)})`)
+  }
+}

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -1,0 +1,16 @@
+import { OneTrustGlobal } from '../lib/onetrust-api'
+import { throwNotImplemented } from './utils'
+
+/**
+ * This can be used to mock the OneTrust global object in individual tests
+ * @example
+ * ```ts
+ * import * as OneTrustAPI from '../onetrust-api'
+ * jest.spyOn(OneTrustAPI, 'getOneTrustGlobal').mockImplementation(() => OneTrustMockGlobal)
+ * ````
+ */
+export const OneTrustMockGlobal: jest.Mocked<OneTrustGlobal> = {
+  GetDomainData: jest.fn().mockImplementation(throwNotImplemented),
+  IsAlertBoxClosed: jest.fn().mockImplementation(throwNotImplemented),
+  OnConsentChanged: jest.fn().mockImplementation(throwNotImplemented), // not implemented atm
+}

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -16,8 +16,8 @@ export const OneTrustMockGlobal: jest.Mocked<OneTrustGlobal> = {
 }
 
 export const analyticsMock: jest.Mocked<AnyAnalytics> = {
-  addSourceMiddleware: jest.fn(),
-  load: jest.fn(),
-  on: jest.fn(),
-  track: jest.fn(),
+  addSourceMiddleware: jest.fn().mockImplementation(throwNotImplemented),
+  load: jest.fn().mockImplementation(throwNotImplemented),
+  on: jest.fn().mockImplementation(throwNotImplemented),
+  track: jest.fn().mockImplementation(throwNotImplemented),
 }

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -1,6 +1,6 @@
 import { OneTrustGlobal } from '../lib/onetrust-api'
 import { throwNotImplemented } from './utils'
-
+import type { AnyAnalytics } from '@segment/analytics-consent-tools'
 /**
  * This can be used to mock the OneTrust global object in individual tests
  * @example
@@ -13,4 +13,11 @@ export const OneTrustMockGlobal: jest.Mocked<OneTrustGlobal> = {
   GetDomainData: jest.fn().mockImplementation(throwNotImplemented),
   IsAlertBoxClosed: jest.fn().mockImplementation(throwNotImplemented),
   OnConsentChanged: jest.fn().mockImplementation(throwNotImplemented), // not implemented atm
+}
+
+export const analyticsMock: jest.Mocked<AnyAnalytics> = {
+  addSourceMiddleware: jest.fn(),
+  load: jest.fn(),
+  on: jest.fn(),
+  track: jest.fn(),
 }

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/onetrust-globals.d.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/onetrust-globals.d.ts
@@ -1,4 +1,4 @@
-import { OneTrustGlobal } from '../onetrust-api'
+import { OneTrustGlobal } from '../lib/onetrust-api'
 /**
  * ALERT: It's OK to declare ambient globals in test code, but __not__ in library code
  * This file should not be included in the final package

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
@@ -1,0 +1,3 @@
+export const throwNotImplemented = (): never => {
+  throw new Error('not implemented')
+}

--- a/packages/consent/consent-wrapper-onetrust/tsconfig.build.json
+++ b/packages/consent/consent-wrapper-onetrust/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/__tests__/**"],
+  "exclude": ["**/__tests__/**", "**/test-helpers/**"],
   "compilerOptions": {
     "outDir": "./dist/esm",
     "declarationDir": "./dist/types"


### PR DESCRIPTION
- Add registerOnConsentChanged setting.
- For OneTrust, dispatch a segment consent changed event whenever OneTrust consent change.
- Add ability to disable consent changed events.
- update README.
Other misc goodies!