### PR TITLE
Match our docs and ajs classic with retry count

### DIFF
--- a/.changeset/five-masks-bow.md
+++ b/.changeset/five-masks-bow.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Change default retries to 10 to match docs + ajs classic

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -68,7 +68,7 @@ function createDefaultQueue(
   retryQueue = false,
   disablePersistance = false
 ) {
-  const maxAttempts = retryQueue ? 4 : 1
+  const maxAttempts = retryQueue ? 10 : 1
   const priorityQueue = disablePersistance
     ? new PriorityQueue(maxAttempts, [])
     : new PersistedPriorityQueue(maxAttempts, name)


### PR DESCRIPTION
Retry 4 times over 15 seconds -> 10 times over like 1.5minutes

I didn't feel like tweaking the backoff logic to exactly match classic, since this is a big improvement over what came before. 