### PR TITLE
Support loading analytics into a custom global variable when using snippet version 5.2.1 or later

### DIFF
--- a/.changeset/kind-crabs-report.md
+++ b/.changeset/kind-crabs-report.md
@@ -1,6 +1,5 @@
 ---
-'@segment/analytics-next': patch
-'@internal/browser-integration-tests': patch
+'@segment/analytics-next': minor
 ---
 
 Support loading analytics into a custom global variable when using snippet version 5.2.1 or later

--- a/.changeset/kind-crabs-report.md
+++ b/.changeset/kind-crabs-report.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-next': patch
+'@internal/browser-integration-tests': patch
+---
+
+Fix globalAnalyticsKey feature

--- a/.changeset/kind-crabs-report.md
+++ b/.changeset/kind-crabs-report.md
@@ -3,4 +3,4 @@
 '@internal/browser-integration-tests': patch
 ---
 
-Fix globalAnalyticsKey feature
+Support loading analytics into a custom global variable when using snippet version 5.2.1 or later

--- a/packages/browser-integration-tests/src/custom-global-key.test.ts
+++ b/packages/browser-integration-tests/src/custom-global-key.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+import { standaloneMock } from './helpers/standalone-mock'
+import { extractWriteKeyFromUrl } from './helpers/extract-writekey'
+import { CDNSettingsBuilder } from '@internal/test-helpers'
+
+test.describe('Segment with custom global key', () => {
+  test.beforeEach(standaloneMock)
+  test.beforeEach(async ({ context }) => {
+    await context.route(
+      'https://cdn.segment.com/v1/projects/*/settings',
+      (route, request) => {
+        if (request.method().toLowerCase() !== 'get') {
+          return route.continue()
+        }
+
+        const writeKey = extractWriteKeyFromUrl(request.url()) || 'writeKey'
+        return route.fulfill({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(new CDNSettingsBuilder({ writeKey }).build()),
+        })
+      }
+    )
+  })
+
+  test('supports using a custom global key', async ({ page }) => {
+    // Load analytics.js
+    await page.goto('/standalone-custom-key.html')
+    await page.evaluate(() =>
+      (window as any).segment_analytics.load('fake-key')
+    )
+
+    const req = await page.waitForRequest('https://api.segment.io/v1/t')
+
+    // confirm that any events triggered from within snippet have been sent
+    expect(req.postDataJSON().event).toBe('track from snippet')
+
+    const contextObj = await page.evaluate(() =>
+      (window as any).segment_analytics.track('track after load')
+    )
+
+    // confirm that any events triggered after load return a regular context object
+    expect(contextObj).toMatchObject(
+      expect.objectContaining({
+        attempts: expect.anything(),
+        event: expect.objectContaining({ event: 'track after load' }),
+        stats: expect.objectContaining({ metrics: expect.anything() }),
+      })
+    )
+  })
+})

--- a/packages/browser-integration-tests/src/custom-global-key.test.ts
+++ b/packages/browser-integration-tests/src/custom-global-key.test.ts
@@ -28,14 +28,15 @@ test.describe('Segment with custom global key', () => {
   test('supports using a custom global key', async ({ page }) => {
     // Load analytics.js
     await page.goto('/standalone-custom-key.html')
-    await page.evaluate(() =>
-      (window as any).segment_analytics.load('fake-key')
-    )
+    await page.evaluate(() => {
+      ;(window as any).segment_analytics.track('track before load')
+      ;(window as any).segment_analytics.load('fake-key')
+    })
 
     const req = await page.waitForRequest('https://api.segment.io/v1/t')
 
-    // confirm that any events triggered from within snippet have been sent
-    expect(req.postDataJSON().event).toBe('track from snippet')
+    // confirm that any events triggered before load have been sent
+    expect(req.postDataJSON().event).toBe('track before load')
 
     const contextObj = await page.evaluate(() =>
       (window as any).segment_analytics.track('track after load')

--- a/packages/browser-integration-tests/standalone-custom-key.html
+++ b/packages/browser-integration-tests/standalone-custom-key.html
@@ -86,9 +86,6 @@
               analytics._writeKey = key
             }
             analytics.SNIPPET_VERSION = '5.2.0'
-
-            // will be used for asserting in the corresponding test
-            analytics.track('track from snippet')
           }
       })()
     </script>

--- a/packages/browser-integration-tests/standalone-custom-key.html
+++ b/packages/browser-integration-tests/standalone-custom-key.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      !(function () {
+        var i = 'segment_analytics',
+          analytics = (window[i] = window[i] || [])
+        if (!analytics.initialize)
+          if (analytics.invoked)
+            window.console &&
+              console.error &&
+              console.error('Segment snippet included twice.')
+          else {
+            analytics.invoked = !0
+            analytics.methods = [
+              'trackSubmit',
+              'trackClick',
+              'trackLink',
+              'trackForm',
+              'pageview',
+              'identify',
+              'reset',
+              'group',
+              'track',
+              'ready',
+              'alias',
+              'debug',
+              'page',
+              'screen',
+              'once',
+              'off',
+              'on',
+              'addSourceMiddleware',
+              'addIntegrationMiddleware',
+              'setAnonymousId',
+              'addDestinationMiddleware',
+              'register',
+            ]
+            analytics.factory = function (e) {
+              return function () {
+                if (window[i].initialized)
+                  return window[i][e].apply(window[i], arguments)
+                var n = Array.prototype.slice.call(arguments)
+                if (
+                  [
+                    'track',
+                    'screen',
+                    'alias',
+                    'group',
+                    'page',
+                    'identify',
+                  ].indexOf(e) > -1
+                ) {
+                  var c = document.querySelector("link[rel='canonical']")
+                  n.push({
+                    __t: 'bpc',
+                    c: (c && c.getAttribute('href')) || void 0,
+                    p: location.pathname,
+                    u: location.href,
+                    s: location.search,
+                    t: document.title,
+                    r: document.referrer,
+                  })
+                }
+                n.unshift(e)
+                analytics.push(n)
+                return analytics
+              }
+            }
+            for (var n = 0; n < analytics.methods.length; n++) {
+              var key = analytics.methods[n]
+              analytics[key] = analytics.factory(key)
+            }
+            analytics.load = function (key, n) {
+              var t = document.createElement('script')
+              t.type = 'text/javascript'
+              t.async = !0
+              t.setAttribute('data-global-segment-analytics-key', i)
+              t.src =
+                'https://cdn.segment.com/analytics.js/v1/' +
+                key +
+                '/analytics.min.js'
+              var r = document.getElementsByTagName('script')[0]
+              r.parentNode.insertBefore(t, r)
+              analytics._loadOptions = n
+              analytics._writeKey = key
+            }
+            analytics.SNIPPET_VERSION = '5.2.0'
+
+            // will be used for asserting in the corresponding test
+            analytics.track('track from snippet')
+          }
+      })()
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -28,6 +28,7 @@ import {
   loadAjsClassicFallback,
   isAnalyticsCSPError,
 } from '../lib/csp-detection'
+import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 
 let ajsIdentifiedCSP = false
 
@@ -69,6 +70,16 @@ async function attempt<T>(promise: () => Promise<T>) {
   } catch (err) {
     onError(err)
   }
+}
+
+const globalAnalyticsKey = (
+  document.querySelector(
+    'script[data-global-segment-analytics-key]'
+  ) as HTMLScriptElement
+)?.dataset.globalSegmentAnalyticsKey
+
+if (globalAnalyticsKey) {
+  setGlobalAnalyticsKey(globalAnalyticsKey)
 }
 
 if (shouldPolyfill()) {


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

Fixes #1014

Please refer to the original issue for more information

Docs for this feature - https://github.com/segmentio/segment-docs/pull/5949

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
