### PR TITLE
Fix segment ga4 bug

### DIFF
--- a/packages/browser/src/plugins/env-enrichment/index.ts
+++ b/packages/browser/src/plugins/env-enrichment/index.ts
@@ -135,6 +135,7 @@ class EnvironmentEnrichmentPlugin implements Plugin {
 
   name = 'Page Enrichment'
   type: PluginType = 'before'
+  critical = true
   version = '0.1.0'
   isLoaded = () => true
   load = async (_ctx: Context, instance: Analytics) => {

--- a/packages/browser/src/plugins/schema-filter/index.ts
+++ b/packages/browser/src/plugins/schema-filter/index.ts
@@ -77,6 +77,7 @@ export function schemaFilter(
 
   return {
     name: 'Schema Filter',
+    critical: true,
     version: '0.1.0',
     isLoaded: () => true,
     load: () => Promise.resolve(),

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,11 +1,6 @@
 import type { CoreAnalytics } from '../analytics'
 import type { CoreContext } from '../context'
 
-interface CorePluginConfig {
-  options: any
-  priority: 'critical' | 'non-critical' // whether AJS should expect this plugin to be loaded before starting event delivery
-}
-
 export type PluginType =
   | 'before'
   | 'after'
@@ -25,12 +20,12 @@ export interface CorePlugin<
   alternativeNames?: string[]
   version: string
   type: PluginType
+  /**
+   * if critical is set to true, will throw an error / abort the entire pipeline if the load() method throws an error.
+   */
+  critical?: boolean
   isLoaded: () => boolean
-  load: (
-    ctx: Ctx,
-    instance: Analytics,
-    config?: CorePluginConfig
-  ) => Promise<unknown>
+  load: (ctx: Ctx, instance: Analytics) => Promise<unknown>
 
   unload?: (ctx: Ctx, instance: Analytics) => Promise<unknown> | unknown
   ready?: () => Promise<unknown>

--- a/packages/core/src/queue/__tests__/extension-flushing.test.ts
+++ b/packages/core/src/queue/__tests__/extension-flushing.test.ts
@@ -53,12 +53,13 @@ describe('Registration', () => {
     expect(load).toHaveBeenCalledWith(ctx, ajs)
   })
 
-  test('fails if plugin cant be loaded', async () => {
+  test('fails if plugin cant be loaded AND is type critical', async () => {
     const eq = new EventQueue()
 
     const plugin: Plugin = {
       name: 'test',
       type: 'before',
+      critical: true,
       version: '0.1.0',
       load: () => Promise.reject(new Error('👻')),
       isLoaded: () => false,

--- a/packages/core/src/queue/event-queue.ts
+++ b/packages/core/src/queue/event-queue.ts
@@ -74,7 +74,11 @@ export abstract class CoreEventQueue<
     } else {
       // for non-destinations plugins, we do need to wait for them to load
       // there is a gotcha: action destinations can have actions that are not of type 'destination', and we await on those
-      await plugin.load(ctx, instance).catch(handleLoadError)
+      try {
+        await plugin.load(ctx, instance)
+      } catch (err) {
+        handleLoadError(err)
+      }
     }
   }
 

--- a/packages/core/src/queue/event-queue.ts
+++ b/packages/core/src/queue/event-queue.ts
@@ -50,6 +50,8 @@ export abstract class CoreEventQueue<
     plugin: Plugin,
     instance: CoreAnalytics
   ): Promise<void> {
+    this.plugins.push(plugin)
+
     const handleLoadError = (err: any) => {
       if (plugin.critical) {
         throw err
@@ -74,8 +76,6 @@ export abstract class CoreEventQueue<
       // there is a gotcha: action destinations can have actions that are not of type 'destination', and we await on those
       await plugin.load(ctx, instance).catch(handleLoadError)
     }
-
-    this.plugins.push(plugin)
   }
 
   async deregister(

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -406,7 +406,6 @@ describe('version', () => {
 describe('ready', () => {
   it('should only resolve when plugin registration is done', async () => {
     const analytics = createTestAnalytics()
-    expect(analytics['_queue'].plugins.length).toBe(0)
     const result = await analytics.ready
     expect(result).toBeUndefined()
     expect(analytics['_queue'].plugins.length).toBeGreaterThan(0)


### PR DESCRIPTION
Addresses an issue where, if one of the non-destination actions fails to load/is blocked, the entire SDK fails to load. This is most notable in GA4, where, if GA was blocked, Segment initialization would fail.