### PR TITLE
Adds missing return types and adds context-batch type

### DIFF
--- a/.changeset/popular-eggs-begin.md
+++ b/.changeset/popular-eggs-begin.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-node': patch
+---
+
+Adds missing return types

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -94,7 +94,10 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
     return timeout ? pTimeout(promise, timeout).catch(() => undefined) : promise
   }
 
-  private _dispatch(segmentEvent: SegmentEvent, callback?: Callback) {
+  private _dispatch(
+    segmentEvent: SegmentEvent,
+    callback?: Callback
+  ): undefined {
     if (this._isClosed) {
       this.emit('call_after_close', segmentEvent as SegmentEvent)
       return undefined

--- a/packages/node/src/lib/abort.ts
+++ b/packages/node/src/lib/abort.ts
@@ -60,7 +60,9 @@ class AbortController {
 /**
  * @param timeoutMs - Set a request timeout, after which the request is cancelled.
  */
-export const abortSignalAfterTimeout = (timeoutMs: number) => {
+export const abortSignalAfterTimeout = (
+  timeoutMs: number
+): [globalThis.AbortSignal | AbortSignal, NodeJS.Timeout] | [] => {
   if (detectRuntime() === 'cloudflare-worker') {
     return [] // TODO: this is broken in cloudflare workers, otherwise results in "A hanging Promise was canceled..." error.
   }
@@ -73,5 +75,5 @@ export const abortSignalAfterTimeout = (timeoutMs: number) => {
   // Allow Node.js processes to exit early if only the timeout is running
   timeoutId?.unref?.()
 
-  return [ac.signal, timeoutId] as const
+  return [ac.signal, timeoutId]
 }

--- a/packages/node/src/plugins/segmentio/publisher.ts
+++ b/packages/node/src/plugins/segmentio/publisher.ts
@@ -174,9 +174,11 @@ export class Publisher {
       return ctxPromise
     } else {
       // this should only occur if max event size is exceeded
-      ctx.setFailedDelivery({
-        reason: new Error(fbAddStatus.message),
-      })
+      if ('message' in fbAddStatus) {
+        ctx.setFailedDelivery({
+          reason: new Error(fbAddStatus.message),
+        })
+      }
       return Promise.resolve(ctx)
     }
   }


### PR DESCRIPTION
These changes are needed to resolve compile errors when consuming this package in an app with TS 4.8.4. The errors that were being encountered were:

```
node_modules/@segment/analytics-node/src/app/analytics-node.ts(97,11): error TS7010: '_dispatch', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/@segment/analytics-node/src/lib/abort.ts(63,40): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any[] | readonly [AbortSignal | AbortSignal, Timeout]' return type.
node_modules/@segment/analytics-node/src/plugins/segmentio/publisher.ts(178,39): error TS2339: Property 'message' does not exist on type '{ success: true; } | { success: false; message: string; }'.
  Property 'message' does not exist on type '{ success: true; }'.
```

Initially, to confirm that changes to the package would fix the issue, I updated the code in the `node_modules` folder and was able to successfully compile my code. This was done using the `1.1.1` version of the `@segment/analytics-node` package.

Once I confirmed the changes worked, I made the changes in the package code (forked repo), ran `yarn changeset` successfully, also `yarn test:node-int`, and then committed the changes, which ran the linter successfully, and finally pushed my branch, which ran the tests again - successfully.

- [ x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
