### PR TITLE
Capture action plugin metrics

### DIFF
--- a/.changeset/metal-drinks-repeat.md
+++ b/.changeset/metal-drinks-repeat.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Capture action plugin metrics

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "28.9 KB"
+      "limit": "29 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
-    "@internal/test-helpers": "0.0.0",
     "@segment/analytics-browser-actions-braze": "^1.3.0",
     "@segment/analytics.js-integration": "^3.3.3",
     "@segment/analytics.js-integration-amplitude": "^3.3.3",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@internal/config": "0.0.0",
+    "@internal/test-helpers": "0.0.0",
     "@segment/analytics-browser-actions-braze": "^1.3.0",
     "@segment/analytics.js-integration": "^3.3.3",
     "@segment/analytics.js-integration-amplitude": "^3.3.3",

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -80,8 +80,6 @@ describe('ActionDestination', () => {
 
     await ajs.ready()
 
-    expect(ajs.ctx?.stats.metrics).toHaveLength(1)
-
     expect(ajs.ctx?.stats.metrics[0]).toMatchObject(
       expect.objectContaining({
         metric: 'analytics_js.action_plugin.invoke',

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -1,16 +1,18 @@
 import unfetch from 'unfetch'
 import braze from '@segment/analytics-browser-actions-braze'
+import { CDNSettingsBuilder } from '@internal/test-helpers'
 
 import { AnalyticsBrowser } from '../../../browser'
 import { createSuccess } from '../../../test-helpers/factories'
 import { JSDOM } from 'jsdom'
 
+const writeKey = 'abc'
+
 jest.mock('unfetch')
 jest.mocked(unfetch).mockImplementation(() =>
-  createSuccess({
-    integrations: {},
-    remotePlugins: [
-      {
+  createSuccess(
+    new CDNSettingsBuilder({ writeKey })
+      .addActionDestinationSettings({
         name: 'Braze Web Mode (Actions)',
         creationName: 'Braze Web Mode (Actions)',
         libraryName: 'brazeDestination',
@@ -38,9 +40,9 @@ jest.mocked(unfetch).mockImplementation(() =>
             },
           ],
         },
-      },
-    ],
-  })
+      })
+      .build()
+  )
 )
 
 beforeEach(async () => {

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -1,0 +1,111 @@
+import unfetch from 'unfetch'
+import braze from '@segment/analytics-browser-actions-braze'
+
+import { AnalyticsBrowser } from '../../../browser'
+import { createSuccess } from '../../../test-helpers/factories'
+import { JSDOM } from 'jsdom'
+
+jest.mock('unfetch')
+jest.mocked(unfetch).mockImplementation(() =>
+  createSuccess({
+    integrations: {},
+    remotePlugins: [
+      {
+        name: 'Braze Web Mode (Actions)',
+        creationName: 'Braze Web Mode (Actions)',
+        libraryName: 'brazeDestination',
+        url: 'https://cdn.segment.com/next-integrations/actions/braze/a6f95f5869852b848386.js',
+        settings: {
+          api_key: 'test-api-key',
+          versionSettings: {
+            componentTypes: [],
+          },
+          subscriptions: [
+            {
+              id: '3thVuvYKBcEGKEZA185Tbs',
+              name: 'Track Calls',
+              enabled: true,
+              partnerAction: 'trackEvent',
+              subscribe: 'type = "track" and event != "Order Completed"',
+              mapping: {
+                eventName: {
+                  '@path': '$.event',
+                },
+                eventProperties: {
+                  '@path': '$.properties',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  })
+)
+
+beforeEach(async () => {
+  const html = `
+  <!DOCTYPE html>
+    <head>
+      <script>'hi'</script>
+    </head>
+    <body>
+    </body>
+  </html>
+  `.trim()
+
+  const jsd = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'https://localhost',
+  })
+
+  const windowSpy = jest.spyOn(global, 'window', 'get')
+  windowSpy.mockImplementation(
+    () => jsd.window as unknown as Window & typeof globalThis
+  )
+
+  const documentSpy = jest.spyOn(global, 'document', 'get')
+  documentSpy.mockImplementation(
+    () => jsd.window.document as unknown as Document
+  )
+})
+
+describe('ActionDestination', () => {
+  it('captures essential metrics when invoking methods on an action plugin', async () => {
+    const ajs = AnalyticsBrowser.load({
+      writeKey: 'abc',
+      plugins: [braze as any],
+    })
+
+    await ajs.ready()
+
+    expect(ajs.ctx?.stats.metrics).toHaveLength(1)
+
+    expect(ajs.ctx?.stats.metrics[0]).toMatchObject(
+      expect.objectContaining({
+        metric: 'analytics_js.action_plugin.invoke',
+        tags: [
+          'method:load',
+          'action_plugin_name:Braze Web Mode (Actions) trackEvent',
+        ],
+      })
+    )
+
+    const trackCtx = await ajs.track('test')
+
+    const actionInvokeMetric = trackCtx.stats.metrics.find(
+      (m) => m.metric === 'analytics_js.action_plugin.invoke'
+    )
+
+    expect(actionInvokeMetric).toMatchObject(
+      expect.objectContaining({
+        metric: 'analytics_js.action_plugin.invoke',
+        tags: [
+          'method:track',
+          'action_plugin_name:Braze Web Mode (Actions) trackEvent',
+        ],
+      })
+    )
+  })
+})

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -1,18 +1,16 @@
 import unfetch from 'unfetch'
 import braze from '@segment/analytics-browser-actions-braze'
-import { CDNSettingsBuilder } from '@internal/test-helpers'
 
 import { AnalyticsBrowser } from '../../../browser'
 import { createSuccess } from '../../../test-helpers/factories'
 import { JSDOM } from 'jsdom'
 
-const writeKey = 'abc'
-
 jest.mock('unfetch')
 jest.mocked(unfetch).mockImplementation(() =>
-  createSuccess(
-    new CDNSettingsBuilder({ writeKey })
-      .addActionDestinationSettings({
+  createSuccess({
+    integrations: {},
+    remotePlugins: [
+      {
         name: 'Braze Web Mode (Actions)',
         creationName: 'Braze Web Mode (Actions)',
         libraryName: 'brazeDestination',
@@ -40,9 +38,9 @@ jest.mocked(unfetch).mockImplementation(() =>
             },
           ],
         },
-      })
-      .build()
-  )
+      },
+    ],
+  })
 )
 
 beforeEach(async () => {

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -129,8 +129,6 @@ export class ActionDestination implements DestinationPlugin {
         `action_plugin_name:${this.action.name}`,
       ])
 
-      console.log(error)
-
       throw error
     }
   }

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -79,7 +79,21 @@ export class ActionDestination implements DestinationPlugin {
         transformedContext = await this.transform(ctx)
       }
 
-      await this.action[methodName]!(transformedContext)
+      try {
+        ctx.stats.increment('analytics_js.action_plugin.invoke', 1, [
+          `method:${methodName}`,
+          `action_plugin_name:${this.action.name}`,
+        ])
+
+        await this.action[methodName]!(transformedContext)
+      } catch (error) {
+        ctx.stats.increment('analytics_js.action_plugin.invoke.error', 1, [
+          `method:${methodName}`,
+          `action_plugin_name:${this.action.name}`,
+        ])
+
+        throw error
+      }
 
       return ctx
     }
@@ -101,8 +115,24 @@ export class ActionDestination implements DestinationPlugin {
     return this.action.ready ? this.action.ready() : Promise.resolve()
   }
 
-  load(ctx: Context, analytics: Analytics): Promise<unknown> {
-    return this.action.load(ctx, analytics)
+  async load(ctx: Context, analytics: Analytics): Promise<unknown> {
+    try {
+      ctx.stats.increment('analytics_js.action_plugin.invoke', 1, [
+        `method:load`,
+        `action_plugin_name:${this.action.name}`,
+      ])
+
+      return await this.action.load(ctx, analytics)
+    } catch (error) {
+      ctx.stats.increment('analytics_js.action_plugin.invoke.error', 1, [
+        `method:load`,
+        `action_plugin_name:${this.action.name}`,
+      ])
+
+      console.log(error)
+
+      throw error
+    }
   }
 
   unload(ctx: Context, analytics: Analytics): Promise<unknown> | unknown {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,7 +2569,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@internal/test-helpers@workspace:^, @internal/test-helpers@workspace:packages/test-helpers":
+"@internal/test-helpers@0.0.0, @internal/test-helpers@workspace:^, @internal/test-helpers@workspace:packages/test-helpers":
   version: 0.0.0-use.local
   resolution: "@internal/test-helpers@workspace:packages/test-helpers"
   dependencies:
@@ -3516,6 +3516,7 @@ __metadata:
   resolution: "@segment/analytics-next@workspace:packages/browser"
   dependencies:
     "@internal/config": 0.0.0
+    "@internal/test-helpers": 0.0.0
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-browser-actions-braze": ^1.3.0
     "@segment/analytics-core": 1.3.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,7 +2569,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@internal/test-helpers@0.0.0, @internal/test-helpers@workspace:^, @internal/test-helpers@workspace:packages/test-helpers":
+"@internal/test-helpers@workspace:^, @internal/test-helpers@workspace:packages/test-helpers":
   version: 0.0.0-use.local
   resolution: "@internal/test-helpers@workspace:packages/test-helpers"
   dependencies:
@@ -3516,7 +3516,6 @@ __metadata:
   resolution: "@segment/analytics-next@workspace:packages/browser"
   dependencies:
     "@internal/config": 0.0.0
-    "@internal/test-helpers": 0.0.0
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-browser-actions-braze": ^1.3.0
     "@segment/analytics-core": 1.3.2


### PR DESCRIPTION
Just like how we capture metrics relating to performance of classic integrations, this patch now enables capturing of metrics related to action destinations as well.