### PR TITLE
fix: fixes buffering for legacy destinations

### DIFF
--- a/.changeset/three-turkeys-talk.md
+++ b/.changeset/three-turkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+fix: fixes buffering for legacy destinations

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -192,7 +192,7 @@ export class LegacyDestination implements InternalPluginWithAddMiddleware {
     return (
       // page events can't be buffered because of destinations that automatically add page views
       ctx.event.type !== 'page' &&
-      (isOffline() || this._ready === false || this._initialized === false)
+      (isOffline() || this._ready !== true || this._initialized !== true)
     )
   }
 
@@ -313,6 +313,11 @@ export class LegacyDestination implements InternalPluginWithAddMiddleware {
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     setTimeout(async () => {
+      if (isOffline() || this._ready !== true || this._initialized !== true) {
+        this.scheduleFlush()
+        return
+      }
+
       this.flushing = true
       this.buffer = await flushQueue(this, this.buffer)
       this.flushing = false


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

# Fixes the Classic Destinations buffering to properly buffer events while not loaded

- Fixed `shouldBuffer` check as the starting state changed from `false` to `undefined` for ready/initialized. Hence events were bypassing buffer all the time.
- Changed the behaviour of `scheduleFlush` as previously it was being called after the timeout and ignoring if the plugin had finished initializing. The retry would work properly if the plugin throws an error but Bing/FB don't hence it was marking those events as sent.
  - TODO: This logic could be refactored in the future. Seems particularly convoluted and it should probably listen to `onReady` and `onInitialized` instead of retrying at intervals.

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
