### PR TITLE
Update integration metrics capturing

### DIFF
--- a/.changeset/poor-masks-jam.md
+++ b/.changeset/poor-masks-jam.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Update integration metrics capturing strategy

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "29 KB"
+      "limit": "29.1 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/stats/metric-helpers.ts
+++ b/packages/browser/src/core/stats/metric-helpers.ts
@@ -1,0 +1,28 @@
+import { Context } from '../context'
+
+export interface RecordIntegrationMetricProps {
+  integrationName: string
+  methodName: string
+  didError?: boolean
+  type: 'classic' | 'action'
+}
+
+export function recordIntegrationMetric(
+  ctx: Context,
+  {
+    methodName,
+    integrationName,
+    type,
+    didError = false,
+  }: RecordIntegrationMetricProps
+): void {
+  ctx.stats.increment(
+    `analytics_js.integration.invoke${didError ? '.error' : ''}`,
+    1,
+    [
+      `method:${methodName}`,
+      `integration_name:${integrationName}`,
+      `type:${type}`,
+    ]
+  )
+}

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -257,6 +257,7 @@ export class LegacyDestination implements DestinationPlugin {
     ctx.stats.increment('analytics_js.integration.invoke', 1, [
       `method:${eventType}`,
       `integration_name:${this.name}`,
+      `type:classic-destination`,
     ])
 
     try {
@@ -267,6 +268,7 @@ export class LegacyDestination implements DestinationPlugin {
       ctx.stats.increment('analytics_js.integration.invoke.error', 1, [
         `method:${eventType}`,
         `integration_name:${this.name}`,
+        `type:classic-destination`,
       ])
       throw err
     }

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -51,21 +51,29 @@ describe('ActionDestination', () => {
 
     expect(ajs.ctx?.stats.metrics[0]).toMatchObject(
       expect.objectContaining({
-        metric: 'analytics_js.action_plugin.invoke',
-        tags: ['method:load', 'action_plugin_name:testDestination'],
+        metric: 'analytics_js.integration.invoke',
+        tags: [
+          'method:load',
+          'integration_name:testDestination',
+          'type:destination',
+        ],
       })
     )
 
     const trackCtx = await ajs.track('test')
 
     const actionInvokeMetric = trackCtx.stats.metrics.find(
-      (m) => m.metric === 'analytics_js.action_plugin.invoke'
+      (m) => m.metric === 'analytics_js.integration.invoke'
     )
 
     expect(actionInvokeMetric).toMatchObject(
       expect.objectContaining({
-        metric: 'analytics_js.action_plugin.invoke',
-        tags: ['method:track', 'action_plugin_name:testDestination'],
+        metric: 'analytics_js.integration.invoke',
+        tags: [
+          'method:track',
+          'integration_name:testDestination',
+          'type:destination',
+        ],
       })
     )
   })

--- a/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/action-destination.test.ts
@@ -55,7 +55,7 @@ describe('ActionDestination', () => {
         tags: [
           'method:load',
           'integration_name:testDestination',
-          'type:destination',
+          'type:action',
         ],
       })
     )
@@ -72,7 +72,7 @@ describe('ActionDestination', () => {
         tags: [
           'method:track',
           'integration_name:testDestination',
-          'type:destination',
+          'type:action',
         ],
       })
     )

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -128,7 +128,7 @@ export class ActionDestination implements DestinationPlugin {
       [
         `method:${methodName}`,
         `integration_name:${this.action.name}`,
-        `type:${this.action.type}`,
+        `type:action`,
       ]
     )
   }


### PR DESCRIPTION
Previous attempt at capturing action metrics used new metrics key, however that requires certain updates on the production server to work. The schedule of when those updates will go live is uncertain, so we're back to using the existing framework without minor changes.