### PR TITLE
Rename `LegacySettings` to `CDNSettings`

### DIFF
--- a/.changeset/ninety-gifts-march.md
+++ b/.changeset/ninety-gifts-march.md
@@ -1,4 +1,4 @@
 ---
-'@segment/analytics-next': patch
+'@segment/analytics-next': minor
 ---
-Internal refactor to change name `legacySettings` -> `cdnSettings`, in order to make things less confusing. This should not have any runtime effects.
+Refactor to change interface name from `legacySettings` -> `cdnSettings`, in order to clarify code.

--- a/.changeset/ninety-gifts-march.md
+++ b/.changeset/ninety-gifts-march.md
@@ -1,0 +1,4 @@
+---
+'@segment/analytics-next': patch
+---
+Internal refactor to change name `legacySettings` -> `cdnSettings`, in order to make things less confusing. This should not have any runtime effects.

--- a/packages/browser/src/browser/__tests__/csp-detection.test.ts
+++ b/packages/browser/src/browser/__tests__/csp-detection.test.ts
@@ -1,11 +1,11 @@
 import jsdom, { JSDOM } from 'jsdom'
 import unfetch from 'unfetch'
-import { LegacySettings } from '..'
+import { CDNSettings } from '..'
 import { pWhile } from '../../lib/p-while'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
 import * as Factory from '../../test-helpers/factories'
 
-const cdnResponse: LegacySettings = {
+const cdnResponse: CDNSettings = {
   integrations: {
     Zapier: {
       type: 'server',

--- a/packages/browser/src/browser/__tests__/standalone-errors.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-errors.test.ts
@@ -1,12 +1,12 @@
 import jsdom, { JSDOM } from 'jsdom'
-import { AnalyticsBrowser, LegacySettings } from '..'
+import { AnalyticsBrowser, CDNSettings } from '..'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
 import { pWhile } from '../../lib/p-while'
 import unfetch from 'unfetch'
 import { RemoteMetrics } from '../../core/stats/remote-metrics'
 import * as Factory from '../../test-helpers/factories'
 
-const cdnResponse: LegacySettings = {
+const cdnResponse: CDNSettings = {
   integrations: {
     Zapier: {
       type: 'server',

--- a/packages/browser/src/browser/__tests__/standalone.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone.test.ts
@@ -1,12 +1,12 @@
 import jsdom, { JSDOM } from 'jsdom'
 import unfetch from 'unfetch'
-import { LegacySettings } from '..'
+import { CDNSettings } from '..'
 import { pWhile } from '../../lib/p-while'
 import { snippet } from '../../tester/__fixtures__/segment-snippet'
 import * as Factory from '../../test-helpers/factories'
 import { getGlobalAnalytics } from '../..'
 
-const cdnResponse: LegacySettings = {
+const cdnResponse: CDNSettings = {
   integrations: {
     Zapier: {
       type: 'server',

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -36,7 +36,7 @@ import { attachInspector } from '../core/inspector'
 import { Stats } from '../core/stats'
 import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 
-export interface RemoteIntegrationConfig {
+export interface RemoteIntegrationSettings {
   /* @deprecated - This does not indicate browser types anymore */
   type?: string
 
@@ -76,7 +76,7 @@ export interface RemoteIntegrationConfig {
  */
 export interface CDNSettings {
   integrations: {
-    [creationName: string]: RemoteIntegrationConfig
+    [creationName: string]: RemoteIntegrationSettings
   }
 
   middlewareSettings?: {

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -36,14 +36,14 @@ import { attachInspector } from '../core/inspector'
 import { Stats } from '../core/stats'
 import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 
-export interface LegacyIntegrationConfiguration {
+export interface RemoteIntegrationConfig {
   /* @deprecated - This does not indicate browser types anymore */
   type?: string
 
   versionSettings?: {
     version?: string
     override?: string
-    componentTypes?: Array<'browser' | 'android' | 'ios' | 'server'>
+    componentTypes?: ('browser' | 'android' | 'ios' | 'server')[]
   }
 
   bundlingStatus?: string
@@ -67,9 +67,12 @@ export interface LegacyIntegrationConfiguration {
   [key: string]: any
 }
 
+/**
+ * The remote settings object, typically fetched
+ */
 export interface CDNSettings {
   integrations: {
-    [name: string]: LegacyIntegrationConfiguration
+    [creationName: string]: RemoteIntegrationConfig
   }
 
   middlewareSettings?: {

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -72,7 +72,8 @@ export interface RemoteIntegrationSettings {
 }
 
 /**
- * The remote settings object, typically fetched
+ * The remote settings object for a source, typically fetched from the Segment CDN.
+ * Warning: this is an *unstable* object.
  */
 export interface CDNSettings {
   integrations: {

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -46,7 +46,11 @@ export interface RemoteIntegrationConfig {
     componentTypes?: ('browser' | 'android' | 'ios' | 'server')[]
   }
 
-  bundlingStatus?: string
+  /**
+   * We know if an integration is device mode if it has `bundlingStatus: 'bundled'` and the `browser` componentType in `versionSettings`.
+   * History: The term 'bundle' is left over from before action destinations, when a device mode destinations were 'bundled' in a custom bundle for every analytics.js source.
+   */
+  bundlingStatus?: 'bundled' | 'unbundled'
 
   /**
    * Consent settings for the integration
@@ -54,7 +58,7 @@ export interface RemoteIntegrationConfig {
   consentSettings?: {
     /**
      * Consent categories for the integration
-     * @example ["Analytics", "Advertising", "CAT001"]
+     * @example ["CAT001", "CAT002"]
      */
     categories: string[]
   }

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -41,7 +41,7 @@ import { PriorityQueue } from '../../lib/priority-queue'
 import { getGlobal } from '../../lib/get-global'
 import { AnalyticsClassic, AnalyticsCore } from './interfaces'
 import { HighEntropyHint } from '../../lib/client-hints/interfaces'
-import type { LegacySettings } from '../../browser'
+import type { CDNSettings } from '../../browser'
 import {
   CookieOptions,
   MemoryStorage,
@@ -109,7 +109,7 @@ export interface InitOptions {
    * This callback allows you to update/mutate CDN Settings.
    * This is called directly after settings are fetched from the CDN.
    */
-  updateCDNSettings?: (settings: LegacySettings) => LegacySettings
+  updateCDNSettings?: (settings: CDNSettings) => CDNSettings
   /**
    * Disables or sets constraints on processing of query string parameters
    */
@@ -143,9 +143,7 @@ export interface InitOptions {
    * disable: (cdnSettings) => cdnSettings.foo === 'bar'
    * ```
    */
-  disable?:
-    | boolean
-    | ((cdnSettings: LegacySettings) => boolean | Promise<boolean>)
+  disable?: boolean | ((cdnSettings: CDNSettings) => boolean | Promise<boolean>)
 }
 
 /* analytics-classic stubs */

--- a/packages/browser/src/lib/merged-options.ts
+++ b/packages/browser/src/lib/merged-options.ts
@@ -1,5 +1,5 @@
 import { JSONObject, Options } from '../core/events/interfaces'
-import { LegacySettings } from '../browser'
+import { CDNSettings } from '../browser'
 
 /**
  * Merge legacy settings and initialized Integration option overrides.
@@ -11,7 +11,7 @@ import { LegacySettings } from '../browser'
  * the Analytics constructor.
  */
 export function mergedOptions(
-  settings: LegacySettings,
+  cdnSettings: CDNSettings,
   options: Options
 ): Record<string, JSONObject> {
   const optionOverrides = Object.entries(options.integrations ?? {}).reduce(
@@ -31,7 +31,7 @@ export function mergedOptions(
     {} as Record<string, JSONObject>
   )
 
-  return Object.entries(settings.integrations).reduce(
+  return Object.entries(cdnSettings.integrations).reduce(
     (integrationSettings, [integration, settings]) => {
       return {
         ...integrationSettings,

--- a/packages/browser/src/plugins/ajs-destination/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/ajs-destination/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import jsdom from 'jsdom'
 import unfetch from 'unfetch'
 import { ajsDestinations, LegacyDestination } from '..'
 import { Analytics } from '../../../core/analytics'
-import { LegacySettings } from '../../../browser'
+import { CDNSettings } from '../../../browser'
 import { Context } from '../../../core/context'
 import { Plan } from '../../../core/events'
 import { tsubMiddleware } from '../../routing-middleware'
@@ -11,7 +11,7 @@ import { AMPLITUDE_WRITEKEY } from '../../../test-helpers/test-writekeys'
 import { PersistedPriorityQueue } from '../../../lib/priority-queue/persisted'
 import * as Factory from '../../../test-helpers/factories'
 
-const cdnResponse: LegacySettings = {
+const cdnResponse: CDNSettings = {
   integrations: {
     Zapier: {
       type: 'server',

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -1,7 +1,7 @@
 import { Integrations, JSONObject } from '../../core/events'
 import { Alias, Facade, Group, Identify, Page, Track } from '@segment/facade'
 import { Analytics, InitOptions } from '../../core/analytics'
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { isOffline, isOnline } from '../../core/connection'
 import { Context, ContextCancelation } from '../../core/context'
 import { isServer } from '../../core/environment'
@@ -331,7 +331,7 @@ export class LegacyDestination implements InternalPluginWithAddMiddleware {
 
 export function ajsDestinations(
   writeKey: string,
-  settings: LegacySettings,
+  settings: CDNSettings,
   globalIntegrations: Integrations = {},
   options: InitOptions = {},
   routingMiddleware?: DestinationMiddlewareFunction,

--- a/packages/browser/src/plugins/ajs-destination/loader.ts
+++ b/packages/browser/src/plugins/ajs-destination/loader.ts
@@ -1,5 +1,5 @@
 import { Analytics } from '../../core/analytics'
-import { LegacyIntegrationConfiguration } from '../../browser'
+import { RemoteIntegrationConfig } from '../../browser'
 import { getNextIntegrationsURL } from '../../lib/parse-cdn'
 import { Context } from '../../core/context'
 import { User } from '../../core/user'
@@ -119,11 +119,11 @@ export async function unloadIntegration(
 }
 
 export function resolveVersion(
-  settings?: LegacyIntegrationConfiguration
+  integrationConfig?: RemoteIntegrationConfig
 ): string {
   return (
-    settings?.versionSettings?.override ??
-    settings?.versionSettings?.version ??
+    integrationConfig?.versionSettings?.override ??
+    integrationConfig?.versionSettings?.version ??
     'latest'
   )
 }

--- a/packages/browser/src/plugins/ajs-destination/loader.ts
+++ b/packages/browser/src/plugins/ajs-destination/loader.ts
@@ -1,5 +1,5 @@
 import { Analytics } from '../../core/analytics'
-import { RemoteIntegrationConfig } from '../../browser'
+import { RemoteIntegrationSettings } from '../../browser'
 import { getNextIntegrationsURL } from '../../lib/parse-cdn'
 import { Context } from '../../core/context'
 import { User } from '../../core/user'
@@ -119,7 +119,7 @@ export async function unloadIntegration(
 }
 
 export function resolveVersion(
-  integrationConfig?: RemoteIntegrationConfig
+  integrationConfig?: RemoteIntegrationSettings
 ): string {
   return (
     integrationConfig?.versionSettings?.override ??

--- a/packages/browser/src/plugins/ajs-destination/utils.ts
+++ b/packages/browser/src/plugins/ajs-destination/utils.ts
@@ -1,9 +1,9 @@
 import { Integrations } from '@segment/analytics-core'
-import { RemoteIntegrationConfig } from '../..'
+import { RemoteIntegrationSettings } from '../..'
 
 export const isInstallableIntegration = (
   name: string,
-  integrationSettings: RemoteIntegrationConfig
+  integrationSettings: RemoteIntegrationSettings
 ) => {
   const { type, bundlingStatus, versionSettings } = integrationSettings
   // We use `!== 'unbundled'` (versus `=== 'bundled'`) to be inclusive of

--- a/packages/browser/src/plugins/ajs-destination/utils.ts
+++ b/packages/browser/src/plugins/ajs-destination/utils.ts
@@ -1,9 +1,9 @@
 import { Integrations } from '@segment/analytics-core'
-import { LegacyIntegrationConfiguration } from '../..'
+import { RemoteIntegrationConfig } from '../..'
 
 export const isInstallableIntegration = (
   name: string,
-  integrationSettings: LegacyIntegrationConfiguration
+  integrationSettings: RemoteIntegrationConfig
 ) => {
   const { type, bundlingStatus, versionSettings } = integrationSettings
   // We use `!== 'unbundled'` (versus `=== 'bundled'`) to be inclusive of

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import braze from '@segment/analytics-browser-actions-braze'
 
 import * as loader from '../../../lib/load-script'
 import { ActionDestination, PluginFactory, remoteLoader } from '..'
-import { AnalyticsBrowser, LegacySettings } from '../../../browser'
+import { AnalyticsBrowser, CDNSettings } from '../../../browser'
 import { InitOptions } from '../../../core/analytics'
 import { Context } from '../../../core/context'
 import { tsubMiddleware } from '../../routing-middleware'
@@ -520,7 +520,7 @@ describe('Remote Loader', () => {
   })
 
   it('accepts settings overrides from merged integrations', async () => {
-    const cdnSettings: LegacySettings = {
+    const cdnSettings: CDNSettings = {
       integrations: {
         remotePlugin: {
           name: 'Charlie Brown',
@@ -785,7 +785,7 @@ describe('Remote Loader', () => {
       track: (ctx: Context) => ctx,
     }
 
-    const cdnSettings: LegacySettings = {
+    const cdnSettings: CDNSettings = {
       integrations: {},
       middlewareSettings: {
         routingRules: [
@@ -856,7 +856,7 @@ describe('Remote Loader', () => {
       track: (ctx: Context) => ctx,
     }
 
-    const cdnSettings: LegacySettings = {
+    const cdnSettings: CDNSettings = {
       integrations: {},
       middlewareSettings: {
         routingRules: [
@@ -923,7 +923,7 @@ describe('Remote Loader', () => {
       },
     }
 
-    const cdnSettings: LegacySettings = {
+    const cdnSettings: CDNSettings = {
       integrations: {},
       remotePlugins: [
         {

--- a/packages/browser/src/plugins/remote-loader/index.ts
+++ b/packages/browser/src/plugins/remote-loader/index.ts
@@ -1,5 +1,5 @@
 import type { Integrations } from '../../core/events/interfaces'
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { JSONObject, JSONValue } from '../../core/events'
 import { Plugin, InternalPluginWithAddMiddleware } from '../../core/plugin'
 import { loadScript } from '../../lib/load-script'
@@ -254,7 +254,7 @@ async function loadPluginFactory(
 }
 
 export async function remoteLoader(
-  settings: LegacySettings,
+  settings: CDNSettings,
   userIntegrations: Integrations,
   mergedIntegrations: Record<string, JSONObject>,
   options?: InitOptions,

--- a/packages/browser/src/plugins/remote-middleware/index.ts
+++ b/packages/browser/src/plugins/remote-middleware/index.ts
@@ -1,4 +1,4 @@
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { Context } from '../../core/context'
 import { isServer } from '../../core/environment'
 import { loadScript } from '../../lib/load-script'
@@ -7,7 +7,7 @@ import { MiddlewareFunction } from '../middleware'
 
 export async function remoteMiddlewares(
   ctx: Context,
-  settings: LegacySettings,
+  settings: CDNSettings,
   obfuscate?: boolean
 ): Promise<MiddlewareFunction[]> {
   if (isServer()) {

--- a/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/schema-filter/__tests__/index.test.ts
@@ -2,10 +2,10 @@ import { Plugin } from '../../../core/plugin'
 import { Analytics } from '../../../core/analytics'
 import { Context } from '../../../core/context'
 import { schemaFilter } from '..'
-import { LegacySettings } from '../../../browser'
+import { CDNSettings } from '../../../browser'
 import { segmentio, SegmentioSettings } from '../../segmentio'
 
-const settings: LegacySettings = {
+const settings: CDNSettings = {
   integrations: {
     'Braze Web Mode (Actions)': {},
     // note that Fullstory's name here doesn't contain 'Actions'

--- a/packages/browser/src/plugins/schema-filter/index.ts
+++ b/packages/browser/src/plugins/schema-filter/index.ts
@@ -1,4 +1,4 @@
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { Context } from '../../core/context'
 import { PlanEvent, TrackPlan } from '../../core/events/interfaces'
 import { Plugin } from '../../core/plugin'
@@ -7,7 +7,7 @@ import { RemotePlugin } from '../remote-loader'
 
 function disabledActionDestinations(
   plan: PlanEvent | undefined,
-  settings: LegacySettings
+  settings: CDNSettings
 ): { [destination: string]: string[] } {
   if (!plan || !Object.keys(plan)) {
     return {}
@@ -46,7 +46,7 @@ function disabledActionDestinations(
 
 export function schemaFilter(
   track: TrackPlan | undefined,
-  settings: LegacySettings
+  settings: CDNSettings
 ): Plugin {
   function filter(ctx: Context): Context {
     const plan = track

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -1,6 +1,6 @@
 import { Facade } from '@segment/facade'
 import { Analytics } from '../../core/analytics'
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { isOffline } from '../../core/connection'
 import { Context } from '../../core/context'
 import { Plugin } from '../../core/plugin'
@@ -53,7 +53,7 @@ function onAlias(analytics: Analytics, json: JSON): JSON {
 export function segmentio(
   analytics: Analytics,
   settings?: SegmentioSettings,
-  integrations?: LegacySettings['integrations']
+  integrations?: CDNSettings['integrations']
 ): Plugin {
   // Attach `pagehide` before buffer is created so that inflight events are added
   // to the buffer before the buffer persists events in its own `pagehide` handler.

--- a/packages/browser/src/plugins/segmentio/normalize.ts
+++ b/packages/browser/src/plugins/segmentio/normalize.ts
@@ -1,5 +1,5 @@
 import { Analytics } from '../../core/analytics'
-import { LegacySettings } from '../../browser'
+import { CDNSettings } from '../../browser'
 import { SegmentFacade } from '../../lib/to-facade'
 import { SegmentioSettings } from './index'
 
@@ -7,7 +7,7 @@ export function normalize(
   analytics: Analytics,
   json: ReturnType<SegmentFacade['json']>,
   settings?: SegmentioSettings,
-  integrations?: LegacySettings['integrations']
+  integrations?: CDNSettings['integrations']
 ): object {
   const user = analytics.user()
 

--- a/packages/browser/src/test-helpers/fixtures/create-fetch-method.ts
+++ b/packages/browser/src/test-helpers/fixtures/create-fetch-method.ts
@@ -1,9 +1,9 @@
-import { LegacySettings } from '../..'
+import { CDNSettings } from '../..'
 import { createSuccess } from '../factories'
 import { cdnSettingsMinimal } from './cdn-settings'
 
 export const createMockFetchImplementation = (
-  cdnSettings: Partial<LegacySettings> = cdnSettingsMinimal
+  cdnSettings: Partial<CDNSettings> = cdnSettingsMinimal
 ) => {
   return (...[url, req]: Parameters<typeof fetch>) => {
     const reqUrl = url.toString()

--- a/packages/test-helpers/src/analytics/cdn-settings-builder.ts
+++ b/packages/test-helpers/src/analytics/cdn-settings-builder.ts
@@ -1,5 +1,5 @@
-import type { LegacySettings } from '@segment/analytics-next'
-type RemotePlugin = NonNullable<LegacySettings['remotePlugins']>[0]
+import type { CDNSettings } from '@segment/analytics-next'
+type RemotePlugin = NonNullable<CDNSettings['remotePlugins']>[0]
 
 export type DestinationSettingsBuilderConfig = Partial<RemotePlugin> & {
   creationName: string
@@ -11,13 +11,13 @@ export type DestinationSettingsBuilderConfig = Partial<RemotePlugin> & {
 }
 
 export class CDNSettingsBuilder {
-  private settings: LegacySettings
+  private settings: CDNSettings
   constructor({
     writeKey,
     baseCDNSettings,
   }: {
     writeKey?: string
-    baseCDNSettings?: LegacySettings
+    baseCDNSettings?: CDNSettings
   } = {}) {
     const settings = baseCDNSettings || {
       integrations: {


### PR DESCRIPTION
As someone who was once new to the codebase, this single-handedly was one of the most confusing parts of the API. There is nothing `legacy` about these settings, and they have no particular special relationship to `LegacyDestination`.