### PR TITLE
fixes issue where a destination plugin loading with an error caused other plugins to be removed

### DIFF
--- a/.changeset/strong-taxis-give.md
+++ b/.changeset/strong-taxis-give.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-core': patch
+---
+
+Fixes an issue introduced in v1.66.0 that caused analytics plugins to be removed from event processing if a destination threw an error while loading.

--- a/packages/core/src/queue/__tests__/event-queue.test.ts
+++ b/packages/core/src/queue/__tests__/event-queue.test.ts
@@ -4,7 +4,7 @@ import { CoreAnalytics } from '../../analytics'
 import { pWhile } from '../../utils/p-while'
 import * as timer from '../../priority-queue/backoff'
 import { ContextCancelation } from '../../context'
-import { CorePlugin } from '../../plugins'
+import { CorePlugin, PluginType } from '../../plugins'
 import { pTimeout } from '../../callback'
 import { TestCtx, TestEventQueue } from '../../../test-helpers'
 
@@ -606,6 +606,32 @@ describe('Flushing', () => {
       expect(amplitude.track).toHaveBeenCalled()
       expect(segmentio.track).toHaveBeenCalled()
     })
+  })
+})
+
+describe('register', () => {
+  it('only filters out failed destinations after loading', async () => {
+    const eq = new TestEventQueue()
+    const goodDestinationPlugin = {
+      ...testPlugin,
+      name: 'good destination',
+      type: 'destination' as PluginType,
+    }
+    const failingPlugin = {
+      ...testPlugin,
+      name: 'failing',
+      type: 'destination' as PluginType,
+
+      load: () => Promise.reject(new Error('I was born to throw')),
+    }
+
+    const plugins = [testPlugin, goodDestinationPlugin, failingPlugin]
+    const promises = plugins.map((p) => eq.register(TestCtx.system(), p, ajs))
+    await Promise.all(promises)
+
+    expect(eq.plugins.length).toBe(2)
+    expect(eq.plugins).toContain(testPlugin)
+    expect(eq.plugins).toContain(goodDestinationPlugin)
   })
 })
 

--- a/packages/core/src/queue/event-queue.ts
+++ b/packages/core/src/queue/event-queue.ts
@@ -61,7 +61,8 @@ export abstract class CoreEventQueue<
           error: err,
         })
 
-        this.plugins = this.plugins.filter((p) => p === plugin)
+        // Filter out the failed plugin by excluding it from the list
+        this.plugins = this.plugins.filter((p) => p !== plugin)
       })
     } else {
       await plugin.load(ctx, instance)


### PR DESCRIPTION
Fixes #1074 

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
