### PR TITLE
message id generation: hash only the event and not the uuid

### DIFF
--- a/.changeset/clean-trains-perform.md
+++ b/.changeset/clean-trains-perform.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Change messageid generation to only hash the event data

--- a/.changeset/clean-trains-perform.md
+++ b/.changeset/clean-trains-perform.md
@@ -2,4 +2,4 @@
 '@segment/analytics-next': patch
 ---
 
-Change messageid generation to only hash the event data
+Change messageid generation to only use date and uuid instead of hashed event data

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -8,7 +8,6 @@ import {
   Traits,
   SegmentEvent,
 } from './interfaces'
-import md5 from 'spark-md5'
 import { addPageContext, PageContext } from '../page'
 
 export * from './interfaces'
@@ -261,7 +260,7 @@ export class EventFactory {
       context,
       integrations: allIntegrations,
       ...overrides,
-      messageId: 'ajs-next-' + md5.hash(JSON.stringify(event)) + uuid(),
+      messageId: `ajs-next-${Date.now()}-${uuid()}`,
     }
     addPageContext(newEvent, pageCtx)
 

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -261,7 +261,7 @@ export class EventFactory {
       context,
       integrations: allIntegrations,
       ...overrides,
-      messageId: 'ajs-next-' + md5.hash(JSON.stringify(event) + uuid()),
+      messageId: 'ajs-next-' + md5.hash(JSON.stringify(event)) + uuid(),
     }
     addPageContext(newEvent, pageCtx)
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
