### PR TITLE
Consent: Support older browsers like ie11

### DIFF
--- a/.changeset/forty-toes-stare.md
+++ b/.changeset/forty-toes-stare.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-consent-tools': patch
+'@segment/analytics-consent-wrapper-onetrust': patch
+---
+
+Support older browsers

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^2.6.2",
     "ts-jest": "^28.0.4",
     "ts-node": "^10.8.0",
-    "turbo": "^1.3.1",
+    "turbo": "^1.10.14",
     "typescript": "^4.7.0",
     "webpack": "^5.76.0",
     "webpack-dev-server": "^4.15.1"

--- a/packages/config-webpack/package.json
+++ b/packages/config-webpack/package.json
@@ -11,6 +11,7 @@
     "@types/circular-dependency-plugin": "^5",
     "babel-loader": "^8.0.0",
     "circular-dependency-plugin": "^5.2.2",
+    "ecma-version-validator-webpack-plugin": "^1.2.1",
     "terser-webpack-plugin": "^5.1.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.8.0",

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -15,6 +15,7 @@ module.exports = {
   devtool: 'source-map',
   stats: isWatch ? 'errors-warnings' : 'normal',
   mode: isProd ? 'production' : 'development',
+  target: ['web', 'es5'], // target es5 for ie11 support (compiles modules to es5)
   module: {
     rules: [
       {

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -70,6 +70,6 @@ module.exports = {
     new CircularDependencyPlugin({
       failOnError: true,
     }),
-    new ECMAVersionValidatorPlugin({ ecmaVersion: 5 }), // ensure we don't accidentally break ie11 syntax.
+    new ECMAVersionValidatorPlugin({ ecmaVersion: 5 }), // ensure our js bundle only contains syntax supported in ie11. This does not check polyfills.
   ],
 }

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -15,7 +15,7 @@ module.exports = {
   devtool: 'source-map',
   stats: isWatch ? 'errors-warnings' : 'normal',
   mode: isProd ? 'production' : 'development',
-  target: ['web', 'es5'], // target es5 for ie11 support (compiles modules to es5)
+  target: ['web', 'es5'], // target es5 for ie11 support (generates module boilerplate in es5)
   module: {
     rules: [
       {

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -1,5 +1,8 @@
 const TerserPlugin = require('terser-webpack-plugin')
 const CircularDependencyPlugin = require('circular-dependency-plugin')
+const {
+  ECMAVersionValidatorPlugin,
+} = require('ecma-version-validator-webpack-plugin')
 
 const isProd = process.env.NODE_ENV === 'production'
 const isWatch = process.env.WATCH === 'true'
@@ -67,5 +70,6 @@ module.exports = {
     new CircularDependencyPlugin({
       failOnError: true,
     }),
+    new ECMAVersionValidatorPlugin({ ecmaVersion: 5 }), // ensure we don't accidentally break ie11 syntax.
   ],
 }

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -37,7 +37,7 @@ module.exports = {
             },
           },
         ],
-        exclude: /node_modules/,
+        // exclude: /node_modules/, // transpile node_modules for ie11 support
       },
     ],
   },

--- a/packages/config-webpack/webpack.config.common.js
+++ b/packages/config-webpack/webpack.config.common.js
@@ -37,7 +37,6 @@ module.exports = {
             },
           },
         ],
-        // exclude: /node_modules/, // transpile node_modules for ie11 support
       },
     ],
   },

--- a/packages/consent/consent-tools/tsconfig.json
+++ b/packages/consent/consent-tools/tsconfig.json
@@ -3,7 +3,7 @@
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "module": "ESNext", // es6 modules
-    "target": "ESNext", // assume that consumers will be using webpack, so don't down-compile
+    "target": "ES2020", // don't down-compile *too much* -- if users are using webpack, they can always transpile this library themselves
     "lib": ["ES2020", "DOM", "DOM.Iterable"], // assume that consumers will be polyfilling at least down to es2020
     "moduleResolution": "node",
     "resolveJsonModule": true

--- a/packages/consent/consent-wrapper-onetrust/README.md
+++ b/packages/consent/consent-wrapper-onetrust/README.md
@@ -101,13 +101,13 @@ withOneTrust(analytics).load({ writeKey: '<MY_WRITE_KEY'> })
 
 - We build three versions of the library:
 
-1. `cjs` (CommonJS modules) - for library users
-2. `esm` (es6 modules) - for library users
+1. `cjs` (CommonJS modules) - for npm library users
+2. `esm` (es6 modules) - for npm library users
 3. `umd` (bundle) - for snippet users (typically)
 
 ### Browser Support
 
-- `cjs/esm` - ONLY support modern JS syntax. We expect our typical `npm install` users to employ something like babel if they need legacy browser support.
+- `cjs/esm` - Support modern JS syntax (ES2020). These are our npm library users, so we expect them to transpile this module themselves using something like babel/webpack if they need extra legacy browser support.
 
 - `umd` - Support back to IE11, but **do not** polyfill . See our docs on [supported browsers](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/supported-browsers).
 

--- a/turbo.json
+++ b/turbo.json
@@ -5,9 +5,11 @@
       "dependsOn": ["^build"],
       "inputs": [
         "**/tsconfig*.json",
+        "**/babel.config*",
+        "**/webpack.config*",
         "**/*.ts",
         "**/*.tsx",
-        ":!**/__tests__/**"
+        "!**/__tests__/**"
       ],
       "outputs": ["**/dist/**", ".next/**"]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6811,7 +6811,7 @@ __metadata:
     prettier: ^2.6.2
     ts-jest: ^28.0.4
     ts-node: ^10.8.0
-    turbo: ^1.3.1
+    turbo: ^1.10.14
     typescript: ^4.7.0
     webpack: ^5.76.0
     webpack-dev-server: ^4.15.1
@@ -19865,146 +19865,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-android-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-android-arm64@npm:1.3.1"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"turbo-darwin-64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-darwin-64@npm:1.3.1"
+"turbo-darwin-64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-darwin-64@npm:1.10.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-darwin-arm64@npm:1.3.1"
+"turbo-darwin-arm64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-darwin-arm64@npm:1.10.14"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-freebsd-64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-freebsd-64@npm:1.3.1"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"turbo-freebsd-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-freebsd-arm64@npm:1.3.1"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"turbo-linux-32@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-32@npm:1.3.1"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"turbo-linux-64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-64@npm:1.3.1"
+"turbo-linux-64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-linux-64@npm:1.10.14"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-arm64@npm:1.3.1"
+"turbo-linux-arm64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-linux-arm64@npm:1.10.14"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-arm@npm:1.3.1"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"turbo-linux-mips64le@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-mips64le@npm:1.3.1"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"turbo-linux-ppc64le@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-linux-ppc64le@npm:1.3.1"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"turbo-windows-32@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-windows-32@npm:1.3.1"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"turbo-windows-64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-windows-64@npm:1.3.1"
+"turbo-windows-64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-windows-64@npm:1.10.14"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "turbo-windows-arm64@npm:1.3.1"
+"turbo-windows-arm64@npm:1.10.14":
+  version: 1.10.14
+  resolution: "turbo-windows-arm64@npm:1.10.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "turbo@npm:1.3.1"
+"turbo@npm:^1.10.14":
+  version: 1.10.14
+  resolution: "turbo@npm:1.10.14"
   dependencies:
-    turbo-android-arm64: 1.3.1
-    turbo-darwin-64: 1.3.1
-    turbo-darwin-arm64: 1.3.1
-    turbo-freebsd-64: 1.3.1
-    turbo-freebsd-arm64: 1.3.1
-    turbo-linux-32: 1.3.1
-    turbo-linux-64: 1.3.1
-    turbo-linux-arm: 1.3.1
-    turbo-linux-arm64: 1.3.1
-    turbo-linux-mips64le: 1.3.1
-    turbo-linux-ppc64le: 1.3.1
-    turbo-windows-32: 1.3.1
-    turbo-windows-64: 1.3.1
-    turbo-windows-arm64: 1.3.1
+    turbo-darwin-64: 1.10.14
+    turbo-darwin-arm64: 1.10.14
+    turbo-linux-64: 1.10.14
+    turbo-linux-arm64: 1.10.14
+    turbo-windows-64: 1.10.14
+    turbo-windows-arm64: 1.10.14
   dependenciesMeta:
-    turbo-android-arm64:
-      optional: true
     turbo-darwin-64:
       optional: true
     turbo-darwin-arm64:
       optional: true
-    turbo-freebsd-64:
-      optional: true
-    turbo-freebsd-arm64:
-      optional: true
-    turbo-linux-32:
-      optional: true
     turbo-linux-64:
       optional: true
-    turbo-linux-arm:
-      optional: true
     turbo-linux-arm64:
-      optional: true
-    turbo-linux-mips64le:
-      optional: true
-    turbo-linux-ppc64le:
-      optional: true
-    turbo-windows-32:
       optional: true
     turbo-windows-64:
       optional: true
@@ -20012,7 +19932,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: fced49081f2c64aaf93a2499edb057bb05d30bd2074b9652610f939c9037869501fcc50e7ad05a48cec4a8b9d344cc1c4ea505edd45fe2f9639fb138fa55182b
+  checksum: 219d245bb5cc32a9f76b136b81e86e179228d93a44cab4df3e3d487a55dd2688b5b85f4d585b66568ac53166145352399dd2d7ed0cd47f1aae63d08beb814ebb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,7 @@ __metadata:
     "@types/circular-dependency-plugin": ^5
     babel-loader: ^8.0.0
     circular-dependency-plugin: ^5.2.2
+    ecma-version-validator-webpack-plugin: ^1.2.1
     terser-webpack-plugin: ^5.1.4
     webpack: ^5.76.0
     webpack-cli: ^4.8.0
@@ -9704,6 +9705,17 @@ __metadata:
     wcwidth:
       optional: true
   checksum: 66961b19751a68d2d30ce9b74ef750c374cc3112bbcac3d1ed5a939e43c035ecf6b1954098df2d5b05f1e853ab2b67de893794390dcbf0abe1f157fddeb52174
+  languageName: node
+  linkType: hard
+
+"ecma-version-validator-webpack-plugin@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "ecma-version-validator-webpack-plugin@npm:1.2.1"
+  dependencies:
+    acorn: ^8.7.0
+  peerDependencies:
+    webpack: ^4.40.0 || ^5.0.0
+  checksum: 9a0f6d9beb600f1af054f65a52790c3784d5d4c19cb10b9ae7446682613349ade952b355cca0e60b45616e66ce9b1914d183a909ce136bb05b47f364dd6bfabf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- turborepo: update in order to fix issue where webpack config changes would not trigger cache invalidation.
- onetrust: transpile node_modules to ie11 
- consent-tools: lib users have support back to ES2020