### PR TITLE
Change segmentio to 'Destination' type

### DIFF
--- a/.changeset/lucky-chicken-wink.md
+++ b/.changeset/lucky-chicken-wink.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-next': minor
+'@segment/analytics-node': minor
+---
+
+Change segmentio to destination type

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -615,8 +615,8 @@ describe('Dispatch', () => {
         "plugin_time",
         "plugin_time",
         "plugin_time",
-        "message_delivered",
         "plugin_time",
+        "message_delivered",
         "delivered",
       ]
     `)

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -125,7 +125,7 @@ export function segmentio(
 
   const segmentio: Plugin = {
     name: 'Segment.io',
-    type: 'after',
+    type: 'destination',
     version: '0.1.0',
     isLoaded: (): boolean => true,
     load: (): Promise<void> => Promise.resolve(),

--- a/packages/node/src/plugins/segmentio/index.ts
+++ b/packages/node/src/plugins/segmentio/index.ts
@@ -41,7 +41,7 @@ export function createNodePlugin(publisher: Publisher): SegmentNodePlugin {
 
   return {
     name: 'Segment.io',
-    type: 'after',
+    type: 'destination',
     version: '1.0.0',
     isLoaded: () => true,
     load: () => Promise.resolve(),


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

This PR changes the segment.io plugin to 'Destination' type, to prevent any issues with other plugins impacting event delivery to Segment

Tested via confirming sending events works as expected

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
