### PR TITLE
Allow custom metrics endpoint

### DIFF
--- a/.changeset/few-pets-tell.md
+++ b/.changeset/few-pets-tell.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Allow custom metrics endpoint

--- a/.changeset/few-pets-tell.md
+++ b/.changeset/few-pets-tell.md
@@ -2,4 +2,4 @@
 '@segment/analytics-next': minor
 ---
 
-Allow custom metrics endpoint
+Allow custom metrics endpoint on load

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -354,13 +354,15 @@ async function loadAnalytics(
 
   const classicIntegrations = settings.classicIntegrations ?? []
 
-  if (options.metricsEndpoint && legacySettings.metrics) {
-    legacySettings.metrics.host = options.metricsEndpoint
-  }
+  const segmentLoadOptions = options.integrations?.['Segment.io'] as
+    | SegmentioSettings
+    | undefined
 
-  Stats.initRemoteMetrics(
-    legacySettings.metrics ?? { host: options.metricsEndpoint }
-  )
+  Stats.initRemoteMetrics({
+    ...legacySettings.metrics,
+    host: segmentLoadOptions?.apiHost ?? legacySettings.metrics?.host,
+    protocol: segmentLoadOptions?.protocol,
+  })
 
   // needs to be flushed before plugins are registered
   flushPreBuffer(analytics, preInitBuffer)

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -353,7 +353,14 @@ async function loadAnalytics(
   const plugins = settings.plugins ?? []
 
   const classicIntegrations = settings.classicIntegrations ?? []
-  Stats.initRemoteMetrics(legacySettings.metrics)
+
+  if (options.metricsEndpoint && legacySettings.metrics) {
+    legacySettings.metrics.host = options.metricsEndpoint
+  }
+
+  Stats.initRemoteMetrics(
+    legacySettings.metrics ?? { host: options.metricsEndpoint }
+  )
 
   // needs to be flushed before plugins are registered
   flushPreBuffer(analytics, preInitBuffer)

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -107,10 +107,6 @@ export interface InitOptions {
   retryQueue?: boolean
   obfuscate?: boolean
   /**
-   * Allows you to change the metrics endpoint used
-   */
-  metricsEndpoint?: string
-  /**
    * This callback allows you to update/mutate CDN Settings.
    * This is called directly after settings are fetched from the CDN.
    */

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -107,6 +107,10 @@ export interface InitOptions {
   retryQueue?: boolean
   obfuscate?: boolean
   /**
+   * Allows you to change the metrics endpoint used
+   */
+  metricsEndpoint?: string
+  /**
    * This callback allows you to update/mutate CDN Settings.
    * This is called directly after settings are fetched from the CDN.
    */

--- a/packages/browser/src/core/stats/remote-metrics.ts
+++ b/packages/browser/src/core/stats/remote-metrics.ts
@@ -8,7 +8,7 @@ export interface MetricsOptions {
   sampleRate?: number
   flushTimer?: number
   maxQueueSize?: number
-  protocol?: string
+  protocol?: 'http' | 'https'
 }
 
 /**

--- a/packages/browser/src/core/stats/remote-metrics.ts
+++ b/packages/browser/src/core/stats/remote-metrics.ts
@@ -8,6 +8,7 @@ export interface MetricsOptions {
   sampleRate?: number
   flushTimer?: number
   maxQueueSize?: number
+  protocol?: string
 }
 
 /**
@@ -56,6 +57,7 @@ export class RemoteMetrics {
   private host: string
   private flushTimer: number
   private maxQueueSize: number
+  private protocol: string
 
   sampleRate: number
   queue: RemoteMetric[]
@@ -65,6 +67,7 @@ export class RemoteMetrics {
     this.sampleRate = options?.sampleRate ?? 1
     this.flushTimer = options?.flushTimer ?? 30 * 1000 /* 30s */
     this.maxQueueSize = options?.maxQueueSize ?? 20
+    this.protocol = options?.protocol ?? 'https'
 
     this.queue = []
 
@@ -130,7 +133,7 @@ export class RemoteMetrics {
     this.queue = []
 
     const headers = { 'Content-Type': 'text/plain' }
-    const url = `https://${this.host}/m`
+    const url = `${this.protocol}://${this.host}/m`
 
     return fetch(url, {
       headers,


### PR DESCRIPTION
Allows users to set a custom metrics endpoint when loading Analytics. Tested locally by setting a custom endpoint and confirming it was used.

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
