### PR TITLE
Capture page context as early as possible if `initialPageview` = true

### DIFF
--- a/.changeset/orange-mirrors-sleep.md
+++ b/.changeset/orange-mirrors-sleep.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+If initialPageview is true, capture page context as early as possible

--- a/.changeset/plenty-socks-shave.md
+++ b/.changeset/plenty-socks-shave.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-consent-tools': minor
+'@segment/analytics-consent-wrapper-onetrust': minor
+---
+
+If initialPageview is true, call analytics.page() as early as possible to avoid stale page context.

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -300,21 +300,17 @@ describe('Initialization', () => {
       })
     })
     it('calls page if initialpageview is set', async () => {
-      jest.mock('../../core/analytics')
-      const mockPage = jest.fn().mockImplementation(() => Promise.resolve())
-      Analytics.prototype.page = mockPage
-
+      const page = jest.spyOn(Analytics.prototype, 'page')
       await AnalyticsBrowser.load({ writeKey }, { initialPageview: true })
-
-      expect(mockPage).toHaveBeenCalled()
+      await sleep(0) // flushed in new task
+      expect(page).toHaveBeenCalledTimes(1)
     })
 
     it('does not call page if initialpageview is not set', async () => {
-      jest.mock('../../core/analytics')
-      const mockPage = jest.fn()
-      Analytics.prototype.page = mockPage
+      const page = jest.spyOn(Analytics.prototype, 'page')
       await AnalyticsBrowser.load({ writeKey }, { initialPageview: false })
-      expect(mockPage).not.toHaveBeenCalled()
+      await sleep(0) // flush happens async
+      expect(page).not.toHaveBeenCalled()
     })
 
     it('does not use a persisted queue when disableClientPersistence is true', async () => {

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -30,6 +30,7 @@ import {
   flushAddSourceMiddleware,
   flushSetAnonymousID,
   flushOn,
+  PreInitMethodCall,
 } from '../core/buffer'
 import { ClassicIntegrationSource } from '../plugins/ajs-destination/types'
 import { attachInspector } from '../core/inspector'
@@ -320,6 +321,11 @@ async function loadAnalytics(
   // this is an ugly side-effect, but it's for the benefits of the plugins that get their cdn via getCDN()
   if (settings.cdnURL) setGlobalCDNUrl(settings.cdnURL)
 
+  if (options.initialPageview) {
+    // capture the page context early, so it's always up-to-date
+    preInitBuffer.push(new PreInitMethodCall('page', []))
+  }
+
   let legacySettings =
     settings.cdnSettings ??
     (await loadLegacySettings(settings.writeKey, settings.cdnURL))
@@ -373,10 +379,6 @@ async function loadAnalytics(
 
   analytics.initialized = true
   analytics.emit('initialize', settings, options)
-
-  if (options.initialPageview) {
-    analytics.page().catch(console.error)
-  }
 
   await flushFinalBuffer(analytics, preInitBuffer)
 

--- a/packages/consent/consent-tools/src/domain/analytics/analytics-service.ts
+++ b/packages/consent/consent-tools/src/domain/analytics/analytics-service.ts
@@ -41,6 +41,10 @@ export class AnalyticsService {
     this.analytics.load = loadFn
   }
 
+  page(): void {
+    this.analytics.page()
+  }
+
   configureConsentStampingMiddleware({
     getCategories,
     pruneUnmappedCategories,

--- a/packages/consent/consent-tools/src/domain/create-wrapper.ts
+++ b/packages/consent/consent-tools/src/domain/create-wrapper.ts
@@ -43,6 +43,14 @@ export const createWrapper = <Analytics extends AnyAnalytics>(
       settings,
       options
     ): Promise<void> => {
+      // Prevent stale page context by handling initialPageview ourself.
+      // By calling page() here early, the current page context (url, etc) gets stored in the pre-init buffer.
+      // We then set initialPageView to false when we call the underlying analytics library, so page() doesn't get called twice.
+      if (options?.initialPageview) {
+        analyticsService.page()
+        options = { ...options, initialPageview: false }
+      }
+
       // do not load anything -- segment included
       if (await shouldDisableSegment?.()) {
         return

--- a/packages/consent/consent-tools/src/test-helpers/mocks/analytics-mock.ts
+++ b/packages/consent/consent-tools/src/test-helpers/mocks/analytics-mock.ts
@@ -2,6 +2,7 @@ import { AnyAnalytics } from '../../types'
 
 export const analyticsMock: jest.Mocked<AnyAnalytics> = {
   addSourceMiddleware: jest.fn(),
+  page: jest.fn(),
   load: jest.fn(),
   on: jest.fn(),
   track: jest.fn(),

--- a/packages/consent/consent-tools/src/types/wrapper.ts
+++ b/packages/consent/consent-tools/src/types/wrapper.ts
@@ -13,6 +13,7 @@ export interface AnalyticsBrowserSettings {
 export interface InitOptions {
   updateCDNSettings?(cdnSettings: CDNSettings): CDNSettings
   disable?: boolean | ((cdnSettings: CDNSettings) => boolean)
+  initialPageview?: boolean
 }
 
 /**
@@ -32,6 +33,7 @@ export interface AnyAnalytics {
   addSourceMiddleware(...args: any[]): any
   on(event: 'initialize', callback: (cdnSettings: CDNSettings) => void): void
   track(event: string, properties?: unknown, ...args: any[]): void
+  page(): void
 
   /**
    * This interface is meant to be compatible with both the snippet (`analytics.load`)

--- a/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
+++ b/packages/consent/consent-wrapper-onetrust/src/test-helpers/mocks.ts
@@ -16,6 +16,7 @@ export const OneTrustMockGlobal: jest.Mocked<OneTrustGlobal> = {
 }
 
 export const analyticsMock: jest.Mocked<AnyAnalytics> = {
+  page: jest.fn(),
   addSourceMiddleware: jest.fn(),
   load: jest.fn(),
   on: jest.fn(),


### PR DESCRIPTION
- Analytics: if initialPageView is true, we want to capture page context before destinations are registered.
- Consent: If initialPageView is true, we want to capture page context before .load() is called (taking advantage of the fact that page context is buffered when you do analytics.page())