### PR TITLE
Deprecate undocumented AnalyticsNode

### DIFF
--- a/.changeset/silent-penguins-sleep.md
+++ b/.changeset/silent-penguins-sleep.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Deprecate AnalyticsNode class (in favor of the standalone @segment/analytics-node)

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -6,6 +6,9 @@ import { Plugin } from '../core/plugin'
 import { EventQueue } from '../core/queue/event-queue'
 import { PriorityQueue } from '../lib/priority-queue'
 
+/**
+ * @deprecated Please use the standalone `@segment/analytics-node` package.
+ */
 export class AnalyticsNode {
   static async load(settings: {
     writeKey: string


### PR DESCRIPTION
Adding a deprecation comment to encourage customers migrate, and so this class can be removed at a future date. 

### Background

Before any current team members were around, there was the thought of having AnalyticsNode live inside of analytics-next. 

For a variety of reasons, this didn't turn out to be good approach, and we went in the more idiomatic and flexible direction of having a [standalone node package](https://github.com/segmentio/analytics-next/tree/master/packages/node). This class was never documented, but there were/are handful of customers who knew about it and used it anyway (~10, last I looked).

* Per SemVer spec -- this is a minor version bump.