### PR TITLE
Retain messageId if exists (allow overriding)

### DIFF
--- a/.changeset/message-id-backward-compatibility.md
+++ b/.changeset/message-id-backward-compatibility.md
@@ -1,5 +1,5 @@
 ---
-'@segment/analytics-next': minor
+'@segment/analytics-core': minor
 ---
 
-This minor update ensures backward compatibility with analytics-node by modifying '@segment/analytics-next'. Specifically, the changes prevent the generation of a messageId if it is already set. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).
+Override messageId if event.messageId is on the event. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).

--- a/.changeset/message-id-backward-compatibility.md
+++ b/.changeset/message-id-backward-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+This minor update ensures backward compatibility with analytics-node by modifying '@segment/analytics-next'. Specifically, the changes prevent the generation of a messageId if it is already set. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).

--- a/.changeset/message-id-backward-compatibility.md
+++ b/.changeset/message-id-backward-compatibility.md
@@ -1,5 +1,8 @@
 ---
-'@segment/analytics-core': minor
+'@segment/analytics-core': patch
+'@segment/analytics-node': minor
 ---
 
-Override messageId if event.messageId is on the event. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).
+This ensures backward compatibility with analytics-node by modifying '@segment/analytics-core'. Specifically, the changes prevent the generation of a messageId if it is already set. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).
+
+While this is a core release, only the node library is affected, as the browser has its own EventFactory atm.

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -289,13 +289,13 @@ describe('Event Factory', () => {
     })
 
     test('accepts a timestamp', () => {
-      const timestamp = new date()
+      const timestamp = new Date()
       const track = factory.track('order completed', shoes, {
         timestamp,
       })
 
-      expect(track.context).toequal({})
-      expect(track.timestamp).toequal(timestamp)
+      expect(track.context).toEqual({})
+      expect(track.timestamp).toEqual(timestamp)
     })
 
     test('accepts traits', () => {
@@ -351,24 +351,24 @@ describe('Event Factory', () => {
       })
     })
 
-    test('accepts a timestamp', () => {
-      const timestamp = new date()
-      const track = factory.track('order completed', shoes, {
-        timestamp,
-      })
-
-      expect(track.context).toequal({})
-      expect(track.timestamp).toequal(timestamp)
-    })
-
     test('accepts a messageId', () => {
-      const messageId = "business-id-123"
+      const messageId = 'business-id-123'
       const track = factory.track('order completed', shoes, {
         messageId,
       })
 
-      expect(track.context).toequal({})
-      expect(track.messageId).toequal(messageId)
+      expect(track.context).toEqual({})
+      expect(track.messageId).toEqual(messageId)
+    })
+    it('should ignore undefined options', () => {
+      const event = factory.track(
+        'Order Completed',
+        { ...shoes },
+        { timestamp: undefined, traits: { foo: 123 } }
+      )
+
+      expect(typeof event.timestamp).toBe('object')
+      expect(isDate(event.timestamp)).toBeTruthy()
     })
   })
 
@@ -399,16 +399,5 @@ describe('Event Factory', () => {
         context: {},
       })
     })
-  })
-
-  it('should ignore undefined options', () => {
-    const event = factory.track(
-      'Order Completed',
-      { ...shoes },
-      { timestamp: undefined, traits: { foo: 123 } }
-    )
-
-    expect(typeof event.timestamp).toBe('object')
-    expect(isDate(event.timestamp)).toBeTruthy()
   })
 })

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -289,13 +289,13 @@ describe('Event Factory', () => {
     })
 
     test('accepts a timestamp', () => {
-      const timestamp = new Date()
-      const track = factory.track('Order Completed', shoes, {
+      const timestamp = new date()
+      const track = factory.track('order completed', shoes, {
         timestamp,
       })
 
-      expect(track.context).toEqual({})
-      expect(track.timestamp).toEqual(timestamp)
+      expect(track.context).toequal({})
+      expect(track.timestamp).toequal(timestamp)
     })
 
     test('accepts traits', () => {
@@ -349,6 +349,26 @@ describe('Event Factory', () => {
         foreignProp: '🇧🇷',
         innerProp: '👻',
       })
+    })
+
+    test('accepts a timestamp', () => {
+      const timestamp = new date()
+      const track = factory.track('order completed', shoes, {
+        timestamp,
+      })
+
+      expect(track.context).toequal({})
+      expect(track.timestamp).toequal(timestamp)
+    })
+
+    test('accepts a messageId', () => {
+      const messageId = "business-id-123"
+      const track = factory.track('order completed', shoes, {
+        messageId,
+      })
+
+      expect(track.context).toequal({})
+      expect(track.messageId).toequal(messageId)
     })
   })
 

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -290,7 +290,7 @@ describe('Event Factory', () => {
 
     test('accepts a timestamp', () => {
       const timestamp = new Date()
-      const track = factory.track('order completed', shoes, {
+      const track = factory.track('Order Completed', shoes, {
         timestamp,
       })
 
@@ -353,7 +353,7 @@ describe('Event Factory', () => {
 
     test('accepts a messageId', () => {
       const messageId = 'business-id-123'
-      const track = factory.track('order completed', shoes, {
+      const track = factory.track('Order Completed', shoes, {
         messageId,
       })
 

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -360,6 +360,7 @@ describe('Event Factory', () => {
       expect(track.context).toEqual({})
       expect(track.messageId).toEqual(messageId)
     })
+
     it('should ignore undefined options', () => {
       const event = factory.track(
         'Order Completed',

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -201,6 +201,7 @@ export class EventFactory {
       'userId',
       'anonymousId',
       'timestamp',
+      'messageId',
     ]
 
     delete options['integrations']
@@ -271,7 +272,7 @@ export class EventFactory {
 
     const evt: CoreSegmentEvent = {
       ...body,
-      messageId: event.messageId || this.createMessageId(),
+      messageId: options.messageId || this.createMessageId(),
     }
 
     validateEvent(evt)

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -271,7 +271,7 @@ export class EventFactory {
 
     const evt: CoreSegmentEvent = {
       ...body,
-      messageId: this.createMessageId(),
+      messageId: event.messageId || this.createMessageId(),
     }
 
     validateEvent(evt)

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -19,6 +19,10 @@ interface EventFactorySettings {
   user?: User
 }
 
+/**
+ * This is currently only used by node.js, but the original idea was to have something that could be shared between browser and node.
+ * Unfortunately, there are some differences in the way the two environments handle events, so this is not currently shared.
+ */
 export class EventFactory {
   createMessageId: EventFactorySettings['createMessageId']
   user?: User

--- a/packages/core/src/events/interfaces.ts
+++ b/packages/core/src/events/interfaces.ts
@@ -33,6 +33,10 @@ export interface CoreOptions {
   anonymousId?: string
   userId?: string
   traits?: Traits
+  /**
+   * Override the messageId. Under normal circumstances, this is not recommended -- but neccessary for deduping events.
+   * ATM, this option only _does_ anything in analytics-nod.
+   */
   messageId?: string
   // ugh, this is ugly, but we allow literally any property to be passed to options (which get spread onto the event)
   [key: string]: any

--- a/packages/core/src/events/interfaces.ts
+++ b/packages/core/src/events/interfaces.ts
@@ -33,6 +33,7 @@ export interface CoreOptions {
   anonymousId?: string
   userId?: string
   traits?: Traits
+  messageId?: string
   // ugh, this is ugly, but we allow literally any property to be passed to options (which get spread onto the event)
   [key: string]: any
 }

--- a/packages/core/src/events/interfaces.ts
+++ b/packages/core/src/events/interfaces.ts
@@ -35,7 +35,8 @@ export interface CoreOptions {
   traits?: Traits
   /**
    * Override the messageId. Under normal circumstances, this is not recommended -- but neccessary for deduping events.
-   * ATM, this option only _does_ anything in analytics-nod.
+   *
+   * **Currently, This option only works in `@segment/analytics-node`.**
    */
   messageId?: string
   // ugh, this is ugly, but we allow literally any property to be passed to options (which get spread onto the event)
@@ -86,7 +87,7 @@ export interface CoreExtraContext {
      * @example CA
      */
     region?: string
-    /**
+    /**C
      * @example 100
      */
     speed?: number

--- a/packages/core/src/events/interfaces.ts
+++ b/packages/core/src/events/interfaces.ts
@@ -87,7 +87,7 @@ export interface CoreExtraContext {
      * @example CA
      */
     region?: string
-    /**C
+    /**
      * @example 100
      */
     speed?: number

--- a/packages/core/src/validation/__tests__/assertions.test.ts
+++ b/packages/core/src/validation/__tests__/assertions.test.ts
@@ -151,5 +151,27 @@ describe(validateEvent, () => {
         })
       ).toThrowError(/nil/i)
     })
+
+    test('should fail if messageId is _not_ string', () => {
+      expect(() =>
+        validateEvent({
+          ...baseEvent,
+          type: 'track',
+          properties: {},
+          userId: undefined,
+          anonymousId: 'foo',
+        })
+      ).not.toThrow()
+
+      expect(() =>
+        validateEvent({
+          ...baseEvent,
+          type: 'track',
+          properties: {},
+          userId: undefined,
+          anonymousId: 'foo',
+          messageId: 123 as any
+        })
+      ).toThrowError(/string/)
   })
 })

--- a/packages/core/src/validation/__tests__/assertions.test.ts
+++ b/packages/core/src/validation/__tests__/assertions.test.ts
@@ -4,7 +4,9 @@ import { validateEvent } from '../assertions'
 const baseEvent: Partial<CoreSegmentEvent> = {
   userId: 'foo',
   event: 'Test Event',
+  messageId: 'foo',
 }
+
 describe(validateEvent, () => {
   test('should be capable of working with empty properties and traits', () => {
     expect(() => validateEvent(undefined)).toThrowError()
@@ -160,6 +162,7 @@ describe(validateEvent, () => {
           properties: {},
           userId: undefined,
           anonymousId: 'foo',
+          messageId: 'bar',
         })
       ).not.toThrow()
 
@@ -170,8 +173,9 @@ describe(validateEvent, () => {
           properties: {},
           userId: undefined,
           anonymousId: 'foo',
-          messageId: 123 as any
+          messageId: 123 as any,
         })
-      ).toThrowError(/string/)
+      ).toThrow(/messageId/)
+    })
   })
 })

--- a/packages/core/src/validation/__tests__/assertions.test.ts
+++ b/packages/core/src/validation/__tests__/assertions.test.ts
@@ -42,6 +42,7 @@ describe(validateEvent, () => {
   test('identify: traits should be an object', () => {
     expect(() =>
       validateEvent({
+        ...baseEvent,
         type: 'identify',
         traits: undefined,
       })

--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -55,9 +55,16 @@ export function assertTraits(event: CoreSegmentEvent): void {
   }
 }
 
+export function assertMessageId(event: CoreSegmentEvent): void {
+  if (!isString(event.messageId)) {
+    throw new ValidationError('.messageId', stringError)
+  }
+}
+
 export function validateEvent(event?: CoreSegmentEvent | null) {
   assertEventExists(event)
   assertEventType(event)
+  assertMessageId(event)
 
   if (event.type === 'track') {
     assertTrackEventName(event)

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -88,6 +88,16 @@ describe('alias', () => {
     expect(ctx.event.userId).toEqual('chris radek')
     expect(ctx.event.previousId).toEqual('chris')
     expect(ctx.event.timestamp).toEqual(timestamp)
+    expect(ctx.event.messageId).toEqual(expect.any(String))
+  })
+  it('allows messageId to be overridden', async () => {
+    const analytics = createTestAnalytics({
+      httpClient: testClient,
+    })
+    const messageId = 'overridden'
+    analytics.alias({ userId: 'foo', previousId: 'bar', messageId })
+    const ctx = await resolveCtx(analytics, 'group')
+    expect(ctx.event.messageId).toBe(messageId)
   })
 })
 
@@ -107,6 +117,8 @@ describe('group', () => {
     expect(ctx.event.userId).toEqual('foo')
     expect(ctx.event.anonymousId).toBe('bar')
     expect(ctx.event.timestamp).toEqual(timestamp)
+    expect(ctx.event.messageId).toEqual(expect.any(String))
+    expect(ctx.event.messageId).toEqual(expect.any(String))
   })
 
   it('invocations are isolated', async () => {
@@ -133,6 +145,16 @@ describe('group', () => {
     expect(ctx2.event.traits).toEqual({ bar: 'bar' })
     expect(ctx2.event.anonymousId).toBeUndefined()
     expect(ctx2.event.userId).toEqual('me')
+  })
+
+  it('allows messageId to be overridden', async () => {
+    const analytics = createTestAnalytics({
+      httpClient: testClient,
+    })
+    const messageId = 'overridden'
+    analytics.group({ groupId: 'foo', userId: 'sup', messageId })
+    const ctx = await resolveCtx(analytics, 'group')
+    expect(ctx.event.messageId).toBe(messageId)
   })
 })
 
@@ -181,6 +203,7 @@ describe('page', () => {
     expect(ctx1.event.userId).toBeUndefined()
     expect(ctx1.event.properties).toEqual({ category })
     expect(ctx1.event.timestamp).toEqual(timestamp)
+    expect(ctx1.event.messageId).toEqual(expect.any(String))
 
     analytics.page({ name, properties: { title: 'wip' }, userId: 'user-id' })
 
@@ -192,6 +215,7 @@ describe('page', () => {
     expect(ctx2.event.userId).toEqual('user-id')
     expect(ctx2.event.properties).toEqual({ title: 'wip' })
     expect(ctx2.event.timestamp).toEqual(expect.any(Date))
+    expect(ctx2.event.messageId).toEqual(expect.any(String))
 
     analytics.page({ properties: { title: 'invisible' }, userId: 'user-id' })
     const ctx3 = await resolveCtx(analytics, 'page')
@@ -201,6 +225,17 @@ describe('page', () => {
     expect(ctx3.event.anonymousId).toBeUndefined()
     expect(ctx3.event.userId).toEqual('user-id')
     expect(ctx3.event.properties).toEqual({ title: 'invisible' })
+    expect(ctx3.event.messageId).toEqual(expect.any(String))
+  })
+
+  it('allows messageId to be overridden', async () => {
+    const analytics = createTestAnalytics({
+      httpClient: testClient,
+    })
+    const messageId = 'overridden'
+    analytics.page({ name: 'foo', userId: 'sup', messageId })
+    const ctx = await resolveCtx(analytics, 'page')
+    expect(ctx.event.messageId).toBe(messageId)
   })
 })
 
@@ -224,6 +259,7 @@ describe('screen', () => {
     expect(ctx1.event.userId).toEqual('user-id')
     expect(ctx1.event.properties).toEqual({ title: 'wip' })
     expect(ctx1.event.timestamp).toEqual(timestamp)
+    expect(ctx1.event.messageId).toEqual(expect.any(String))
 
     analytics.screen({
       properties: { title: 'invisible' },
@@ -238,6 +274,16 @@ describe('screen', () => {
     expect(ctx2.event.userId).toEqual('user-id')
     expect(ctx2.event.properties).toEqual({ title: 'invisible' })
     expect(ctx2.event.timestamp).toEqual(expect.any(Date))
+    expect(ctx2.event.messageId).toEqual(expect.any(String))
+  })
+  it('allows messageId to be overridden', async () => {
+    const analytics = createTestAnalytics({
+      httpClient: testClient,
+    })
+    const messageId = 'overridden'
+    analytics.screen({ name: 'foo', userId: 'sup', messageId })
+    const ctx = await resolveCtx(analytics, 'screen')
+    expect(ctx.event.messageId).toBe(messageId)
   })
 })
 
@@ -272,6 +318,7 @@ describe('track', () => {
     expect(ctx1.event.anonymousId).toEqual('unknown')
     expect(ctx1.event.userId).toEqual('known')
     expect(ctx1.event.timestamp).toEqual(timestamp)
+    expect(ctx1.event.messageId).toEqual(expect.any(String))
 
     analytics.track({
       event: eventName,
@@ -286,6 +333,17 @@ describe('track', () => {
     expect(ctx2.event.anonymousId).toBeUndefined()
     expect(ctx2.event.userId).toEqual('known')
     expect(ctx2.event.timestamp).toEqual(expect.any(Date))
+    expect(ctx2.event.messageId).toEqual(expect.any(String))
+  })
+
+  it('allows messageId to be overridden', async () => {
+    const analytics = createTestAnalytics({
+      httpClient: testClient,
+    })
+    const messageId = 'overridden'
+    analytics.track({ event: 'foo', userId: 'sup', messageId })
+    const ctx = await resolveCtx(analytics, 'track')
+    expect(ctx.event.messageId).toBe(messageId)
   })
 })
 

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -96,7 +96,7 @@ describe('alias', () => {
     })
     const messageId = 'overridden'
     analytics.alias({ userId: 'foo', previousId: 'bar', messageId })
-    const ctx = await resolveCtx(analytics, 'group')
+    const ctx = await resolveCtx(analytics, 'alias')
     expect(ctx.event.messageId).toBe(messageId)
   })
 })
@@ -117,7 +117,6 @@ describe('group', () => {
     expect(ctx.event.userId).toEqual('foo')
     expect(ctx.event.anonymousId).toBe('bar')
     expect(ctx.event.timestamp).toEqual(timestamp)
-    expect(ctx.event.messageId).toEqual(expect.any(String))
     expect(ctx.event.messageId).toEqual(expect.any(String))
   })
 

--- a/packages/node/src/app/analytics-node.ts
+++ b/packages/node/src/app/analytics-node.ts
@@ -148,13 +148,21 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
    * @link https://segment.com/docs/connections/sources/catalog/libraries/server/node/#alias
    */
   alias(
-    { userId, previousId, context, timestamp, integrations }: AliasParams,
+    {
+      userId,
+      previousId,
+      context,
+      timestamp,
+      integrations,
+      messageId,
+    }: AliasParams,
     callback?: Callback
   ): void {
     const segmentEvent = this._eventFactory.alias(userId, previousId, {
       context,
       integrations,
       timestamp,
+      messageId,
     })
     this._dispatch(segmentEvent, callback)
   }
@@ -172,6 +180,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       traits = {},
       context,
       integrations,
+      messageId,
     }: GroupParams,
     callback?: Callback
   ): void {
@@ -181,6 +190,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       userId,
       timestamp,
       integrations,
+      messageId,
     })
 
     this._dispatch(segmentEvent, callback)
@@ -198,6 +208,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       context,
       timestamp,
       integrations,
+      messageId,
     }: IdentifyParams,
     callback?: Callback
   ): void {
@@ -207,6 +218,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       userId,
       timestamp,
       integrations,
+      messageId,
     })
     this._dispatch(segmentEvent, callback)
   }
@@ -225,6 +237,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       context,
       timestamp,
       integrations,
+      messageId,
     }: PageParams,
     callback?: Callback
   ): void {
@@ -232,7 +245,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       category ?? null,
       name ?? null,
       properties,
-      { context, anonymousId, userId, timestamp, integrations }
+      { context, anonymousId, userId, timestamp, integrations, messageId }
     )
     this._dispatch(segmentEvent, callback)
   }
@@ -253,6 +266,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       context,
       timestamp,
       integrations,
+      messageId,
     }: PageParams,
     callback?: Callback
   ): void {
@@ -260,7 +274,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       category ?? null,
       name ?? null,
       properties,
-      { context, anonymousId, userId, timestamp, integrations }
+      { context, anonymousId, userId, timestamp, integrations, messageId }
     )
 
     this._dispatch(segmentEvent, callback)
@@ -279,6 +293,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       context,
       timestamp,
       integrations,
+      messageId,
     }: TrackParams,
     callback?: Callback
   ): void {
@@ -288,6 +303,7 @@ export class Analytics extends NodeEmitter implements CoreAnalytics {
       anonymousId,
       timestamp,
       integrations,
+      messageId,
     })
 
     this._dispatch(segmentEvent, callback)

--- a/packages/node/src/app/types/params.ts
+++ b/packages/node/src/app/types/params.ts
@@ -30,6 +30,10 @@ export type AliasParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  /**
+   * Override the default messageId for the purposes of deduping events. Using a uuid library is strongly encouraged.
+   * @link https://segment.com/docs/partners/faqs/#does-segment-de-dupe-messages
+   */
   messageId?: string
 }
 
@@ -44,6 +48,10 @@ export type GroupParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  /**
+   * Override the default messageId for the purposes of deduping events. Using a uuid library is strongly encouraged.
+   * @link https://segment.com/docs/partners/faqs/#does-segment-de-dupe-messages
+   */
   messageId?: string
 } & IdentityOptions
 
@@ -57,6 +65,10 @@ export type IdentifyParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  /**
+   * Override the default messageId for the purposes of deduping events. Using a uuid library is strongly encouraged.
+   * @link https://segment.com/docs/partners/faqs/#does-segment-de-dupe-messages
+   */
   messageId?: string
 } & IdentityOptions
 
@@ -70,6 +82,10 @@ export type PageParams = {
   timestamp?: Timestamp
   context?: ExtraContext
   integrations?: Integrations
+  /**
+   * Override the default messageId for the purposes of deduping events. Using a uuid library is strongly encouraged.
+   * @link https://segment.com/docs/partners/faqs/#does-segment-de-dupe-messages
+   */
   messageId?: string
 } & IdentityOptions
 
@@ -79,6 +95,10 @@ export type TrackParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  /**
+   * Override the default messageId for the purposes of deduping events. Using a uuid library is strongly encouraged.
+   * @link https://segment.com/docs/partners/faqs/#does-segment-de-dupe-messages
+   */
   messageId?: string
 } & IdentityOptions
 

--- a/packages/node/src/app/types/params.ts
+++ b/packages/node/src/app/types/params.ts
@@ -30,6 +30,7 @@ export type AliasParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  messageId?: string
 }
 
 export type GroupParams = {
@@ -43,6 +44,7 @@ export type GroupParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  messageId?: string
 } & IdentityOptions
 
 export type IdentifyParams = {
@@ -55,6 +57,7 @@ export type IdentifyParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  messageId?: string
 } & IdentityOptions
 
 export type PageParams = {
@@ -67,6 +70,7 @@ export type PageParams = {
   timestamp?: Timestamp
   context?: ExtraContext
   integrations?: Integrations
+  messageId?: string
 } & IdentityOptions
 
 export type TrackParams = {
@@ -75,6 +79,7 @@ export type TrackParams = {
   context?: ExtraContext
   timestamp?: Timestamp
   integrations?: Integrations
+  messageId?: string
 } & IdentityOptions
 
 export type FlushParams = {


### PR DESCRIPTION
This addresses an inconsistency with analytics-node (new vs old). 

There are cases valid use cases where we want the messageId to be overridable, such as deduping.

This ensures backward compatibility with analytics-node by modifying '@segment/analytics-core'. Specifically, the changes prevent the generation of a messageId if it is already set. This adjustment aligns with the behavior outlined in analytics-node's source code [here](https://github.com/segmentio/analytics-node/blob/master/index.js#L195-L201).

While this is a core release, only the node library is affected, as the browser has its own EventFactory atm.