### PR TITLE
Fix release tag parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.5",
     "@changesets/cli": "^2.23.2",
-    "@npmcli/promise-spawn": "^3.0.0",
+    "@npmcli/promise-spawn": "^7.0.0",
     "@types/express": "4",
     "@types/jest": "^28.1.1",
     "@types/lodash": "^4",

--- a/scripts/create-release-from-tags/__tests__/index.test.ts
+++ b/scripts/create-release-from-tags/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { parseReleaseNotes } from '..'
+import { parseReleaseNotes, parseRawTags } from '..'
 import fs from 'fs'
 import path from 'path'
 
@@ -35,6 +35,132 @@ describe('parseReleaseNotes', () => {
           ### Patch Changes
 
           * [#404](https://github.com/segmentio/analytics-next/pull/404) [\\\\\`b9abc6\\\\\`](https://github.com/segmentio/analytics-next/commit/b9c6356b7d35ee8acb6ecbd1eebc468d18d63958) Thanks [@silesky] - bar!)"
+    `)
+  })
+})
+
+describe('parseRawTags', () => {
+  test('should work if all are on a single line', () => {
+    const rawTags =
+      '@segment/analytics-next@2.1.1 @segment/analytics-foo@1.0.1 @segment/analytics-core@1.0.0'
+    const tags = parseRawTags(rawTags)
+    expect(tags).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "name": "@segment/analytics-next",
+          "raw": "@segment/analytics-next@2.1.1",
+          "versionNumber": "2.1.1",
+        },
+        Object {
+          "name": "@segment/analytics-foo",
+          "raw": "@segment/analytics-foo@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-core",
+          "raw": "@segment/analytics-core@1.0.0",
+          "versionNumber": "1.0.0",
+        },
+      ]
+    `)
+  })
+  test('should work if there are multiple columns', () => {
+    const rawTags = `
+    @segment/analytics-next@2.1.1  @segment/analytics-foo@1.0.1
+    @segment/analytics-core@1.0.0  @segment/analytics-bar@1.0.1
+    `
+    const tags = parseRawTags(rawTags)
+    expect(tags).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "name": "@segment/analytics-next",
+          "raw": "@segment/analytics-next@2.1.1",
+          "versionNumber": "2.1.1",
+        },
+        Object {
+          "name": "@segment/analytics-foo",
+          "raw": "@segment/analytics-foo@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-core",
+          "raw": "@segment/analytics-core@1.0.0",
+          "versionNumber": "1.0.0",
+        },
+        Object {
+          "name": "@segment/analytics-bar",
+          "raw": "@segment/analytics-bar@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+      ]
+    `)
+  })
+  test('should work if there are many many columns', () => {
+    const rawTags = `
+    @segment/analytics-next@2.1.1  @segment/analytics-foo@1.0.1 @segment/analytics-bar@1.0.1
+    @segment/analytics-next@2.1.1  @segment/analytics-baz@1.0.1 @segment/analytics-foobar@1.0.1
+    @segment/analytics-core@1.0.0
+    `
+    const tags = parseRawTags(rawTags)
+    expect(tags).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "name": "@segment/analytics-next",
+          "raw": "@segment/analytics-next@2.1.1",
+          "versionNumber": "2.1.1",
+        },
+        Object {
+          "name": "@segment/analytics-foo",
+          "raw": "@segment/analytics-foo@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-bar",
+          "raw": "@segment/analytics-bar@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-next",
+          "raw": "@segment/analytics-next@2.1.1",
+          "versionNumber": "2.1.1",
+        },
+        Object {
+          "name": "@segment/analytics-baz",
+          "raw": "@segment/analytics-baz@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-foobar",
+          "raw": "@segment/analytics-foobar@1.0.1",
+          "versionNumber": "1.0.1",
+        },
+        Object {
+          "name": "@segment/analytics-core",
+          "raw": "@segment/analytics-core@1.0.0",
+          "versionNumber": "1.0.0",
+        },
+      ]
+    `)
+  })
+  test('should work if there is newline characters', () => {
+    const rawTags = `
+    @segment/analytics-next@2.1.1
+    @segment/analytics-core@1.0.0
+    `
+    const tags = parseRawTags(rawTags)
+    expect(tags).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "name": "@segment/analytics-next",
+          "raw": "@segment/analytics-next@2.1.1",
+          "versionNumber": "2.1.1",
+        },
+        Object {
+          "name": "@segment/analytics-core",
+          "raw": "@segment/analytics-core@1.0.0",
+          "versionNumber": "1.0.0",
+        },
+      ]
     `)
   })
 })

--- a/scripts/create-release-from-tags/index.ts
+++ b/scripts/create-release-from-tags/index.ts
@@ -25,7 +25,6 @@ export const getCurrentGitTags = async (): Promise<Tag[]> => {
     'tag',
     '--points-at',
     'HEAD',
-    '--column',
   ])
   if (code !== 0) {
     throw new Error(stderr.toString())
@@ -34,10 +33,8 @@ export const getCurrentGitTags = async (): Promise<Tag[]> => {
   return parseRawTags(stdout.toString())
 }
 
-export const getConfig = async ({
-  DRY_RUN,
-  TAGS,
-}: NodeJS.ProcessEnv): Promise<Config> => {
+export const getConfig = async (): Promise<Config> => {
+  const { DRY_RUN, TAGS } = process.env
   const isDryRun = Boolean(DRY_RUN)
   const tags = TAGS ? parseRawTags(TAGS) : await getCurrentGitTags()
 
@@ -116,7 +113,12 @@ const extractPartsFromTag = (rawTag: string): Tag | undefined => {
  * @param rawTags - string delimited list of tags (e.g. `@segment/analytics-next@2.1.1 @segment/analytics-core@1.0.0`)
  */
 export const parseRawTags = (rawTags: string): Tag[] => {
-  return rawTags.trim().split(' ').map(extractPartsFromTag).filter(exists)
+  return rawTags
+    .trim()
+    .replace(new RegExp('\\n', 'g'), ' ') // remove any newLine characters
+    .split(' ')
+    .map(extractPartsFromTag)
+    .filter(exists)
 }
 
 /**
@@ -187,6 +189,7 @@ export const createReleaseFromTags = async (config: Config) => {
   console.log('Processing tags:', config.tags, '\n')
 
   for (const tag of config.tags) {
+    console.log(`\n ---> Creating release for tag: ${tag.raw}`)
     await createGithubReleaseFromTag(tag, { dryRun: config.isDryRun })
   }
 }

--- a/scripts/create-release-from-tags/run.ts
+++ b/scripts/create-release-from-tags/run.ts
@@ -1,7 +1,7 @@
 import { createReleaseFromTags, getConfig } from '.'
 
 async function run() {
-  const config = await getConfig(process.env)
+  const config = await getConfig()
   return createReleaseFromTags(config)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,12 +3587,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/promise-spawn@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@npmcli/promise-spawn@npm:3.0.0"
+"@npmcli/promise-spawn@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@npmcli/promise-spawn@npm:7.0.0"
   dependencies:
-    infer-owner: ^1.0.4
-  checksum: 3454465a2731cea5875ba51f80873e2205e5bd878c31517286b0ede4ea931c7bf3de895382287e906d03710fff6f9e44186bd0eee068ce578901c5d3b58e7692
+    which: ^4.0.0
+  checksum: 22a8c4fd4ef2729cf75d13b0b294e8c695e08bdb2143e951288056656091fc5281e8baf330c97a6bc803e6fc09489028bf80dcd787972597ef9fda9a9349fc0f
   languageName: node
   linkType: hard
 
@@ -7151,7 +7151,7 @@ __metadata:
   dependencies:
     "@changesets/changelog-github": ^0.4.5
     "@changesets/cli": ^2.23.2
-    "@npmcli/promise-spawn": ^3.0.0
+    "@npmcli/promise-spawn": ^7.0.0
     "@types/express": 4
     "@types/jest": ^28.1.1
     "@types/lodash": ^4


### PR DESCRIPTION
Publish worked, but github release failed due to error that was obscured because promise-spawn was out of date. Basically, "--column breaks tags into newlines if they exceed a width (duh)", but we had never published that many tags simultaneously before.