### PR TITLE
consent: handle cases where show banner is unchecked

### DIFF
--- a/examples/standalone-playground/pages/index-consent-no-banner.html
+++ b/examples/standalone-playground/pages/index-consent-no-banner.html
@@ -1,0 +1,215 @@
+<html>
+
+<head>
+
+
+  <!-- Form: WriteKey -->
+  <form method="get">
+    <input type="text" name="writeKey" placeholder="Writekey" />
+    <button>Load</button>
+  </form>
+  <script>
+    const { searchParams } = new URL(document.location);
+    const writeKey = searchParams.get("writeKey");
+    document.querySelector("input").value = writeKey;
+  </script>
+
+  <!-- Form: Clear OneTrust Cookie -->
+  <button id="clear-ot-cookies">Clear OneTrust Cookies & Reload</button>
+  <script>
+    document.getElementById('clear-ot-cookies').addEventListener('click', () => {
+      ['OptanonConsent', 'OptanonAlertBoxClosed'].forEach((name) => {
+        document.cookie =
+          name + "=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+      });
+      window.location.reload();
+      console.log("OneTrust Cookies cleared.");
+    })
+  </script>
+
+
+  <!-- OneTrust Vendor Script -->
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript"
+    data-domain-script="09b87b90-1b30-4d68-9610-9d2fe11234f3-test"></script>
+  <script type="text/javascript">
+    const wk = document.querySelector("input").value
+    wk && console.log('should be on the following url ->', `${window.location.origin + window.location.pathname}?writeKey=${wk}&otpreview=true&otgeo=za`)
+    function OptanonWrapper() {
+      // debugging.
+      if (!window.OnetrustActiveGroups.replaceAll(',', '')) {
+        window.OnetrustActiveGroups = ',CAT0001' // very hacky, simulates at least one group if none exist
+      }
+      console.log('ShowAlertNotice: should be false (initially) ->', window.OneTrust.GetDomainData().ShowAlertNotice)
+      console.log('OneTrust.testLog() ->', window.OneTrust.testLog())
+    }
+  </script>
+  <!-- OneTrust Wrapper -->
+  <script
+    src="/node_modules/@segment/analytics-consent-wrapper-onetrust/dist/umd/analytics-onetrust.umd.development.js">
+    </script>
+  <!-- Segment Snippet (Modified)-->
+  <script>
+    if (writeKey) {
+      !(function () {
+        var analytics = (window.analytics = window.analytics || [])
+        if (!analytics.initialize)
+          if (analytics.invoked)
+            window.console &&
+              console.error &&
+              console.error('Segment snippet included twice.')
+          else {
+            analytics.invoked = !0
+            analytics.methods = [
+              'screen',
+              'register',
+              'deregister',
+              'trackSubmit',
+              'trackClick',
+              'trackLink',
+              'trackForm',
+              'pageview',
+              'identify',
+              'reset',
+              'group',
+              'track',
+              'ready',
+              'alias',
+              'debug',
+              'page',
+              'once',
+              'off',
+              'on',
+              'addSourceMiddleware',
+              'addIntegrationMiddleware',
+              'setAnonymousId',
+              'addDestinationMiddleware',
+              'emit'
+            ]
+            analytics.factory = function (e) {
+              return function () {
+                if (window.analytics.initialized) {
+                  // Sometimes users assigned analytics to a variable before analytics is done loading, resulting in a stale reference.
+                  // If so, proxy any calls to the 'real' analytics instance.
+                  return window.analytics[e].apply(window.analytics, arguments);
+                }
+                var t = Array.prototype.slice.call(arguments)
+                t.unshift(e)
+                analytics.push(t)
+                return analytics
+              }
+            }
+            for (var e = 0; e < analytics.methods.length; e++) {
+              var key = analytics.methods[e]
+              analytics[key] = analytics.factory(key)
+            }
+            analytics.load = function (key, e) {
+              var t = document.createElement('script')
+              t.type = 'text/javascript'
+              t.async = !0
+              t.src =
+                'https://cdn.segment.com/analytics.js/v1/' +
+                writeKey +
+                '/analytics.min.js'
+              var n = document.getElementsByTagName('script')[0]
+              n.parentNode.insertBefore(t, n)
+              analytics._loadOptions = e
+            }
+            analytics.SNIPPET_VERSION = '4.13.1'
+            analytics._writeKey = writeKey
+            withOneTrust(analytics).load()
+            analytics.page()
+          }
+      })()
+    }
+  </script>
+
+</head>
+
+<body>
+  <form>
+    <textarea name="event" id="event">
+{
+  "name": "hi",
+  "properties": { },
+  "traits": { },
+  "options": { }
+}
+    </textarea>
+    <div>
+      <button id="track">Track</button>
+      <button id="identify">Identify</button>
+    </div>
+  </form>
+  <h2>Consent Changed Event</h2>
+  <pre id="consent-changed"></pre>
+  <h2>Logs</h2>
+  <pre id="logs"></pre>
+
+  <script type="text/javascript">
+    const displayConsentLogs = (str) => document.querySelector('#consent-changed').textContent = str
+    analytics.on('track', (name, properties, options) => {
+      if (name.includes("Segment Consent")) {
+        displayConsentLogs("Consent Changed Event Fired")
+        setTimeout(() => displayConsentLogs(''), 3000)
+      }
+    })
+    const displayRegularLogs = (str) => document.querySelector('#logs').textContent = str
+    const logEvent = (promise) => {
+      if (Array.isArray(promise)) {
+        displayRegularLogs('Analytics is not initialized!')
+        setTimeout(() => displayRegularLogs(''), 5000)
+        return
+      }
+      if (promise) {
+        promise.then((ctx) => {
+          ctx.flush()
+          displayRegularLogs(JSON.stringify(
+            ctx.event,
+            null,
+            2
+          ))
+        })
+      }
+    }
+
+
+    document.querySelector('#track').addEventListener('click', async (e) => {
+      e.preventDefault()
+      const contents = document.querySelector('#event').value
+      const evt = JSON.parse(contents)
+      const promise = window.analytics.track(
+        evt.name ?? '',
+        evt.properties ?? {},
+        evt.options ?? {}
+      )
+      logEvent(promise)
+    })
+
+    document
+      .querySelector('#identify')
+      .addEventListener('click', async (e) => {
+        e.preventDefault()
+        const contents = document.querySelector('#event').value
+        const evt = JSON.parse(contents)
+        const promise = window.analytics.identify(
+          evt.name ?? '',
+          evt.properties ?? {},
+          evt.options ?? {}
+        )
+        logEvent(promise)
+      })
+  </script>
+  <style>
+    body {
+      font-family: monospace;
+    }
+
+    #event {
+      margin: 2em 0;
+      min-height: 200px;
+      min-width: 700px;
+    }
+  </style>
+</body>
+
+</html>

--- a/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/domain/wrapper.ts
@@ -34,9 +34,14 @@ export const withOneTrust = <Analytics extends AnyAnalytics>(
     // wait for AlertBox to be closed before segment can be loaded. If no consented groups, do not load Segment.
     shouldLoadSegment: async () => {
       await resolveWhen(() => {
+        const OneTrust = getOneTrustGlobal()!
         return (
+          // if any groups at all are consented to
           Boolean(getConsentedGroupIds().length) &&
-          getOneTrustGlobal()!.IsAlertBoxClosed()
+          // if show banner is unchecked in the UI
+          (OneTrust.GetDomainData().ShowAlertNotice === false ||
+            // if alert box is closed by end user
+            OneTrust.IsAlertBoxClosed())
         )
       }, 500)
     },

--- a/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/lib/__tests__/onetrust-api.test.ts
@@ -9,7 +9,7 @@ import {
   getOneTrustGlobal,
   getAllGroups,
 } from '../onetrust-api'
-import { OneTrustMockGlobal } from '../../test-helpers/mocks'
+import { domainDataMock, OneTrustMockGlobal } from '../../test-helpers/mocks'
 import { OneTrustApiValidationError } from '../validation'
 
 beforeEach(() => {
@@ -21,13 +21,39 @@ beforeEach(() => {
 
 describe(getOneTrustGlobal, () => {
   it('should get the global', () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementationOnce(() => {})
     ;(window as any).OneTrust = OneTrustMockGlobal
     expect(getOneTrustGlobal()).toEqual(OneTrustMockGlobal)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  it('should throw an error if the global is missing fields', () => {
+  it('should handle null or undefined', () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementationOnce(() => {})
+    ;(window as any).OneTrust = undefined
+    expect(getOneTrustGlobal()).toBeUndefined()
+    ;(window as any).OneTrust = null
+    expect(getOneTrustGlobal()).toBeUndefined()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('should log an error if the global is an unexpected type', () => {
     ;(window as any).OneTrust = {}
-    expect(() => getOneTrustGlobal()).toThrow(OneTrustApiValidationError)
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementationOnce(() => {})
+    expect(getOneTrustGlobal()).toBeUndefined()
+    expect(consoleErrorSpy.mock.lastCall[0]).toMatch(/window.OneTrust/i)
+  })
+
+  it('should not log an error if OneTrust just returns geolocationResponse', () => {
+    ;(window as any).OneTrust = { geolocationResponse: {} as any }
+    const consoleErrorSpy = jest.spyOn(console, 'error')
+    expect(getOneTrustGlobal()).toBeUndefined()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 })
 
@@ -41,6 +67,7 @@ describe(getAllGroups, () => {
     window.OneTrust = {
       ...OneTrustMockGlobal,
       GetDomainData: () => ({
+        ...domainDataMock,
         Groups: [
           {
             CustomGroupId: 'C0001',
@@ -125,6 +152,7 @@ describe(getGroupDataFromGroupIds, () => {
     window.OneTrust = {
       ...OneTrustMockGlobal,
       GetDomainData: () => ({
+        ...domainDataMock,
         Groups: [
           {
             CustomGroupId: 'C0001',
@@ -162,6 +190,7 @@ describe(getNormalizedCategoriesFromGroupIds, () => {
     window.OneTrust = {
       ...OneTrustMockGlobal,
       GetDomainData: () => ({
+        ...domainDataMock,
         Groups: [
           {
             CustomGroupId: 'C0001',

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -1,4 +1,4 @@
-import { OneTrustGlobal } from '../lib/onetrust-api'
+import { OneTrustDomainData, OneTrustGlobal } from '../lib/onetrust-api'
 import { addDebugMockImplementation } from './utils'
 import type { AnyAnalytics } from '@segment/analytics-consent-tools'
 /**
@@ -20,6 +20,23 @@ export const analyticsMock: jest.Mocked<AnyAnalytics> = {
   load: jest.fn(),
   on: jest.fn(),
   track: jest.fn(),
+}
+
+export const domainGroupMock = {
+  StrictlyNeccessary: {
+    CustomGroupId: 'C0001',
+  },
+  Targeting: {
+    CustomGroupId: 'C0004',
+  },
+  Performance: {
+    CustomGroupId: 'C0005',
+  },
+}
+
+export const domainDataMock: jest.Mocked<OneTrustDomainData> = {
+  Groups: [domainGroupMock.StrictlyNeccessary],
+  ShowAlertNotice: true,
 }
 
 addDebugMockImplementation(OneTrustMockGlobal)


### PR DESCRIPTION
#972 

Fix bug: if showAlertNotice is false and Segment has default categories, we want to immediately load Segment with any default categories. 

This PR mantains the status quo when it comes to end user re-consent / updated consent (consent updates made after the initial consent decision, in this case, any decision where the end user toggles the alert box on again.)
- stamped consent categories will update as usual
- analytics will not load any new device mode plugins according to  the updated consent 

^ This will come in later PRs / work