### PR TITLE
Node: deprecate `maxEventsInBatch` in favor of `flushAt`

### DIFF
--- a/.changeset/fifty-trains-act.md
+++ b/.changeset/fifty-trains-act.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-node': major
+---
+
+Deprecate `maxEventsInBatch` in favor of our commonly used: `flushAt`. The purpose is to establish consistency between our SDKs, regardless of language.

--- a/.changeset/fifty-trains-act.md
+++ b/.changeset/fifty-trains-act.md
@@ -1,5 +1,5 @@
 ---
-'@segment/analytics-node': major
+'@segment/analytics-node': minor
 ---
 
 Deprecate `maxEventsInBatch` in favor of our commonly used: `flushAt`. The purpose is to establish consistency between our SDKs, regardless of language.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -150,7 +150,7 @@ export default defineComponent({
 
 1. Run analytics.js in a web worker via [partytown.io](https://partytown.builder.io/). See [our partytown example](../../playgrounds/next-playground/pages/partytown). **Supports both cloud and device mode destinations, but not all device mode destinations may work.**
 
-2. Try [@segment/analytics-node](../node) with `maxEventsInBatch: 1`, which should work in any runtime where `fetch` is available. **Warning: cloud destinations only!**
+2. Try [@segment/analytics-node](../node) with `flushAt: 1`, which should work in any runtime where `fetch` is available. **Warning: cloud destinations only!**
 
 
 

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    ".": "yarn run -T turbo run --filter=@segment/analytics-node...",
     "tsc": "yarn run -T tsc",
     "eslint": "yarn run -T eslint",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",

--- a/packages/node-integration-tests/src/cloudflare-tests/index.test.ts
+++ b/packages/node-integration-tests/src/cloudflare-tests/index.test.ts
@@ -257,7 +257,7 @@ describe('Analytics in Cloudflare workers', () => {
       }
     )
     const response = await worker.fetch(
-      'http://localhost?maxEventsInBatch=2&eventCount=6'
+      'http://localhost?flushAt=2&eventCount=6'
     )
     await response.text()
     await worker.stop()

--- a/packages/node-integration-tests/src/cloudflare-tests/workers/send-multiple-events.ts
+++ b/packages/node-integration-tests/src/cloudflare-tests/workers/send-multiple-events.ts
@@ -4,15 +4,12 @@ import { Analytics } from '@segment/analytics-node'
 export default {
   async fetch(request: Request, _env: {}, _ctx: ExecutionContext) {
     const url = new URL(request.url)
-    const maxEventsInBatch = parseInt(
-      url.searchParams.get('maxEventsInBatch') ?? '15',
-      10
-    )
+    const flushAt = parseInt(url.searchParams.get('flushAt') ?? '15', 10)
     const eventCount = parseInt(url.searchParams.get('eventCount') ?? '1', 10)
     const analytics = new Analytics({
       writeKey: '__TEST__',
       host: 'http://localhost:3000',
-      maxEventsInBatch,
+      flushAt,
     })
 
     for (let i = 0; i < eventCount; i++) {

--- a/packages/node-integration-tests/src/durability-tests/server-start-analytics.ts
+++ b/packages/node-integration-tests/src/durability-tests/server-start-analytics.ts
@@ -5,7 +5,7 @@ import { trackEventSmall } from '../server/fixtures'
 const analytics = new Analytics({
   writeKey: 'foo',
   flushInterval: 1000,
-  maxEventsInBatch: 15,
+  flushAt: 15,
 })
 
 startServer({ onClose: analytics.closeAndFlush })

--- a/packages/node-integration-tests/src/perf-tests/server-start-analytics.ts
+++ b/packages/node-integration-tests/src/perf-tests/server-start-analytics.ts
@@ -5,7 +5,7 @@ import { trackEventSmall } from '../server/fixtures'
 const analytics = new Analytics({
   writeKey: 'foo',
   flushInterval: 1000,
-  maxEventsInBatch: 15,
+  flushAt: 15,
 })
 
 startServer({ onClose: analytics.closeAndFlush })

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -78,7 +78,7 @@ const { Analytics } = require('@segment/analytics-node');
 // since analytics has the potential to be stateful if there are any plugins added,
 // to be on the safe side, we should instantiate a new instance of analytics on every request (the cost of instantiation is low).
 const analytics = () => new Analytics({
-      maxEventsInBatch: 1,
+      flushAt: 1,
       writeKey: '<MY_WRITE_KEY>',
     })
     .on('error', console.error);
@@ -105,7 +105,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export const analytics = new Analytics({
   writeKey: '<MY_WRITE_KEY>',
-  maxEventsInBatch: 1,
+  flushAt: 1,
 })
   .on('error', console.error)
 
@@ -132,7 +132,7 @@ export default {
     ctx: ExecutionContext
   ): Promise<Response> {
     const analytics = new Analytics({
-      maxEventsInBatch: 1,
+      flushAt: 1,
       writeKey: '<MY_WRITE_KEY>',
     }).on('error', console.error);
 

--- a/packages/node/src/__tests__/callback.test.ts
+++ b/packages/node/src/__tests__/callback.test.ts
@@ -4,7 +4,7 @@ import { Context } from '../app/context'
 describe('Callback behavior', () => {
   it('should handle success', async () => {
     const ajs = createTestAnalytics({
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
     const ctx = await new Promise<Context>((resolve, reject) =>
       ajs.track(
@@ -25,7 +25,7 @@ describe('Callback behavior', () => {
   it('should handle errors', async () => {
     const ajs = createTestAnalytics(
       {
-        maxEventsInBatch: 1,
+        flushAt: 1,
       },
       { withError: true }
     )

--- a/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
+++ b/packages/node/src/__tests__/graceful-shutdown-integration.test.ts
@@ -22,7 +22,7 @@ describe('Ability for users to exit without losing events', () => {
   beforeEach(async () => {
     ajs = new Analytics({
       writeKey: 'abc123',
-      maxEventsInBatch: 1,
+      flushAt: 1,
       httpClient: testClient,
     })
   })
@@ -190,7 +190,7 @@ describe('Ability for users to exit without losing events', () => {
       const analytics = new Analytics({
         writeKey: 'foo',
         flushInterval: 10000,
-        maxEventsInBatch: 15,
+        flushAt: 15,
         httpClient: testClient,
       })
       _helpers.makeTrackCall(analytics)
@@ -221,7 +221,7 @@ describe('Ability for users to exit without losing events', () => {
       const analytics = new Analytics({
         writeKey: 'foo',
         flushInterval: 10000,
-        maxEventsInBatch: 15,
+        flushAt: 15,
         httpClient: testClient,
       })
       await analytics.register(_testPlugin)

--- a/packages/node/src/__tests__/http-integration.test.ts
+++ b/packages/node/src/__tests__/http-integration.test.ts
@@ -346,7 +346,7 @@ describe('Client: requestTimeout', () => {
     jest.useRealTimers()
     const ajs = createTestAnalytics(
       {
-        maxEventsInBatch: 1,
+        flushAt: 1,
         httpRequestTimeout: 0,
       },
       { useRealHTTPClient: true }

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -48,7 +48,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
         host: settings.host,
         path: settings.path,
         maxRetries: settings.maxRetries ?? 3,
-        maxEventsInBatch: settings.maxEventsInBatch ?? 15,
+        flushAt: settings.flushAt ?? settings.maxEventsInBatch ?? 15,
         httpRequestTimeout: settings.httpRequestTimeout,
         disable: settings.disable,
         flushInterval,

--- a/packages/node/src/app/settings.ts
+++ b/packages/node/src/app/settings.ts
@@ -19,7 +19,12 @@ export interface AnalyticsSettings {
    */
   maxRetries?: number
   /**
-   * The number of messages to enqueue before flushing. Default: 15
+   * The number of events to enqueue before flushing. Default: 15.
+   */
+  flushAt?: number
+  /**
+   * @deprecated
+   * The number of events to enqueue before flushing. This is deprecated in favor of `flushAt`. Default: 15.
    */
   maxEventsInBatch?: number
   /**

--- a/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/methods.test.ts
@@ -19,7 +19,7 @@ const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   createConfiguredNodePlugin(
     {
       maxRetries: 3,
-      maxEventsInBatch: 1,
+      flushAt: 1,
       flushInterval: 1000,
       writeKey: '',
       httpClient: testClient,

--- a/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/publisher.test.ts
@@ -20,7 +20,7 @@ const getLastRequest = () => makeReqSpy.mock.lastCall![0]
 const createTestNodePlugin = (props: Partial<PublisherProps> = {}) =>
   createConfiguredNodePlugin(
     {
-      maxEventsInBatch: 1,
+      flushAt: 1,
       httpClient: testClient,
       writeKey: '',
       flushInterval: 1000,
@@ -45,7 +45,7 @@ beforeEach(() => {
 it('supports multiple events in a batch', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
-    maxEventsInBatch: 3,
+    flushAt: 3,
   })
 
   // Create 3 events of mixed types to send.
@@ -71,7 +71,7 @@ it('supports multiple events in a batch', async () => {
 it('supports waiting a max amount of time before sending', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
-    maxEventsInBatch: 3,
+    flushAt: 3,
   })
 
   const context = new Context(eventFactory.alias('to', 'from'))
@@ -97,7 +97,7 @@ it('supports waiting a max amount of time before sending', async () => {
 it('sends as soon as batch fills up or max time is reached', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
-    maxEventsInBatch: 2,
+    flushAt: 2,
   })
 
   const context = new Context(eventFactory.alias('to', 'from'))
@@ -131,7 +131,7 @@ it('sends as soon as batch fills up or max time is reached', async () => {
 it('sends if batch will exceed max size in bytes when adding event', async () => {
   const { plugin: segmentPlugin } = createTestNodePlugin({
     maxRetries: 3,
-    maxEventsInBatch: 20,
+    flushAt: 20,
     flushInterval: 100,
   })
 
@@ -185,7 +185,7 @@ describe('flushAfterClose', () => {
       )
 
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxEventsInBatch: 20,
+      flushAt: 20,
     })
 
     publisher.flushAfterClose(3)
@@ -199,7 +199,7 @@ describe('flushAfterClose', () => {
 
   it('continues to flush on each event if batch size is 1', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     publisher.flushAfterClose(3)
@@ -212,7 +212,7 @@ describe('flushAfterClose', () => {
 
   it('sends immediately once there are no pending items, even if pending events exceeds batch size', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxEventsInBatch: 3,
+      flushAt: 3,
     })
 
     publisher.flushAfterClose(5)
@@ -224,7 +224,7 @@ describe('flushAfterClose', () => {
 
   it('works if there are previous items in the batch', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxEventsInBatch: 7,
+      flushAt: 7,
     })
 
     range(3).forEach(() => segmentPlugin.track(_createTrackCtx())) // should not flush
@@ -237,7 +237,7 @@ describe('flushAfterClose', () => {
 
   it('works if there are previous items in the batch AND pending items > batch size', async () => {
     const { plugin: segmentPlugin, publisher } = createTestNodePlugin({
-      maxEventsInBatch: 7,
+      flushAt: 7,
     })
 
     range(3).forEach(() => segmentPlugin.track(_createTrackCtx())) // should not flush
@@ -256,7 +256,7 @@ describe('flushAfterClose', () => {
 describe('error handling', () => {
   it('excludes events that are too large', async () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     const context = new Context(
@@ -289,7 +289,7 @@ describe('error handling', () => {
     )
 
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     const context = new Context(eventFactory.alias('to', 'from'))
@@ -320,7 +320,7 @@ describe('error handling', () => {
 
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 2,
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     const context = new Context(eventFactory.alias('to', 'from'))
@@ -347,7 +347,7 @@ describe('error handling', () => {
 
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 2,
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     const context = new Context(eventFactory.alias('my', 'from'))
@@ -374,7 +374,7 @@ describe('error handling', () => {
     makeReqSpy.mockRejectedValue(new Error('Connection Error'))
     const { plugin: segmentPlugin } = createTestNodePlugin({
       maxRetries: 0,
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     const fn = jest.fn()
@@ -396,7 +396,7 @@ describe('error handling', () => {
 describe('http_request emitter event', () => {
   it('should emit an http_request object', async () => {
     const { plugin: segmentPlugin } = createTestNodePlugin({
-      maxEventsInBatch: 1,
+      flushAt: 1,
     })
 
     makeReqSpy.mockReturnValueOnce(createSuccess())


### PR DESCRIPTION
Deprecate `maxEventsInBatch` in favor of `flushAt`. The purpose is to establish consistency between our SDKs, regardless of language.

(Basically, let's go back to the original naming of maxEventsInBatch)

Docs Change: https://github.com/segmentio/segment-docs/pull/5808