### PR TITLE
Fix schema filter name collision bug

### DIFF
--- a/.changeset/spicy-fireants-reflect.md
+++ b/.changeset/spicy-fireants-reflect.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix schema-filter bug

--- a/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
@@ -10,6 +10,8 @@ const settings: LegacySettings = {
     'Braze Web Mode (Actions)': {},
     // note that Fullstory's name here doesn't contain 'Actions'
     Fullstory: {},
+    'Google Analytics': {},
+    'Google Analytics 4 Web': {},
     'Segment.io': {},
   },
   remotePlugins: [
@@ -45,6 +47,19 @@ const settings: LegacySettings = {
           },
           {
             partnerAction: 'identifyUser',
+          },
+        ],
+      },
+    },
+    {
+      name: 'Google Analytics 4 Web',
+      creationName: 'Google Analytics 4 Web',
+      libraryName: 'google-analytics-4-webDestination',
+      url: 'https://cdn.segment.com/next-integrations/actions/google-analytics-4-web/bfab87631cbcb7d70964.js',
+      settings: {
+        subscriptions: [
+          {
+            partnerAction: 'Custom Event',
           },
         ],
       },
@@ -92,6 +107,11 @@ const fullstory: Plugin = {
   name: 'Fullstory (Actions) trackEvent',
 }
 
+const ga4: Plugin = {
+  ...trackEvent,
+  name: 'Google Analytics 4 Web Custom Event',
+}
+
 describe('schema filter', () => {
   let options: SegmentioSettings
   let filterXt: Plugin
@@ -113,6 +133,7 @@ describe('schema filter', () => {
     jest.spyOn(updateUserProfile, 'track')
     jest.spyOn(amplitude, 'track')
     jest.spyOn(fullstory, 'track')
+    jest.spyOn(ga4, 'track')
   })
 
   describe('plugins and destinations', () => {
@@ -515,6 +536,26 @@ describe('schema filter', () => {
       expect(trackPurchase.track).toHaveBeenCalled()
       expect(updateUserProfile.track).toHaveBeenCalled()
       expect(fullstory.track).toHaveBeenCalled()
+    })
+
+    it('doesnt block destinations with similar names', async () => {
+      const filterXt = schemaFilter(
+        {
+          hi: {
+            enabled: true,
+            integrations: {
+              'Google Analytics': false,
+            },
+          },
+        },
+        settings
+      )
+
+      await ajs.register(segment, ga4, filterXt)
+
+      await ajs.track('hi')
+
+      expect(ga4.track).toHaveBeenCalled()
     })
   })
 })

--- a/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
@@ -35,7 +35,7 @@ const settings: LegacySettings = {
     {
       // note that Fullstory name contains 'Actions'
       name: 'Fullstory (Actions)',
-      creationName: 'Fullstory (Actions)',
+      creationName: 'Fullstory',
       libraryName: 'fullstoryDestination',
       url: 'https://cdn.segment.com/next-integrations/actions/fullstory/35ea1d304f85f3306f48.js',
       settings: {
@@ -472,7 +472,7 @@ describe('schema filter', () => {
       expect(updateUserProfile.track).toHaveBeenCalled()
     })
 
-    it('covers different names between remote plugins and integrations', async () => {
+    it('works when current name differs from creation name', async () => {
       const filterXt = schemaFilter(
         {
           hi: {

--- a/packages/browser/src/plugins/schema-filter/index.ts
+++ b/packages/browser/src/plugins/schema-filter/index.ts
@@ -24,7 +24,7 @@ function disabledActionDestinations(
   const disabledRemotePlugins: string[] = []
   ;(settings.remotePlugins ?? []).forEach((p: RemotePlugin) => {
     disabledIntegrations.forEach((int) => {
-      if (p.name.includes(int) || int.includes(p.name)) {
+      if (p.creationName == int) {
         disabledRemotePlugins.push(p.name)
       }
     })


### PR DESCRIPTION
This PR fixes an issue with integrations containing similar names (ie. Google Analytics and Google Analytics 4) having their schema filters applied incorrectly. It updates the filters to compare the schema filter name (which uses the creation name of the integration) with the creationName field in the remote plugin.

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
