### PR TITLE
rename 'shouldLoad' -> 'shouldLoadSegment'; add shouldLoadWrapper API

### DIFF
--- a/.changeset/fair-pillows-sin.md
+++ b/.changeset/fair-pillows-sin.md
@@ -2,4 +2,6 @@
 '@segment/analytics-consent-tools': major
 ---
 
-Rename shouldLoad -> shouldLoadSegment and add shouldLoadWrapper API
+* Rename `shouldLoad` -> `shouldLoadSegment`
+* Rename `ctx.abort({ loadSegmentNormally -> disableConsentRequirement` to be more consistent with the setting that shares that name.
+* Create `shouldLoadWrapper` API for waiting for consent script initialization.

--- a/.changeset/fair-pillows-sin.md
+++ b/.changeset/fair-pillows-sin.md
@@ -3,5 +3,5 @@
 ---
 
 * Rename `shouldLoad` -> `shouldLoadSegment`
-* Remove redundant `shouldDisableConsentRequirement` setting, in favor of shouldLoad's `ctx.abort({  disableConsentRequirement: true/false })`
+* Remove redundant `shouldDisableConsentRequirement` setting, in favor of shouldLoad's `ctx.abort({loadSegmentNormally: true})`
 * Create `shouldLoadWrapper` API for waiting for consent script initialization.

--- a/.changeset/fair-pillows-sin.md
+++ b/.changeset/fair-pillows-sin.md
@@ -3,5 +3,5 @@
 ---
 
 * Rename `shouldLoad` -> `shouldLoadSegment`
-* Rename `ctx.abort({ loadSegmentNormally -> disableConsentRequirement` to be more consistent with the setting that shares that name.
+* Remove redundant `shouldDisableConsentRequirement` setting, in favor of shouldLoad's `ctx.abort({  disableConsentRequirement: true/false })`
 * Create `shouldLoadWrapper` API for waiting for consent script initialization.

--- a/.changeset/fair-pillows-sin.md
+++ b/.changeset/fair-pillows-sin.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-tools': major
+---
+
+Rename shouldLoad -> shouldLoadSegment and add shouldLoadWrapper API

--- a/packages/consent/consent-tools/README.md
+++ b/packages/consent/consent-tools/README.md
@@ -7,12 +7,15 @@
 import { createWrapper, resolveWhen } from '@segment/analytics-consent-tools'
 
 export const withCMP = createWrapper({
+  // Wait to load wrapper or call "shouldLoadSegment" until window.CMP exists.
+  shouldLoadWrapper: async () => {
+    await resolveWhen(() => window.CMP !== undefined, 500)
+  },
 
   // Wrapper waits to load segment / get categories until this function returns / resolves
-  shouldLoad: async (ctx) => {
-    const CMP = await getCMP()
+  shouldLoadSegment: async (ctx) => {
     await resolveWhen(
-      () => !CMP.popUpVisible(),
+      () => !window.CMP.popUpVisible(),
       500
     )
 
@@ -24,24 +27,16 @@ export const withCMP = createWrapper({
     }
   },
 
-  getCategories: async () => {
-    const CMP = await getCMP()
-    return normalizeCategories(CMP.consentedCategories()) // Expected format: { foo: true, bar: false }
+  getCategories: () => {
+    return normalizeCategories(window.CMP.consentedCategories()) // Expected format: { foo: true, bar: false }
   },
 
-  registerOnConsentChanged: async (setCategories) => {
-    const CMP = await getCMP()
-    CMP.onConsentChanged((event) => {
+  registerOnConsentChanged: (setCategories) => {
+    window.CMP.onConsentChanged((event) => {
       setCategories(normalizeCategories(event.detail))
     })
   },
 })
-
-
-const getCMP = async () => {
- await resolveWhen(() => window.CMP !== undefined, 500)
- return window.CMP
-}
 ```
 
 ## Wrapper Usage API

--- a/packages/consent/consent-tools/README.md
+++ b/packages/consent/consent-tools/README.md
@@ -21,9 +21,9 @@ export const withCMP = createWrapper({
 
     // Optional -- for granular control of initialization
     if (noConsentNeeded) {
-      ctx.abort({ disableConsentRequirement: true })
+      ctx.abort({ loadSegmentNormally: true })
     } else if (allTrackingDisabled) {
-      ctx.abort({ disableConsentRequirement: false })
+      ctx.abort({ loadSegmentNormally: false })
     }
   },
 

--- a/packages/consent/consent-tools/README.md
+++ b/packages/consent/consent-tools/README.md
@@ -21,9 +21,9 @@ export const withCMP = createWrapper({
 
     // Optional -- for granular control of initialization
     if (noConsentNeeded) {
-      ctx.abort({ loadSegmentNormally: true })
+      ctx.abort({ disableConsentRequirement: true })
     } else if (allTrackingDisabled) {
-      ctx.abort({ loadSegmentNormally: false })
+      ctx.abort({ disableConsentRequirement: false })
     }
   },
 

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -144,7 +144,7 @@ describe(createWrapper, () => {
 
       it('should throw a special error if ctx.abort is called', async () => {
         const { shouldLoadSegment, getError } = createShouldLoadThatThrows({
-          disableConsentRequirement: true,
+          loadSegmentNormally: true,
         })
         wrapTestAnalytics({
           shouldLoadSegment,
@@ -153,10 +153,7 @@ describe(createWrapper, () => {
         expect(getError() instanceof AbortLoadError).toBeTruthy()
       })
 
-      it.each([
-        { disableConsentRequirement: true },
-        { disableConsentRequirement: false },
-      ])(
+      it.each([{ loadSegmentNormally: true }, { loadSegmentNormally: false }])(
         `should not log a console error or throw an error if ctx.abort is called (%p)`,
         async (args) => {
           wrapTestAnalytics({
@@ -174,7 +171,7 @@ describe(createWrapper, () => {
         wrapTestAnalytics({
           shouldLoadSegment: (ctx) => {
             ctx.abort({
-              disableConsentRequirement: true,
+              loadSegmentNormally: true,
             })
           },
         })
@@ -195,7 +192,7 @@ describe(createWrapper, () => {
         wrapTestAnalytics({
           shouldLoadSegment: (ctx) => {
             ctx.abort({
-              disableConsentRequirement: false, // magic config option
+              loadSegmentNormally: false, // magic config option
             })
             throw new Error('Fail')
           },

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -144,7 +144,7 @@ describe(createWrapper, () => {
 
       it('should throw a special error if ctx.abort is called', async () => {
         const { shouldLoadSegment, getError } = createShouldLoadThatThrows({
-          loadSegmentNormally: true,
+          disableConsentRequirement: true,
         })
         wrapTestAnalytics({
           shouldLoadSegment,
@@ -153,7 +153,10 @@ describe(createWrapper, () => {
         expect(getError() instanceof AbortLoadError).toBeTruthy()
       })
 
-      it.each([{ loadSegmentNormally: true }, { loadSegmentNormally: false }])(
+      it.each([
+        { disableConsentRequirement: true },
+        { disableConsentRequirement: false },
+      ])(
         `should not log a console error or throw an error if ctx.abort is called (%p)`,
         async (args) => {
           wrapTestAnalytics({
@@ -169,7 +172,7 @@ describe(createWrapper, () => {
         wrapTestAnalytics({
           shouldLoadSegment: (ctx) => {
             ctx.abort({
-              loadSegmentNormally: true, // magic config option
+              disableConsentRequirement: true, // magic config option
             })
           },
         })
@@ -182,7 +185,7 @@ describe(createWrapper, () => {
         wrapTestAnalytics({
           shouldLoadSegment: (ctx) => {
             ctx.abort({
-              loadSegmentNormally: false, // magic config option
+              disableConsentRequirement: false, // magic config option
             })
             throw new Error('Fail')
           },

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -24,7 +24,6 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
 
   const {
     shouldDisableSegment,
-    shouldDisableConsentRequirement,
     getCategories,
     shouldLoadSegment,
     integrationCategoryMappings,
@@ -60,13 +59,9 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
       let initialCategories: Categories
       try {
         await loadWrapper
-        const ctx = new LoadContext()
-        if (await shouldDisableConsentRequirement?.()) {
-          throw ctx.abort({ disableConsentRequirement: true })
-        }
-
         initialCategories =
-          (await shouldLoadSegment?.(ctx)) || (await getCategories())
+          (await shouldLoadSegment?.(new LoadContext())) ||
+          (await getCategories())
       } catch (e: unknown) {
         // consumer can call ctx.abort({ disableConsentRequirement: true })
         // to load Segment but disable consent requirement

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -62,16 +62,16 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
         await loadWrapper
         const ctx = new LoadContext()
         if (await shouldDisableConsentRequirement?.()) {
-          throw ctx.abort({ loadSegmentNormally: true })
+          throw ctx.abort({ disableConsentRequirement: true })
         }
 
         initialCategories =
           (await shouldLoadSegment?.(ctx)) || (await getCategories())
       } catch (e: unknown) {
-        // consumer can call ctx.abort({ loadSegmentNormally: true })
+        // consumer can call ctx.abort({ disableConsentRequirement: true })
         // to load Segment but disable consent requirement
         if (e instanceof AbortLoadError) {
-          if (e.loadSegmentNormally === true) {
+          if (e.disableConsentRequirement === true) {
             ogLoad.call(analytics, settings, options)
           }
           // do not load anything, but do not log anything either

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -63,10 +63,10 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
           (await shouldLoadSegment?.(new LoadContext())) ||
           (await getCategories())
       } catch (e: unknown) {
-        // consumer can call ctx.abort({ disableConsentRequirement: true })
+        // consumer can call ctx.abort({ loadSegmentNormally: true })
         // to load Segment but disable consent requirement
         if (e instanceof AbortLoadError) {
-          if (e.disableConsentRequirement === true) {
+          if (e.loadSegmentNormally === true) {
             ogLoad.call(analytics, settings, options)
           }
           // do not load anything, but do not log anything either

--- a/packages/consent/consent-tools/src/domain/load-cancellation.ts
+++ b/packages/consent/consent-tools/src/domain/load-cancellation.ts
@@ -5,7 +5,7 @@ import { ValidationError } from './validation/validation-error'
  * Thrown when a load should be cancelled.
  */
 export class AbortLoadError extends AnalyticsConsentError {
-  constructor(public disableConsentRequirement: boolean) {
+  constructor(public loadSegmentNormally: boolean) {
     super('AbortLoadError', '')
   }
 }
@@ -15,7 +15,7 @@ export interface AbortLoadOptions {
    * Whether or not to disable the consent requirement that is normally enforced by the wrapper.
    * If true -- load segment normally.
    */
-  disableConsentRequirement: boolean
+  loadSegmentNormally: boolean
 }
 
 export class LoadContext {
@@ -26,6 +26,6 @@ export class LoadContext {
     if (typeof options !== 'object') {
       throw new ValidationError('arg should be an object', options)
     }
-    throw new AbortLoadError(options.disableConsentRequirement)
+    throw new AbortLoadError(options.loadSegmentNormally)
   }
 }

--- a/packages/consent/consent-tools/src/domain/load-cancellation.ts
+++ b/packages/consent/consent-tools/src/domain/load-cancellation.ts
@@ -5,17 +5,17 @@ import { ValidationError } from './validation/validation-error'
  * Thrown when a load should be cancelled.
  */
 export class AbortLoadError extends AnalyticsConsentError {
-  constructor(public loadSegmentNormally: boolean) {
+  constructor(public disableConsentRequirement: boolean) {
     super('AbortLoadError', '')
   }
 }
 
 export interface AbortLoadOptions {
   /**
-   * Whether or not to load segment.
-   * If true -- load segment normally (and disable consent requirement.) Wrapper is essentially a no-op
+   * Whether or not to disable the consent requirement that is normally enforced by the wrapper.
+   * If true -- load segment normally.
    */
-  loadSegmentNormally: boolean
+  disableConsentRequirement: boolean
 }
 
 export class LoadContext {
@@ -26,6 +26,6 @@ export class LoadContext {
     if (typeof options !== 'object') {
       throw new ValidationError('arg should be an object', options)
     }
-    throw new AbortLoadError(options.loadSegmentNormally)
+    throw new AbortLoadError(options.disableConsentRequirement)
   }
 }

--- a/packages/consent/consent-tools/src/domain/validation/options-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/options-validators.ts
@@ -32,7 +32,8 @@ export function validateSettings(options: {
 
   assertIsFunction(options.getCategories, 'getCategories')
 
-  options.shouldLoad && assertIsFunction(options.shouldLoad, 'shouldLoad')
+  options.shouldLoadSegment &&
+    assertIsFunction(options.shouldLoadSegment, 'shouldLoadSegment')
 
   options.shouldDisableConsentRequirement &&
     assertIsFunction(

--- a/packages/consent/consent-tools/src/domain/validation/options-validators.ts
+++ b/packages/consent/consent-tools/src/domain/validation/options-validators.ts
@@ -35,12 +35,6 @@ export function validateSettings(options: {
   options.shouldLoadSegment &&
     assertIsFunction(options.shouldLoadSegment, 'shouldLoadSegment')
 
-  options.shouldDisableConsentRequirement &&
-    assertIsFunction(
-      options.shouldDisableConsentRequirement,
-      'shouldDisableConsentRequirement'
-    )
-
   options.shouldEnableIntegration &&
     assertIsFunction(options.shouldEnableIntegration, 'shouldEnableIntegration')
 

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -14,11 +14,23 @@ export type RegisterOnConsentChangedFunction = (
  */
 export interface CreateWrapperSettings {
   /**
+   * Wait until this function's Promise resolves before attempting to initialize the wrapper with any settings passed into it.
+   * Typically, this is used to wait for a CMP global object (e.g. window.OneTrust) to be available.
+   * This function is called as early possible in the lifecycle, before `shouldLoadWrapper`, `registerOnConsentChanged` and `getCategories`.
+   * Throwing an error here will prevent the wrapper from loading (just as if `shouldDisableSegment` returned true).
+   * @example
+   * ```ts
+   * () => resolveWhen(() => window.myCMP !== undefined, 500)
+   * ```
+   **/
+  shouldLoadWrapper?: () => Promise<void>
+
+  /**
    * Wait until this function resolves/returns before loading analytics.
    * This function should return a list of initial categories.
    * If this function returns `undefined`, `getCategories()` function will be called to get initial categories.
    **/
-  shouldLoad?: (
+  shouldLoadSegment?: (
     context: LoadContext
   ) => Categories | void | Promise<Categories | void>
 
@@ -61,7 +73,7 @@ export interface CreateWrapperSettings {
 
   /**
    * This permanently disables any consent requirement (i.e device mode gating, event pref stamping).
-   * Called on wrapper initialization. **shouldLoad will never be called**
+   * Called on wrapper initialization. **shouldLoadSegment will never be called**
    **/
   shouldDisableConsentRequirement?: () => boolean | Promise<boolean>
 
@@ -69,7 +81,7 @@ export interface CreateWrapperSettings {
    * Disable the Segment analytics SDK completely. analytics.load() will have no effect.
    * .track / .identify etc calls should not throw any errors, but analytics settings will never be fetched and no events will be sent to Segment.
    * Called on wrapper initialization. This can be useful in dev environments (e.g. 'devMode').
-   * **shouldLoad will never be called**
+   * **shouldLoadSegment will never be called**
    **/
   shouldDisableSegment?: () => boolean | Promise<boolean>
 

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -40,10 +40,10 @@ export interface CreateWrapperSettings {
    *   // Optional
    *   if (noConsentNeeded) {
    *    // load Segment normally
-   *     ctx.abort({ disableConsentRequirement: true })
+   *     ctx.abort({ loadSegmentNormally: true })
    *   } else if (noTrackingNeeded) {
    *    // do not load Segment
-   *     ctx.abort({ disableConsentRequirement: false })
+   *     ctx.abort({ loadSegmentNormally: false })
    *   }
    * },
    * ```

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -49,7 +49,7 @@ export interface CreateWrapperSettings {
    * ```
    **/
   shouldLoadSegment?: (
-    context: LoadContext
+    ctx: LoadContext
   ) => Categories | void | Promise<Categories | void>
 
   /**

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -91,13 +91,6 @@ export interface CreateWrapperSettings {
   registerOnConsentChanged?: RegisterOnConsentChangedFunction
 
   /**
-   * This permanently disables the consent requirement (i.e device mode gating, event pref stamping) enforced by the wrapper.
-   * This is the same as doing "ctx.abort({ disableConsentRequirement: true })" inside of `shouldLoadSegment`.
-   * Called once on wrapper initialization. **shouldLoadSegment will never be called**
-   **/
-  shouldDisableConsentRequirement?: () => boolean | Promise<boolean>
-
-  /**
    * Disable the Segment analytics SDK completely. analytics.load() will have no effect.
    * .track / .identify etc calls should not throw any errors, but analytics settings will never be fetched and no events will be sent to Segment.
    * Called on wrapper initialization. This can be useful in dev environments (e.g. 'devMode').

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -37,7 +37,6 @@ export interface CreateWrapperSettings {
    *     () => !window.CMP.popUpVisible(),
    *     500
    *   )
-   *
    *   // Optional
    *   if (noConsentNeeded) {
    *    // load Segment normally

--- a/packages/consent/consent-tools/src/types/settings.ts
+++ b/packages/consent/consent-tools/src/types/settings.ts
@@ -29,6 +29,25 @@ export interface CreateWrapperSettings {
    * Wait until this function resolves/returns before loading analytics.
    * This function should return a list of initial categories.
    * If this function returns `undefined`, `getCategories()` function will be called to get initial categories.
+   * @example
+   * ```ts
+   *   // Wrapper waits to load segment / get categories until this function returns / resolves
+   * shouldLoadSegment: async (ctx) => {
+   *   await resolveWhen(
+   *     () => !window.CMP.popUpVisible(),
+   *     500
+   *   )
+   *
+   *   // Optional
+   *   if (noConsentNeeded) {
+   *    // load Segment normally
+   *     ctx.abort({ disableConsentRequirement: true })
+   *   } else if (noTrackingNeeded) {
+   *    // do not load Segment
+   *     ctx.abort({ disableConsentRequirement: false })
+   *   }
+   * },
+   * ```
    **/
   shouldLoadSegment?: (
     context: LoadContext
@@ -72,8 +91,9 @@ export interface CreateWrapperSettings {
   registerOnConsentChanged?: RegisterOnConsentChangedFunction
 
   /**
-   * This permanently disables any consent requirement (i.e device mode gating, event pref stamping).
-   * Called on wrapper initialization. **shouldLoadSegment will never be called**
+   * This permanently disables the consent requirement (i.e device mode gating, event pref stamping) enforced by the wrapper.
+   * This is the same as doing "ctx.abort({ disableConsentRequirement: true })" inside of `shouldLoadSegment`.
+   * Called once on wrapper initialization. **shouldLoadSegment will never be called**
    **/
   shouldDisableConsentRequirement?: () => boolean | Promise<boolean>
 

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -39,13 +39,17 @@ export const withOneTrust = <Analytics extends AnyAnalytics>(
     })
   }
   return createWrapper<Analytics>({
-    shouldLoad: async () => {
+    // wait for OneTrust global to be available before wrapper is loaded
+    shouldLoadWrapper: async () => {
+      await resolveWhen(() => getOneTrustGlobal() !== undefined, 500)
+    },
+    // wait for AlertBox to be closed before segment can be loaded. If no consented groups, do not load Segment.
+    shouldLoadSegment: async () => {
       await resolveWhen(() => {
         const oneTrustGlobal = getOneTrustGlobal()
         return (
-          oneTrustGlobal !== undefined &&
           Boolean(getConsentedGroupIds().length) &&
-          oneTrustGlobal.IsAlertBoxClosed()
+          oneTrustGlobal!.IsAlertBoxClosed()
         )
       }, 500)
     },

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -1,5 +1,5 @@
 import { OneTrustGlobal } from '../lib/onetrust-api'
-import { throwNotImplemented } from './utils'
+import { addMockImplementation } from './utils'
 import type { AnyAnalytics } from '@segment/analytics-consent-tools'
 /**
  * This can be used to mock the OneTrust global object in individual tests
@@ -10,14 +10,17 @@ import type { AnyAnalytics } from '@segment/analytics-consent-tools'
  * ````
  */
 export const OneTrustMockGlobal: jest.Mocked<OneTrustGlobal> = {
-  GetDomainData: jest.fn().mockImplementation(throwNotImplemented),
-  IsAlertBoxClosed: jest.fn().mockImplementation(throwNotImplemented),
-  OnConsentChanged: jest.fn().mockImplementation(throwNotImplemented), // not implemented atm
+  GetDomainData: jest.fn(),
+  IsAlertBoxClosed: jest.fn(),
+  OnConsentChanged: jest.fn(),
 }
 
 export const analyticsMock: jest.Mocked<AnyAnalytics> = {
-  addSourceMiddleware: jest.fn().mockImplementation(throwNotImplemented),
-  load: jest.fn().mockImplementation(throwNotImplemented),
-  on: jest.fn().mockImplementation(throwNotImplemented),
-  track: jest.fn().mockImplementation(throwNotImplemented),
+  addSourceMiddleware: jest.fn(),
+  load: jest.fn(),
+  on: jest.fn(),
+  track: jest.fn(),
 }
+
+addMockImplementation(OneTrustMockGlobal)
+addMockImplementation(analyticsMock)

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -1,5 +1,5 @@
 import { OneTrustGlobal } from '../lib/onetrust-api'
-import { addMockImplementation } from './utils'
+import { addDebugMockImplementation } from './utils'
 import type { AnyAnalytics } from '@segment/analytics-consent-tools'
 /**
  * This can be used to mock the OneTrust global object in individual tests
@@ -22,5 +22,5 @@ export const analyticsMock: jest.Mocked<AnyAnalytics> = {
   track: jest.fn(),
 }
 
-addMockImplementation(OneTrustMockGlobal)
-addMockImplementation(analyticsMock)
+addDebugMockImplementation(OneTrustMockGlobal)
+addDebugMockImplementation(analyticsMock)

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
@@ -2,7 +2,7 @@ export const addMockImplementation = (mock: jest.Mocked<any>) => {
   Object.entries(mock).forEach(([method, value]) => {
     // automatically add mock implementation for debugging purposes
     if (typeof value === 'function') {
-      mock[method] = mock[method].mockImplementation((args: any) => {
+      mock[method] = mock[method].mockImplementation((...args: any[]) => {
         throw new Error(`Not Implemented: ${method}(${JSON.stringify(args)})`)
       })
     }

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
@@ -1,4 +1,4 @@
-export const addMockImplementation = (mock: jest.Mocked<any>) => {
+export const addDebugMockImplementation = (mock: jest.Mocked<any>) => {
   Object.entries(mock).forEach(([method, value]) => {
     // automatically add mock implementation for debugging purposes
     if (typeof value === 'function') {

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Allows mocked objects to throw a helpful error message when a method is called without an implementation
+ */
 export const addDebugMockImplementation = (mock: jest.Mocked<any>) => {
   Object.entries(mock).forEach(([method, value]) => {
     // automatically add mock implementation for debugging purposes

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/utils.ts
@@ -1,3 +1,10 @@
-export const throwNotImplemented = (): never => {
-  throw new Error('not implemented')
+export const addMockImplementation = (mock: jest.Mocked<any>) => {
+  Object.entries(mock).forEach(([method, value]) => {
+    // automatically add mock implementation for debugging purposes
+    if (typeof value === 'function') {
+      mock[method] = mock[method].mockImplementation((args: any) => {
+        throw new Error(`Not Implemented: ${method}(${JSON.stringify(args)})`)
+      })
+    }
+  })
 }


### PR DESCRIPTION
See changeset for full list of changes.

Removes disableConsentRequirement setting in favor of using shouldLoad's ctx.abort (the settings API was getting a bit hard to understand with some redundant ways of doing things).


...Mainly this adds shouldLoadWrapper API , which is a bit like a perform block in action destinations. It allows people to wait for their globals to initialize before any other settings that might use those globals have time to create issues.
