### PR TITLE
Consent - Do not load segment/send events unneccessarily

### DIFF
--- a/.changeset/calm-dancers-happen.md
+++ b/.changeset/calm-dancers-happen.md
@@ -1,0 +1,9 @@
+---
+'@segment/analytics-consent-tools': minor
+---
+Segment will not load, or, if already loaded, will not send events to segment, if all of the following conditions are met:
+1. No destinations without a consent mapping (consentSettings.hasUnmappedDestinations == false)
+
+    AND
+
+2. User has not consented to any category present in the consentSettings.allCategories array.

--- a/.changeset/tame-cooks-invite.md
+++ b/.changeset/tame-cooks-invite.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+add hasUnmappedDestinations property to types

--- a/examples/standalone-playground/pages/index-consent-no-banner.html
+++ b/examples/standalone-playground/pages/index-consent-no-banner.html
@@ -106,10 +106,7 @@
               var t = document.createElement('script')
               t.type = 'text/javascript'
               t.async = !0
-              t.src =
-                'https://cdn.segment.com/analytics.js/v1/' +
-                writeKey +
-                '/analytics.min.js'
+              t.src = '/node_modules/@segment/analytics-next/dist/umd/standalone.js'
               var n = document.getElementsByTagName('script')[0]
               n.parentNode.insertBefore(t, n)
               analytics._loadOptions = e

--- a/examples/standalone-playground/pages/index-consent.html
+++ b/examples/standalone-playground/pages/index-consent.html
@@ -94,10 +94,7 @@
               var t = document.createElement('script')
               t.type = 'text/javascript'
               t.async = !0
-              t.src =
-                'https://cdn.segment.com/analytics.js/v1/' +
-                writeKey +
-                '/analytics.min.js'
+              t.src = '/node_modules/@segment/analytics-next/dist/umd/standalone.js'
               var n = document.getElementsByTagName('script')[0]
               n.parentNode.insertBefore(t, n)
               analytics._loadOptions = e

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -90,11 +90,16 @@ export interface LegacySettings {
    */
   consentSettings?: {
     /**
-     * All unique consent categories.
+     * All unique consent categories for enabled destinations.
      * There can be categories in this array that are important for consent that are not included in any integration  (e.g. 2 cloud mode categories).
      * @example ["Analytics", "Advertising", "CAT001"]
      */
     allCategories: string[]
+
+    /**
+     * Whether or not there are any unmapped destinations for enabled destinations.
+     */
+    hasUnmappedDestinations: boolean
   }
 }
 

--- a/packages/consent/consent-tools/package.json
+++ b/packages/consent/consent-tools/package.json
@@ -13,7 +13,7 @@
     "!**/test-helpers/**"
   ],
   "scripts": {
-    ".": "yarn run -T turbo run --filter=@segment/analytics-consent-tools",
+    ".": "yarn run -T turbo run --filter=@segment/analytics-consent-tools...",
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -746,7 +746,7 @@ describe(createWrapper, () => {
       ).toBe(false)
     })
 
-    it('should be disabled if a user overrides disable with a true value, regardless of what we calculate', async () => {
+    it('should be disabled if if a user overrides disabled with boolean: true, and pass through a boolean', async () => {
       disableSegmentMock.segmentShouldBeDisabled.mockReturnValue(false)
       wrapTestAnalytics()
       await analytics.load(
@@ -757,9 +757,7 @@ describe(createWrapper, () => {
       )
       expect(
         // @ts-ignore
-        analyticsLoadSpy.mock.lastCall[1].disable!(
-          DEFAULT_LOAD_SETTINGS.cdnSettings
-        )
+        analyticsLoadSpy.mock.lastCall[1].disable
       ).toBe(true)
     })
 
@@ -795,6 +793,24 @@ describe(createWrapper, () => {
           DEFAULT_LOAD_SETTINGS.cdnSettings
         )
       ).toBe(true)
+    })
+
+    it('should enable if user passes the wrong option to "load"', async () => {
+      disableSegmentMock.segmentShouldBeDisabled.mockReturnValue(false)
+      wrapTestAnalytics()
+      await analytics.load(
+        {
+          ...DEFAULT_LOAD_SETTINGS,
+        },
+        // @ts-ignore
+        { disable: 'foo' }
+      )
+      expect(
+        // @ts-ignore
+        analyticsLoadSpy.mock.lastCall[1].disable!(
+          DEFAULT_LOAD_SETTINGS.cdnSettings
+        )
+      ).toBe(false)
     })
   })
 })

--- a/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/create-wrapper.test.ts
@@ -719,7 +719,7 @@ describe(createWrapper, () => {
   describe('Disabling Segment Automatically', () => {
     // if user has no unmapped destinations and only irrelevant categories, we disable segment.
     // for more tests, see disable-segment.test.ts
-    it('should be disabled if segment should be disabled', async () => {
+    it('should always disable if segmentShouldBeDisabled returns true', async () => {
       disableSegmentMock.segmentShouldBeDisabled.mockReturnValue(true)
       wrapTestAnalytics()
       await analytics.load({
@@ -732,7 +732,7 @@ describe(createWrapper, () => {
         )
       ).toBe(true)
     })
-    it('should not be disabled if segment should be enabled', async () => {
+    it('should disable if segmentShouldBeDisabled returns false and disable is not overridden', async () => {
       disableSegmentMock.segmentShouldBeDisabled.mockReturnValue(false)
       wrapTestAnalytics()
       await analytics.load({

--- a/packages/consent/consent-tools/src/domain/__tests__/disable-segment.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/disable-segment.test.ts
@@ -2,7 +2,7 @@ import { CDNSettingsConsent } from '../../types'
 import { segmentShouldBeDisabled } from '../disable-segment'
 
 describe('segmentShouldBeDisabled', () => {
-  it('should be disabled if user has only consented to irrelevant vategories', () => {
+  it('should be disabled if user has only consented to irrelevant categories: multiple', () => {
     const consentCategories = { foo: true, bar: true, baz: false }
     const consentSettings: CDNSettingsConsent = {
       allCategories: ['baz', 'qux'],
@@ -13,7 +13,7 @@ describe('segmentShouldBeDisabled', () => {
     )
   })
 
-  it('should be disabled if user has only consented to irrelevant categories', () => {
+  it('should be disabled if user has only consented to irrelevant categories: single', () => {
     const consentCategories = { foo: true }
     const consentSettings = {
       allCategories: ['bar'],

--- a/packages/consent/consent-tools/src/domain/__tests__/disable-segment.test.ts
+++ b/packages/consent/consent-tools/src/domain/__tests__/disable-segment.test.ts
@@ -1,0 +1,67 @@
+import { CDNSettingsConsent } from '../../types'
+import { segmentShouldBeDisabled } from '../disable-segment'
+
+describe('segmentShouldBeDisabled', () => {
+  it('should be disabled if user has only consented to irrelevant vategories', () => {
+    const consentCategories = { foo: true, bar: true, baz: false }
+    const consentSettings: CDNSettingsConsent = {
+      allCategories: ['baz', 'qux'],
+      hasUnmappedDestinations: false,
+    }
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      true
+    )
+  })
+
+  it('should be disabled if user has only consented to irrelevant categories', () => {
+    const consentCategories = { foo: true }
+    const consentSettings = {
+      allCategories: ['bar'],
+      hasUnmappedDestinations: false,
+    }
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      true
+    )
+  })
+
+  it('should be enabled if there are any relevant categories consented to', () => {
+    const consentCategories = { foo: true, bar: true, baz: true }
+    const consentSettings: CDNSettingsConsent = {
+      allCategories: ['baz'],
+      hasUnmappedDestinations: false,
+    }
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      false
+    )
+  })
+
+  it('should be enabled if consentSettings is undefined', () => {
+    const consentCategories = { foo: true }
+    const consentSettings = undefined
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      false
+    )
+  })
+
+  it('should be enabled if consentSettings has unmapped destinations', () => {
+    const consentCategories = { foo: true }
+    const consentSettings = {
+      allCategories: ['foo'],
+      hasUnmappedDestinations: true,
+    }
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      false
+    )
+  })
+
+  it('should be enabled if user has consented to all relevant categories', () => {
+    const consentCategories = { foo: true }
+    const consentSettings = {
+      allCategories: ['foo'],
+      hasUnmappedDestinations: false,
+    }
+    expect(segmentShouldBeDisabled(consentCategories, consentSettings)).toBe(
+      false
+    )
+  })
+})

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -100,11 +100,7 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
           updateCDNSettings,
           options?.updateCDNSettings || ((id) => id)
         ),
-        disable:
-          options?.disable === true
-            ? true
-            : (cdnSettings) =>
-                isDisabled(cdnSettings, initialCategories, options?.disable),
+        disable: createDisableOption(initialCategories, options?.disable),
       })
     }
     analyticsService.replaceLoadMethod(loadWithConsent)
@@ -187,13 +183,17 @@ const disableIntegrations = (
   return results
 }
 
-const isDisabled = (
-  cdnSettings: CDNSettings,
+const createDisableOption = (
   initialCategories: Categories,
   disable: InitOptions['disable']
-): boolean => {
-  return (
-    segmentShouldBeDisabled(initialCategories, cdnSettings.consentSettings) ||
-    (typeof disable === 'function' ? disable(cdnSettings) : disable === true)
-  )
+): NonNullable<InitOptions['disable']> => {
+  if (disable === true) {
+    return true
+  }
+  return (cdnSettings: CDNSettings) => {
+    return (
+      segmentShouldBeDisabled(initialCategories, cdnSettings.consentSettings) ||
+      (typeof disable === 'function' ? disable(cdnSettings) : false)
+    )
+  }
 }

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -100,8 +100,11 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
           updateCDNSettings,
           options?.updateCDNSettings || ((id) => id)
         ),
-        disable: (cdnSettings) =>
-          isDisabled(cdnSettings, initialCategories, options?.disable),
+        disable:
+          options?.disable === true
+            ? true
+            : (cdnSettings) =>
+                isDisabled(cdnSettings, initialCategories, options?.disable),
       })
     }
     analyticsService.replaceLoadMethod(loadWithConsent)
@@ -187,16 +190,10 @@ const disableIntegrations = (
 const isDisabled = (
   cdnSettings: CDNSettings,
   initialCategories: Categories,
-  disableOpt: InitOptions['disable'] | undefined
+  disable: InitOptions['disable']
 ): boolean => {
-  const shouldBeDisabled = segmentShouldBeDisabled(
-    initialCategories,
-    cdnSettings.consentSettings
-  )
   return (
-    shouldBeDisabled ||
-    (typeof disableOpt === 'function'
-      ? disableOpt(cdnSettings)
-      : disableOpt === true)
+    segmentShouldBeDisabled(initialCategories, cdnSettings.consentSettings) ||
+    (typeof disable === 'function' ? disable(cdnSettings) : disable === true)
   )
 }

--- a/packages/consent/consent-tools/src/domain/disable-segment.ts
+++ b/packages/consent/consent-tools/src/domain/disable-segment.ts
@@ -1,0 +1,18 @@
+import { Categories, CDNSettingsConsent } from '../types'
+
+/**
+ * @returns whether or not analytics.js should be completely disabled (never load, or drop cookies)
+ */
+export const segmentShouldBeDisabled = (
+  consentCategories: Categories,
+  consentSettings: CDNSettingsConsent | undefined
+): boolean => {
+  if (!consentSettings || consentSettings.hasUnmappedDestinations) {
+    return false
+  }
+
+  // disable if _all_ of the the consented categories are _not_ in allCategories
+  return Object.keys(consentCategories)
+    .filter((c) => consentCategories[c])
+    .every((c) => !consentSettings.allCategories.includes(c))
+}

--- a/packages/consent/consent-tools/src/domain/disable-segment.ts
+++ b/packages/consent/consent-tools/src/domain/disable-segment.ts
@@ -11,7 +11,7 @@ export const segmentShouldBeDisabled = (
     return false
   }
 
-  // disable if _all_ of the the consented categories are _not_ in allCategories
+  // disable if _all_ of the the consented categories are irrelevant to segment
   return Object.keys(consentCategories)
     .filter((c) => consentCategories[c])
     .every((c) => !consentSettings.allCategories.includes(c))

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -12,6 +12,7 @@ export interface AnalyticsBrowserSettings {
  */
 export interface InitOptions {
   updateCDNSettings?(cdnSettings: CDNSettings): CDNSettings
+  disable?: boolean | ((cdnSettings: CDNSettings) => boolean)
 }
 
 /**
@@ -67,13 +68,17 @@ export interface IntegrationCategoryMappings {
   [integrationName: string]: string[]
 }
 
+export interface CDNSettingsConsent {
+  // all unique categories keys
+  allCategories: string[]
+  // where user has unmapped enabled destinations
+  hasUnmappedDestinations: boolean
+}
+
 export interface CDNSettings {
   integrations: CDNSettingsIntegrations
   remotePlugins?: CDNSettingsRemotePlugin[]
-  consentSettings?: {
-    // all unique categories keys
-    allCategories: string[]
-  }
+  consentSettings?: CDNSettingsConsent
 }
 
 /**


### PR DESCRIPTION
See changeset.

This will **not** cause any problems for  recent older versions of analytics that don't have "disabled" -- they just won't get this feature.