### PR TITLE
Do not hash by message -- also, refactor event factory

### DIFF
--- a/.changeset/clean-trains-perform.md
+++ b/.changeset/clean-trains-perform.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Change messageid generation to only use date and uuid instead of hashed event data

--- a/packages/browser/src/core/events/__tests__/index.test.ts
+++ b/packages/browser/src/core/events/__tests__/index.test.ts
@@ -3,7 +3,6 @@ import { range, uniq } from 'lodash'
 import { EventFactory } from '..'
 import { getDefaultPageContext } from '../../page'
 import { User } from '../../user'
-import { SegmentEvent, Options } from '../interfaces'
 
 describe('Event Factory', () => {
   let user: User
@@ -58,6 +57,24 @@ describe('Event Factory', () => {
     it('sets the groupId to the message', () => {
       const group = factory.group('coolKidsId', { coolkids: true })
       expect(group.groupId).toEqual('coolKidsId')
+    })
+
+    it('allows userId / anonymousId to be specified as an option', () => {
+      const group = factory.group('my_group_id', undefined, {
+        userId: 'bar',
+        anonymousId: 'foo',
+      })
+      expect(group.userId).toBe('bar')
+      expect(group.anonymousId).toBe('foo')
+    })
+
+    it('allows userId / anonymousId to be overridden', function () {
+      const group = factory.group('my_group_id', undefined, {
+        userId: 'bar',
+        anonymousId: 'foo',
+      })
+      expect(group.userId).toBe('bar')
+      expect(group.anonymousId).toBe('foo')
     })
   })
 
@@ -390,32 +407,6 @@ describe('Event Factory', () => {
         })
         expect(track.context?.anonymousId).toBe('foo')
         expect(track.anonymousId).toBe('foo')
-      })
-    })
-  })
-
-  describe('normalize', function () {
-    const msg: SegmentEvent = { type: 'track' }
-    const opts: Options = (msg.options = {})
-
-    describe('message', function () {
-      it('should merge original with normalized', function () {
-        msg.userId = 'user-id'
-        opts.integrations = { Segment: true }
-        const normalized = factory['normalize'](msg)
-
-        expect(normalized.messageId?.length).toBeGreaterThanOrEqual(41) // 'ajs-next-md5(content + [UUID])'
-        delete normalized.messageId
-
-        expect(normalized.timestamp).toBeInstanceOf(Date)
-        delete normalized.timestamp
-
-        expect(normalized).toStrictEqual({
-          integrations: { Segment: true },
-          type: 'track',
-          userId: 'user-id',
-          context: defaultContext,
-        })
       })
     })
   })

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -17,23 +17,15 @@ export class EventFactory extends CoreEventFactory {
   constructor(user: User) {
     super({
       createMessageId: () => `ajs-next-${Date.now()}-${uuid()}`,
+      onEventMethodCall: ({ options }) => {
+        this.maybeUpdateAnonId(options)
+      },
+      updateEvent: (event) => {
+        this.addIdentity(event)
+        return event
+      },
     })
     this.user = user
-  }
-
-  /**
-   * Hook that runs before all event creation methods.
-   */
-  private beforeAll(options: Options | undefined) {
-    this.maybeUpdateAnonId(options)
-  }
-
-  /**
-   * Hook that runs after all event creation methods, when the event is available.
-   */
-  private afterAll(ev: SegmentEvent, pageCtx: PageContext | undefined) {
-    addPageContext(ev, pageCtx)
-    this.addIdentity(ev)
   }
 
   /**
@@ -64,9 +56,8 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.track(event, properties, options, globalIntegrations)
-    this.afterAll(ev, pageCtx)
+    addPageContext(ev, pageCtx)
     return ev
   }
 
@@ -78,7 +69,6 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.page(
       category,
       page,
@@ -87,7 +77,6 @@ export class EventFactory extends CoreEventFactory {
       globalIntegrations
     )
     addPageContext(ev, pageCtx)
-    this.afterAll(ev, pageCtx)
     return ev
   }
 
@@ -99,7 +88,6 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.screen(
       category,
       screen,
@@ -107,7 +95,7 @@ export class EventFactory extends CoreEventFactory {
       options,
       globalIntegrations
     )
-    this.afterAll(ev, pageCtx)
+    addPageContext(ev, pageCtx)
     return ev
   }
 
@@ -118,9 +106,8 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.identify(userId, traits, options, globalIntegrations)
-    this.afterAll(ev, pageCtx)
+    addPageContext(ev, pageCtx)
     return ev
   }
 
@@ -131,9 +118,8 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.group(groupId, traits, options, globalIntegrations)
-    this.afterAll(ev, pageCtx)
+    addPageContext(ev, pageCtx)
     return ev
   }
 
@@ -144,9 +130,8 @@ export class EventFactory extends CoreEventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    this.beforeAll(options)
     const ev = super.alias(to, from, options, globalIntegrations)
-    this.afterAll(ev, pageCtx)
+    addPageContext(ev, pageCtx)
     return ev
   }
 }

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -8,7 +8,6 @@ import {
   Traits,
   SegmentEvent,
 } from './interfaces'
-import md5 from 'spark-md5'
 import { addPageContext, PageContext } from '../page'
 
 export * from './interfaces'
@@ -261,7 +260,7 @@ export class EventFactory {
       context,
       integrations: allIntegrations,
       ...overrides,
-      messageId: 'ajs-next-' + md5.hash(JSON.stringify(event) + uuid()),
+      messageId: `ajs-next-${Date.now()}-${uuid()}`,
     }
     addPageContext(newEvent, pageCtx)
 

--- a/packages/browser/src/core/events/index.ts
+++ b/packages/browser/src/core/events/index.ts
@@ -1,5 +1,4 @@
 import { v4 as uuid } from '@lukeed/uuid'
-import { dset } from 'dset'
 import { ID, User } from '../user'
 import {
   Options,
@@ -9,33 +8,69 @@ import {
   SegmentEvent,
 } from './interfaces'
 import { addPageContext, PageContext } from '../page'
+import { EventFactory as CoreEventFactory } from '@segment/analytics-core'
 
 export * from './interfaces'
 
-export class EventFactory {
-  constructor(public user: User) {}
+export class EventFactory extends CoreEventFactory {
+  user: User
+  constructor(user: User) {
+    super({
+      createMessageId: () => `ajs-next-${Date.now()}-${uuid()}`,
+    })
+    this.user = user
+  }
 
-  track(
+  /**
+   * Hook that runs before all event creation methods.
+   */
+  private beforeAll(options: Options | undefined) {
+    this.maybeUpdateAnonId(options)
+  }
+
+  /**
+   * Hook that runs after all event creation methods, when the event is available.
+   */
+  private afterAll(ev: SegmentEvent, pageCtx: PageContext | undefined) {
+    addPageContext(ev, pageCtx)
+    this.addIdentity(ev)
+  }
+
+  /**
+   * Updates the anonymousId *globally* if it's provided in the options.
+   * This should generally be done in the identify method, but some customers rely on this.
+   */
+  private maybeUpdateAnonId(options: Options | undefined): void {
+    options?.anonymousId && this.user.anonymousId(options.anonymousId)
+  }
+
+  /**
+   * add user id / anonymous id to the event
+   */
+  private addIdentity(event: SegmentEvent) {
+    if (this.user.id()) {
+      event.userId = this.user.id()
+    }
+
+    if (this.user.anonymousId()) {
+      event.anonymousId = this.user.anonymousId()
+    }
+  }
+
+  override track(
     event: string,
     properties?: EventProperties,
     options?: Options,
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        event,
-        type: 'track' as const,
-        properties,
-        options: { ...options },
-        integrations: { ...globalIntegrations },
-      },
-      pageCtx
-    )
+    this.beforeAll(options)
+    const ev = super.track(event, properties, options, globalIntegrations)
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 
-  page(
+  override page(
     category: string | null,
     page: string | null,
     properties?: EventProperties,
@@ -43,33 +78,20 @@ export class EventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    const event: Partial<SegmentEvent> = {
-      type: 'page' as const,
-      properties: { ...properties },
-      options: { ...options },
-      integrations: { ...globalIntegrations },
-    }
-
-    if (category !== null) {
-      event.category = category
-      event.properties = event.properties ?? {}
-      event.properties.category = category
-    }
-
-    if (page !== null) {
-      event.name = page
-    }
-
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        ...event,
-      } as SegmentEvent,
-      pageCtx
+    this.beforeAll(options)
+    const ev = super.page(
+      category,
+      page,
+      properties,
+      options,
+      globalIntegrations
     )
+    addPageContext(ev, pageCtx)
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 
-  screen(
+  override screen(
     category: string | null,
     screen: string | null,
     properties?: EventProperties,
@@ -77,193 +99,54 @@ export class EventFactory {
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    const event: Partial<SegmentEvent> = {
-      type: 'screen' as const,
-      properties: { ...properties },
-      options: { ...options },
-      integrations: { ...globalIntegrations },
-    }
-
-    if (category !== null) {
-      event.category = category
-    }
-
-    if (screen !== null) {
-      event.name = screen
-    }
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        ...event,
-      } as SegmentEvent,
-      pageCtx
+    this.beforeAll(options)
+    const ev = super.screen(
+      category,
+      screen,
+      properties,
+      options,
+      globalIntegrations
     )
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 
-  identify(
+  override identify(
     userId: ID,
     traits?: Traits,
     options?: Options,
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        type: 'identify' as const,
-        userId,
-        traits,
-        options: { ...options },
-        integrations: { ...globalIntegrations },
-      },
-      pageCtx
-    )
+    this.beforeAll(options)
+    const ev = super.identify(userId, traits, options, globalIntegrations)
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 
-  group(
+  override group(
     groupId: ID,
     traits?: Traits,
     options?: Options,
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        type: 'group' as const,
-        traits,
-        options: { ...options },
-        integrations: { ...globalIntegrations },
-        groupId,
-      },
-      pageCtx
-    )
+    this.beforeAll(options)
+    const ev = super.group(groupId, traits, options, globalIntegrations)
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 
-  alias(
+  override alias(
     to: string,
     from: string | null,
     options?: Options,
     globalIntegrations?: Integrations,
     pageCtx?: PageContext
   ): SegmentEvent {
-    const base: Partial<SegmentEvent> = {
-      userId: to,
-      type: 'alias' as const,
-      options: { ...options },
-      integrations: { ...globalIntegrations },
-    }
-
-    if (from !== null) {
-      base.previousId = from
-    }
-
-    if (to === undefined) {
-      return this.normalize({
-        ...base,
-        ...this.baseEvent(),
-      } as SegmentEvent)
-    }
-
-    return this.normalize(
-      {
-        ...this.baseEvent(),
-        ...base,
-      } as SegmentEvent,
-      pageCtx
-    )
-  }
-
-  private baseEvent(): Partial<SegmentEvent> {
-    const base: Partial<SegmentEvent> = {
-      integrations: {},
-      options: {},
-    }
-
-    const user = this.user
-
-    if (user.id()) {
-      base.userId = user.id()
-    }
-
-    if (user.anonymousId()) {
-      base.anonymousId = user.anonymousId()
-    }
-
-    return base
-  }
-
-  /**
-   * Builds the context part of an event based on "foreign" keys that
-   * are provided in the `Options` parameter for an Event
-   */
-  private context(event: SegmentEvent): [object, object] {
-    const optionsKeys = ['integrations', 'anonymousId', 'timestamp', 'userId']
-
-    const options = event.options ?? {}
-    delete options['integrations']
-
-    const providedOptionsKeys = Object.keys(options)
-
-    const context = event.options?.context ?? {}
-    const overrides = {}
-
-    providedOptionsKeys.forEach((key) => {
-      if (key === 'context') {
-        return
-      }
-
-      if (optionsKeys.includes(key)) {
-        dset(overrides, key, options[key])
-      } else {
-        dset(context, key, options[key])
-      }
-    })
-
-    return [context, overrides]
-  }
-
-  public normalize(event: SegmentEvent, pageCtx?: PageContext): SegmentEvent {
-    // set anonymousId globally if we encounter an override
-    //segment.com/docs/connections/sources/catalog/libraries/website/javascript/identity/#override-the-anonymous-id-using-the-options-object
-    event.options?.anonymousId &&
-      this.user.anonymousId(event.options.anonymousId)
-
-    const integrationBooleans = Object.keys(event.integrations ?? {}).reduce(
-      (integrationNames, name) => {
-        return {
-          ...integrationNames,
-          [name]: Boolean(event.integrations?.[name]),
-        }
-      },
-      {} as Record<string, boolean>
-    )
-
-    // This is pretty trippy, but here's what's going on:
-    // - a) We don't pass initial integration options as part of the event, only if they're true or false
-    // - b) We do accept per integration overrides (like integrations.Amplitude.sessionId) at the event level
-    // Hence the need to convert base integration options to booleans, but maintain per event integration overrides
-    const allIntegrations = {
-      // Base config integrations object as booleans
-      ...integrationBooleans,
-
-      // Per event overrides, for things like amplitude sessionId, for example
-      ...event.options?.integrations,
-    }
-
-    const [context, overrides] = this.context(event)
-    const { options, ...rest } = event
-
-    const newEvent: SegmentEvent = {
-      timestamp: new Date(),
-      ...rest,
-      context,
-      integrations: allIntegrations,
-      ...overrides,
-      messageId: `ajs-next-${Date.now()}-${uuid()}`,
-    }
-    addPageContext(newEvent, pageCtx)
-
-    return newEvent
+    this.beforeAll(options)
+    const ev = super.alias(to, from, options, globalIntegrations)
+    this.afterAll(ev, pageCtx)
+    return ev
   }
 }

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -1,21 +1,14 @@
 import { EventFactory } from '..'
-import { User } from '../../user'
 import { CoreSegmentEvent } from '../..'
 import { isDate } from 'lodash'
 
 describe('Event Factory', () => {
   let factory: EventFactory
-  let user: User
   const shoes = { product: 'shoes', total: '$35', category: 'category' }
   const shopper = { totalSpent: 100 }
 
   beforeEach(() => {
-    user = {
-      anonymousId: () => undefined,
-      id: () => 'foo',
-    }
     factory = new EventFactory({
-      user,
       createMessageId: () => 'foo',
     })
   })
@@ -46,7 +39,6 @@ describe('Event Factory', () => {
       expect(group.traits).toEqual({ coolkids: true })
       expect(group.type).toEqual('group')
       expect(group.event).toBeUndefined()
-      expect(group.userId).toBe('foo')
       expect(group.anonymousId).toBeUndefined()
     })
 
@@ -58,37 +50,6 @@ describe('Event Factory', () => {
     it('sets the groupId to the message', () => {
       const group = factory.group('coolKidsId', { coolkids: true })
       expect(group.groupId).toEqual('coolKidsId')
-    })
-
-    it('allows userId / anonymousId to be specified as an option', () => {
-      const group = factory.group('my_group_id', undefined, {
-        userId: 'bar',
-        anonymousId: 'foo',
-      })
-      expect(group.userId).toBe('bar')
-      expect(group.anonymousId).toBe('foo')
-    })
-
-    it('allows userId / anonymousId to be overridden', function () {
-      const group = factory.group('my_group_id', undefined, {
-        userId: 'bar',
-        anonymousId: 'foo',
-      })
-      expect(group.userId).toBe('bar')
-      expect(group.anonymousId).toBe('foo')
-    })
-
-    it('uses userId / anonymousId from the user class (if specified)', function () {
-      factory = new EventFactory({
-        createMessageId: () => 'foo',
-        user: {
-          id: () => 'abc',
-          anonymousId: () => '123',
-        },
-      })
-      const group = factory.group('my_group_id')
-      expect(group.userId).toBe('abc')
-      expect(group.anonymousId).toBe('123')
     })
 
     test('should be capable of working with empty traits', () => {
@@ -160,20 +121,6 @@ describe('Event Factory', () => {
     test('adds a timestamp', () => {
       const track = factory.track('Order Completed', shoes)
       expect(track.timestamp).toBeInstanceOf(Date)
-    })
-
-    test('sets an user id', () => {
-      user.id = () => '007'
-
-      const track = factory.track('Order Completed', shoes)
-      expect(track.userId).toEqual('007')
-    })
-
-    test('sets an anonymous id', () => {
-      user.anonymousId = () => 'foo'
-
-      const track = factory.track('Order Completed', shoes)
-      expect(track.anonymousId).toEqual(user.anonymousId())
     })
 
     test('sets options in the context', () => {

--- a/packages/core/src/events/__tests__/index.test.ts
+++ b/packages/core/src/events/__tests__/index.test.ts
@@ -8,9 +8,15 @@ describe('Event Factory', () => {
   const shopper = { totalSpent: 100 }
 
   beforeEach(() => {
-    factory = new EventFactory({
-      createMessageId: () => 'foo',
-    })
+    class TestEventFactory extends EventFactory {
+      constructor() {
+        super({
+          createMessageId: () => 'foo',
+        })
+      }
+    }
+
+    factory = new TestEventFactory()
   })
 
   describe('alias', () => {
@@ -60,7 +66,9 @@ describe('Event Factory', () => {
 
   describe('page', () => {
     test('creates page events', () => {
-      const page = factory.page('category', 'name')
+      const page = factory.page('category', 'name', undefined, {
+        userId: 'foo',
+      })
       expect(page.traits).toBeUndefined()
       expect(page.type).toEqual('page')
       expect(page.event).toBeUndefined()
@@ -69,12 +77,12 @@ describe('Event Factory', () => {
     })
 
     it('accepts properties', () => {
-      const page = factory.page('category', 'name', shoes)
+      const page = factory.page('category', 'name', shoes, { userId: 'foo' })
       expect(page.properties).toEqual(shoes)
     })
 
     it('ignores category and page if not passed in', () => {
-      const page = factory.page(null, null)
+      const page = factory.page(null, null, undefined, { userId: 'foo' })
       expect(page.category).toBeUndefined()
       expect(page.name).toBeUndefined()
     })
@@ -106,7 +114,7 @@ describe('Event Factory', () => {
     })
 
     test('creates track events', () => {
-      const track = factory.track('Order Completed', shoes)
+      const track = factory.track('Order Completed', shoes, { userId: 'foo' })
       expect(track.event).toEqual('Order Completed')
       expect(track.properties).toEqual(shoes)
       expect(track.traits).toBeUndefined()
@@ -114,17 +122,18 @@ describe('Event Factory', () => {
     })
 
     test('adds a message id', () => {
-      const track = factory.track('Order Completed', shoes)
+      const track = factory.track('Order Completed', shoes, { userId: 'foo' })
       expect(typeof track.messageId).toBe('string')
     })
 
     test('adds a timestamp', () => {
-      const track = factory.track('Order Completed', shoes)
+      const track = factory.track('Order Completed', shoes, { userId: 'foo' })
       expect(track.timestamp).toBeInstanceOf(Date)
     })
 
     test('sets options in the context', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         opt1: true,
       })
       expect(track.context).toEqual({ opt1: true })
@@ -134,7 +143,9 @@ describe('Event Factory', () => {
       const track = factory.track(
         'Order Completed',
         shoes,
-        {},
+        {
+          userId: 'foo',
+        },
         {
           amplitude: false,
         }
@@ -148,6 +159,7 @@ describe('Event Factory', () => {
         'Order Completed',
         shoes,
         {
+          userId: 'foo',
           opt1: true,
           integrations: {
             amplitude: false,
@@ -170,6 +182,7 @@ describe('Event Factory', () => {
         'Order Completed',
         shoes,
         {
+          userId: 'foo',
           integrations: {
             Amplitude: {
               sessionId: 'session_123',
@@ -202,6 +215,7 @@ describe('Event Factory', () => {
 
     test('should move foreign options into `context`', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         opt1: true,
         opt2: '🥝',
         integrations: {
@@ -214,6 +228,7 @@ describe('Event Factory', () => {
 
     test('should not move known options into `context`', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         opt1: true,
         opt2: '🥝',
         integrations: {
@@ -238,6 +253,7 @@ describe('Event Factory', () => {
     test('accepts a timestamp', () => {
       const timestamp = new Date()
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         timestamp,
       })
 
@@ -247,6 +263,7 @@ describe('Event Factory', () => {
 
     test('accepts traits', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         traits: {
           cell: '📱',
         },
@@ -260,6 +277,7 @@ describe('Event Factory', () => {
 
     test('accepts a context object', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         context: {
           library: {
             name: 'ajs-next',
@@ -278,6 +296,7 @@ describe('Event Factory', () => {
 
     test('merges a context object', () => {
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         foreignProp: '🇧🇷',
         context: {
           innerProp: '👻',
@@ -301,6 +320,7 @@ describe('Event Factory', () => {
     test('accepts a messageId', () => {
       const messageId = 'business-id-123'
       const track = factory.track('Order Completed', shoes, {
+        userId: 'foo',
         messageId,
       })
 
@@ -312,7 +332,7 @@ describe('Event Factory', () => {
       const event = factory.track(
         'Order Completed',
         { ...shoes },
-        { timestamp: undefined, traits: { foo: 123 } }
+        { userId: 'foo', timestamp: undefined, traits: { foo: 123 } }
       )
 
       expect(typeof event.timestamp).toBe('object')

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -14,7 +14,7 @@ import { pickBy } from '../utils/pick'
 import type { RemoveIndexSignature } from '../utils/ts-helpers'
 import { validateEvent } from '../validation/assertions'
 
-export type onEventCb = ({
+export type onEventMethodCallCb = ({
   type,
   options,
 }: {
@@ -22,8 +22,8 @@ export type onEventCb = ({
   options?: CoreOptions
 }) => void
 
-export type EventUpdater = (event: CoreSegmentEvent) => void
-export type EventValidator = (event: CoreSegmentEvent) => void
+export type UpdateEventFn = (event: CoreSegmentEvent) => void
+export type ValidateEventFn = (event: CoreSegmentEvent) => void
 
 export interface EventFactorySettings {
   /**
@@ -33,15 +33,15 @@ export interface EventFactorySettings {
   /**
    * Update / augment an event
    */
-  updateEvent?: EventUpdater
+  updateEvent?: UpdateEventFn
   /**
    * callback whenever an event method is called
    */
-  onEventMethodCall?: onEventCb
+  onEventMethodCall?: onEventMethodCallCb
   /**
    * additional validation to run on each event
    */
-  validateEvent?: EventValidator
+  validateEvent?: ValidateEventFn
 }
 
 /**
@@ -50,9 +50,9 @@ export interface EventFactorySettings {
  */
 export abstract class EventFactory {
   createMessageId: EventFactorySettings['createMessageId']
-  onEventMethodCall: onEventCb
-  updateEvent?: EventUpdater
-  validateEvent?: EventValidator
+  onEventMethodCall: onEventMethodCallCb
+  updateEvent?: UpdateEventFn
+  validateEvent?: ValidateEventFn
 
   constructor(settings: EventFactorySettings) {
     this.createMessageId = settings.createMessageId

--- a/packages/core/src/user/index.ts
+++ b/packages/core/src/user/index.ts
@@ -1,7 +1,1 @@
 export type ID = string | null | undefined
-
-// TODO: this is a base user
-export interface User {
-  id(): ID
-  anonymousId(): ID
-}

--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -74,4 +74,5 @@ export function validateEvent(event?: CoreSegmentEvent | null) {
   if (['group', 'identify'].includes(event.type)) {
     assertTraits(event)
   }
+  assertUserIdentity(event)
 }

--- a/packages/core/src/validation/assertions.ts
+++ b/packages/core/src/validation/assertions.ts
@@ -74,6 +74,4 @@ export function validateEvent(event?: CoreSegmentEvent | null) {
   if (['group', 'identify'].includes(event.type)) {
     assertTraits(event)
   }
-
-  assertUserIdentity(event)
 }


### PR DESCRIPTION
Finally, `EventFactory` is now shared between node and browser.

Features / Changes:
- Update messageId algorithm to be consistent with node (analytics-next-<epochdate>-uuid)
- Browser will throw an error in the EventFactory (not just in a plugin) if the event is invalid
- *alert* Validation now checks that one of userId/anonId/groupId/previousId is available and throws an error (to have consistency with the node validation). I assume that Browser will always have one of these values defined at this point (The user instance, etc) -- the only edge case would be if an instance had added identity resolution later.