### PR TITLE
Be more selective about signal redaction

### DIFF
--- a/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
@@ -1,15 +1,17 @@
 import { CDNSettingsBuilder } from '@internal/test-helpers'
-import { Page, Request } from '@playwright/test'
+import { Page } from '@playwright/test'
 import { logConsole } from './log-console'
-import { SegmentEvent } from '@segment/analytics-next'
 import { Signal, SignalsPluginSettingsConfig } from '@segment/analytics-signals'
-import { PageNetworkUtils, SignalAPIRequestBuffer } from './network-utils'
+import {
+  PageNetworkUtils,
+  SignalAPIRequestBuffer,
+  TrackingAPIRequestBuffer,
+} from './network-utils'
 
 export class BasePage {
   protected page!: Page
   public signalsAPI = new SignalAPIRequestBuffer()
-  public lastTrackingApiReq!: Request
-  public trackingApiReqs: SegmentEvent[] = []
+  public trackingAPI = new TrackingAPIRequestBuffer()
   public url: string
   public edgeFnDownloadURL = 'https://cdn.edgefn.segment.com/MY-WRITEKEY/foo.js'
   public edgeFn!: string
@@ -28,9 +30,7 @@ export class BasePage {
    * and wait for analytics and signals to be initialized
    */
   async loadAndWait(...args: Parameters<BasePage['load']>) {
-    await this.load(...args)
-    await this.waitForSignalsAssets()
-    return this
+    await Promise.all([this.load(...args), this.waitForSettings()])
   }
 
   /**
@@ -39,22 +39,24 @@ export class BasePage {
   async load(
     page: Page,
     edgeFn: string,
-    signalSettings: Partial<SignalsPluginSettingsConfig> = {}
+    signalSettings: Partial<SignalsPluginSettingsConfig> = {},
+    options: { updateURL?: (url: string) => string } = {}
   ) {
     logConsole(page)
     this.page = page
     this.network = new PageNetworkUtils(page)
     this.edgeFn = edgeFn
     await this.setupMockedRoutes()
-    await this.page.goto(this.url)
+    const url = options.updateURL ? options.updateURL(this.url) : this.url
+    await this.page.goto(url)
     await this.invokeAnalyticsLoad(signalSettings)
   }
 
   /**
    * Wait for analytics and signals to be initialized
+   * We could do the same thing with analytics.ready() and signalsPlugin.ready()
    */
-  async waitForSignalsAssets() {
-    // this is kind of an approximation of full initialization
+  async waitForSettings() {
     return Promise.all([
       this.waitForCDNSettingsResponse(),
       this.waitForEdgeFunctionResponse(),
@@ -72,7 +74,6 @@ export class BasePage {
       ({ signalSettings }) => {
         window.signalsPlugin = new window.SignalsPlugin({
           disableSignalsRedaction: true,
-          flushInterval: 1000,
           ...signalSettings,
         })
         window.analytics.load({
@@ -87,7 +88,7 @@ export class BasePage {
 
   private async setupMockedRoutes() {
     // clear any existing saved requests
-    this.trackingApiReqs = []
+    this.trackingAPI.clear()
     this.signalsAPI.clear()
 
     await Promise.all([
@@ -99,11 +100,10 @@ export class BasePage {
 
   async mockTrackingApi() {
     await this.page.route('https://api.segment.io/v1/*', (route, request) => {
-      this.lastTrackingApiReq = request
-      this.trackingApiReqs.push(request.postDataJSON())
       if (request.method().toLowerCase() !== 'post') {
         throw new Error(`Unexpected method: ${request.method()}`)
       }
+      this.trackingAPI.addRequest(request)
       return route.fulfill({
         contentType: 'application/json',
         status: 201,
@@ -122,10 +122,10 @@ export class BasePage {
     await this.page.route(
       'https://signals.segment.io/v1/*',
       (route, request) => {
-        this.signalsAPI.addRequest(request)
         if (request.method().toLowerCase() !== 'post') {
           throw new Error(`Unexpected method: ${request.method()}`)
         }
+        this.signalsAPI.addRequest(request)
         return route.fulfill({
           contentType: 'application/json',
           status: 201,
@@ -241,15 +241,17 @@ export class BasePage {
     })
   }
 
-  waitForEdgeFunctionResponse() {
+  waitForEdgeFunctionResponse(timeout = 30000) {
     return this.page.waitForResponse(
-      `https://cdn.edgefn.segment.com/MY-WRITEKEY/**`
+      `https://cdn.edgefn.segment.com/MY-WRITEKEY/**`,
+      { timeout }
     )
   }
 
-  waitForCDNSettingsResponse() {
+  async waitForCDNSettingsResponse(timeout = 30000) {
     return this.page.waitForResponse(
-      'https://cdn.segment.com/v1/projects/*/settings'
+      'https://cdn.segment.com/v1/projects/*/settings',
+      { timeout }
     )
   }
 

--- a/packages/signals/signals-integration-tests/src/helpers/playwright-utils.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/playwright-utils.ts
@@ -1,0 +1,51 @@
+import { Page } from '@playwright/test'
+import type { Compute } from './ts'
+
+export function waitForCondition(
+  conditionFn: () => boolean,
+  {
+    checkInterval = 100,
+    timeout = 10000,
+    errorMessage = 'Condition was not met within the specified time.',
+  } = {}
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now()
+
+    const interval = setInterval(() => {
+      try {
+        if (conditionFn()) {
+          clearInterval(interval)
+          resolve()
+        } else if (Date.now() - startTime >= timeout) {
+          clearInterval(interval)
+          reject(new Error(errorMessage))
+        }
+      } catch (error) {
+        clearInterval(interval)
+        reject(error)
+      }
+    }, checkInterval)
+  })
+}
+
+type FillOptions = Compute<Parameters<Page['fill']>[2]>
+
+export async function fillAndBlur(
+  page: Page,
+  selector: string,
+  text: string,
+  options: FillOptions = {}
+) {
+  await page.fill(selector, text, options)
+  // Remove focus so the onChange event is triggered
+  await page.evaluate(
+    (args) => {
+      const input = document.querySelector(args.selector) as HTMLElement
+      if (input) {
+        input.blur()
+      }
+    },
+    { selector }
+  )
+}

--- a/packages/signals/signals-integration-tests/src/helpers/ts.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/ts.ts
@@ -1,0 +1,1 @@
+export type Compute<T> = { [K in keyof T]: T[K] } & {}

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/all-segment-events.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/all-segment-events.test.ts
@@ -54,7 +54,9 @@ test('Segment events', async ({ page }) => {
     indexPage.waitForTrackingApiFlush(),
   ])
 
-  const trackingApiReqs = indexPage.trackingApiReqs.map(normalizeSnapshotEvent)
+  const trackingApiReqs = indexPage.trackingAPI
+    .getEvents()
+    .map(normalizeSnapshotEvent)
   expect(trackingApiReqs).toEqual(snapshot)
 })
 
@@ -76,13 +78,13 @@ test('Should dispatch events from signals that occurred before analytics was ins
   // add a user defined signal before analytics is instantiated
   void indexPage.addUserDefinedSignal()
 
-  await indexPage.waitForSignalsAssets()
+  await indexPage.waitForSettings()
 
   await Promise.all([
     indexPage.waitForSignalsApiFlush(),
     indexPage.waitForTrackingApiFlush(),
   ])
-  const trackingApiReqs = indexPage.trackingApiReqs
+  const trackingApiReqs = indexPage.trackingAPI.getEvents()
   expect(trackingApiReqs).toHaveLength(2)
 
   const pageEvents = trackingApiReqs.find((el) => el.type === 'page')!

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
@@ -39,7 +39,7 @@ test('network signals', async () => {
 
 test('network signals xhr', async () => {
   /**
-   * Make a fetch call, see if it gets sent to the signals endpoint
+   * Make a xhr call, see if it gets sent to the signals endpoint
    */
   await indexPage.network.mockTestRoute()
   await indexPage.network.makeXHRCall()

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
@@ -124,8 +124,7 @@ test('interaction signals', async () => {
     },
   })
 
-  const analyticsReqJSON = indexPage.lastTrackingApiReq.postDataJSON()
-
+  const analyticsReqJSON = indexPage.trackingAPI.lastEvent()
   expect(analyticsReqJSON).toMatchObject({
     writeKey: '<SOME_WRITE_KEY>',
     event: 'click [interaction]',

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/button-click-complex.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/button-click-complex.test.ts
@@ -3,15 +3,33 @@ import { IndexPage } from './index-page'
 
 const indexPage = new IndexPage()
 
-const basicEdgeFn = `
-    // this is a process signal function
-    const processSignal = (signal) => {}`
+const basicEdgeFn = `const processSignal = (signal) => {}`
 
 test.beforeEach(async ({ page }) => {
   await indexPage.loadAndWait(page, basicEdgeFn)
 })
 
-test('button click (complex, with nested items)', async () => {
+const data = {
+  eventType: 'click',
+  target: {
+    attributes: {
+      id: 'complex-button',
+    },
+    classList: [],
+    id: 'complex-button',
+    labels: [],
+    name: '',
+    nodeName: 'BUTTON',
+    tagName: 'BUTTON',
+    title: '',
+    type: 'submit',
+    innerText: 'Other Example Button with Nested Text',
+    textContent: 'Other Example Button with Nested Text',
+    value: '',
+  },
+}
+
+test('clicking a button with nested content', async () => {
   /**
    * Click a button with nested text, ensure that that correct text shows up
    */
@@ -22,28 +40,28 @@ test('button click (complex, with nested items)', async () => {
 
   const interactionSignals = indexPage.signalsAPI.getEvents('interaction')
   expect(interactionSignals).toHaveLength(1)
-  const data = {
-    eventType: 'click',
-    target: {
-      attributes: {
-        id: 'complex-button',
-      },
-      classList: [],
-      id: 'complex-button',
-      labels: [],
-      name: '',
-      nodeName: 'BUTTON',
-      tagName: 'BUTTON',
-      title: '',
-      type: 'submit',
-      innerText: expect.any(String),
-      textContent: expect.stringContaining(
-        'Other Example Button with Nested Text'
-      ),
-      value: '',
-    },
-  }
 
+  expect(interactionSignals[0]).toMatchObject({
+    event: 'Segment Signal Generated',
+    type: 'track',
+    properties: {
+      type: 'interaction',
+      data,
+    },
+  })
+})
+
+test('clicking the h1 tag inside a button', async () => {
+  /**
+   * Click the nested text, ensure that that correct text shows up
+   */
+  await Promise.all([
+    indexPage.clickInsideComplexButton(),
+    indexPage.waitForSignalsApiFlush(),
+  ])
+
+  const interactionSignals = indexPage.signalsAPI.getEvents('interaction')
+  expect(interactionSignals).toHaveLength(1)
   expect(interactionSignals[0]).toMatchObject({
     event: 'Segment Signal Generated',
     type: 'track',

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/change-input.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/change-input.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+import { waitForCondition } from '../../helpers/playwright-utils'
+import { IndexPage } from './index-page'
+
+const indexPage = new IndexPage()
+
+const basicEdgeFn = `const processSignal = (signal) => {}`
+
+test('Collecting signals whenever a user enters text input', async ({
+  page,
+}) => {
+  /**
+   * Input some text into the input field, see if the signal is emitted correctly
+   */
+  await indexPage.loadAndWait(page, basicEdgeFn, {
+    disableSignalsRedaction: true,
+  })
+
+  await Promise.all([
+    indexPage.fillNameInput('John Doe'),
+    indexPage.waitForSignalsApiFlush(),
+  ])
+
+  await waitForCondition(
+    () => indexPage.signalsAPI.getEvents('interaction').length > 0,
+    { errorMessage: 'No interaction signals found' }
+  )
+  const interactionSignals = indexPage.signalsAPI.getEvents('interaction')
+
+  const data = {
+    eventType: 'change',
+    target: expect.objectContaining({
+      attributes: expect.objectContaining({
+        type: 'text',
+        id: 'name',
+        name: 'name',
+      }),
+      classList: [],
+      id: 'name',
+      labels: [
+        {
+          textContent: 'Name:',
+        },
+      ],
+      name: 'name',
+      nodeName: 'INPUT',
+      tagName: 'INPUT',
+      value: 'John Doe',
+    }),
+  }
+  expect(interactionSignals[0].properties!.data).toMatchObject(data)
+})

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
@@ -1,5 +1,6 @@
 import { BasePage } from '../../helpers/base-page-object'
 import { promiseTimeout } from '@internal/test-helpers'
+import { fillAndBlur } from '../../helpers/playwright-utils'
 
 export class IndexPage extends BasePage {
   constructor() {
@@ -39,5 +40,13 @@ export class IndexPage extends BasePage {
 
   async clickComplexButton() {
     return this.page.click('#complex-button')
+  }
+
+  async clickInsideComplexButton() {
+    return this.page.click('#complex-button h1')
+  }
+
+  async fillNameInput(text: string) {
+    return await fillAndBlur(this.page, '#name', text)
   }
 }

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-filter.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-filter.test.ts
@@ -3,14 +3,7 @@ import { IndexPage } from './index-page'
 
 const indexPage = new IndexPage()
 
-const basicEdgeFn = `
-    // this is a process signal function
-    const processSignal = (signal) => {
-      if (signal.type === 'interaction') {
-        const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
-        analytics.track(eventName, signal.data)
-      }
-  }`
+const basicEdgeFn = `const processSignal = (signal) => {}`
 
 test('network signals allow and disallow list', async ({ page }) => {
   await indexPage.loadAndWait(page, basicEdgeFn, {

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-xhr.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-xhr.test.ts
@@ -1,14 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `
-    // this is a process signal function
-    const processSignal = (signal) => {
-      if (signal.type === 'interaction') {
-        const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
-        analytics.track(eventName, signal.data)
-      }
-  }`
+const basicEdgeFn = `const processSignal = (signal) => {}`
 
 test.describe('XHR Tests', () => {
   let indexPage: IndexPage
@@ -161,6 +154,7 @@ test.describe('XHR Tests', () => {
     })
 
     await indexPage.network.makeXHRCall('http://localhost/test', {
+      responseType: 'json',
       method: 'GET',
     })
 
@@ -269,5 +263,4 @@ test.describe('XHR Tests', () => {
       data: { req2: 'value' },
     })
   })
-  // Check the response
 })

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-redaction.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-redaction.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+import { waitForCondition } from '../../helpers/playwright-utils'
+import { IndexPage } from './index-page'
+
+const indexPage = new IndexPage()
+
+const basicEdgeFn = `const processSignal = (signal) => {}`
+
+test('redaction enabled -> will XXX the value of text input', async ({
+  page,
+}) => {
+  await indexPage.loadAndWait(page, basicEdgeFn, {
+    disableSignalsRedaction: false,
+  })
+
+  await Promise.all([
+    indexPage.fillNameInput('John Doe'),
+    indexPage.waitForSignalsApiFlush(),
+  ])
+
+  await waitForCondition(
+    () => indexPage.signalsAPI.getEvents('interaction').length > 0,
+    { errorMessage: 'No interaction signals found' }
+  )
+  const interactionSignals = indexPage.signalsAPI.getEvents('interaction')
+
+  const data = {
+    eventType: 'change',
+    target: expect.objectContaining({
+      name: 'name',
+      type: 'text',
+      value: 'XXX', // redacted
+    }),
+  }
+  expect(interactionSignals[0].properties!.data).toMatchObject(data)
+})
+
+test('redation disabled -> will not touch the value of text input', async ({
+  page,
+}) => {
+  await indexPage.loadAndWait(page, basicEdgeFn, {
+    disableSignalsRedaction: true,
+  })
+
+  await Promise.all([
+    indexPage.fillNameInput('John Doe'),
+    indexPage.waitForSignalsApiFlush(),
+  ])
+
+  await waitForCondition(
+    () => indexPage.signalsAPI.getEvents('interaction').length > 0,
+    { errorMessage: 'No interaction signals found' }
+  )
+  const interactionSignals = indexPage.signalsAPI.getEvents('interaction')
+
+  const data = {
+    eventType: 'change',
+    target: expect.objectContaining({
+      value: 'John Doe', // noe redacted
+    }),
+  }
+  expect(interactionSignals[0].properties!.data).toMatchObject(data)
+})

--- a/packages/signals/signals/src/core/client/__tests__/client.test.ts
+++ b/packages/signals/signals/src/core/client/__tests__/client.test.ts
@@ -15,7 +15,7 @@ describe(SignalsIngestClient, () => {
     await client.init({ writeKey: 'test' })
   })
 
-  it('makes a track call via the analytics api', async () => {
+  it('makes an instrumentation track call via the analytics api', async () => {
     expect(client).toBeTruthy()
     const ctx = await client.send({
       type: 'instrumentation',
@@ -32,9 +32,36 @@ describe(SignalsIngestClient, () => {
       index: 0,
       data: {
         rawEvent: {
-          foo: 'XXX',
+          foo: 'bar',
         },
       },
     })
+  })
+  it('makes a network track call via the analytics api', async () => {
+    expect(client).toBeTruthy()
+    const ctx = await client.send({
+      type: 'network',
+      data: {
+        action: 'request',
+        data: {
+          hello: 'how are you',
+        },
+        method: 'post',
+        url: 'http://foo.com',
+      },
+    })
+
+    expect(ctx!.event.type).toEqual('track')
+    expect(ctx!.event.properties!.type).toBe('network')
+    expect(ctx!.event.properties!.data).toMatchInlineSnapshot(`
+      {
+        "action": "request",
+        "data": {
+          "hello": "XXX",
+        },
+        "method": "post",
+        "url": "http://foo.com",
+      }
+    `)
   })
 })

--- a/packages/signals/signals/src/core/client/__tests__/redact.test.ts
+++ b/packages/signals/signals/src/core/client/__tests__/redact.test.ts
@@ -1,6 +1,12 @@
-import { redactJsonValues } from '../redact'
+import {
+  createInstrumentationSignal,
+  createInteractionSignal,
+  createNetworkSignal,
+  NetworkSignalMetadata,
+} from '../../../types'
+import { redactJsonValues, redactSignalData } from '../redact'
 
-describe('redactJsonValues', () => {
+describe(redactJsonValues, () => {
   it('should redact string values in an object', () => {
     const obj = { name: 'John Doe', age: '30' }
     const expected = { name: 'XXX', age: 'XXX' }
@@ -52,5 +58,70 @@ describe('redactJsonValues', () => {
       l2: { b: 'B', l3: { c: 'XXX', l4: { d: 'XXX' } } },
     }
     expect(redactJsonValues(obj, 3)).toEqual(expected)
+  })
+})
+
+describe(redactSignalData, () => {
+  const metadataFixture: NetworkSignalMetadata = {
+    filters: {
+      allowed: [],
+      disallowed: [],
+    },
+  }
+  it('should return the signal as is if the type is "instrumentation"', () => {
+    const signal = createInstrumentationSignal({
+      foo: 123,
+    } as any)
+    expect(redactSignalData(signal)).toEqual(signal)
+  })
+
+  it('should return the signal as is if the type is "userDefined"', () => {
+    const signal = { type: 'userDefined', data: { value: 'secret' } } as const
+    expect(redactSignalData(signal)).toEqual(signal)
+  })
+
+  it('should redact the value in the "target" property if the type is "interaction"', () => {
+    const signal = createInteractionSignal({
+      eventType: 'change',
+      target: { value: 'secret' },
+    })
+    const expected = createInteractionSignal({
+      eventType: 'change',
+      target: { value: 'XXX' },
+    })
+    expect(redactSignalData(signal)).toEqual(expected)
+  })
+
+  it('should redact the values in the "data" property if the type is "network"', () => {
+    const signal = createNetworkSignal(
+      {
+        action: 'request',
+        method: 'post',
+        url: 'http://foo.com',
+        data: { name: 'John Doe', age: 30 },
+      },
+      metadataFixture
+    )
+    const expected = createNetworkSignal(
+      {
+        action: 'request',
+        method: 'post',
+        url: 'http://foo.com',
+        data: { name: 'XXX', age: 999 },
+      },
+      metadataFixture
+    )
+    expect(redactSignalData(signal)).toEqual(expected)
+  })
+
+  it('should not mutate the original signal object', () => {
+    const originalSignal = createInteractionSignal({
+      eventType: 'click',
+      target: { value: 'sensitiveData' },
+    })
+    const originalSignalCopy = JSON.parse(JSON.stringify(originalSignal))
+
+    redactSignalData(originalSignal)
+    expect(originalSignal).toEqual(originalSignalCopy)
   })
 })

--- a/packages/signals/signals/src/core/client/redact.ts
+++ b/packages/signals/signals/src/core/client/redact.ts
@@ -1,4 +1,18 @@
-function redact(value: unknown) {
+import { Signal } from '../../types'
+
+export const redactSignalData = (signalArg: Signal): Signal => {
+  const signal = structuredClone(signalArg)
+  if (signal.type === 'interaction') {
+    if ('target' in signal.data && 'value' in signal.data.target) {
+      signal.data.target.value = redactJsonValues(signal.data.target.value)
+    }
+  } else if (signal.type === 'network') {
+    signal.data = redactJsonValues(signal.data, 2)
+  }
+  return signal
+}
+
+function redactPrimitive(value: unknown) {
   const type = typeof value
   if (type === 'boolean') {
     return true
@@ -31,7 +45,7 @@ export function redactJsonValues(data: unknown, redactAfterDepth = 0): any {
       return redactedData
     }
   } else if (redactAfterDepth <= 0) {
-    const ret = redact(data)
+    const ret = redactPrimitive(data)
     return ret
   } else {
     return data

--- a/packages/signals/signals/src/core/processor/__tests__/signals-runtime.test.ts
+++ b/packages/signals/signals/src/core/processor/__tests__/signals-runtime.test.ts
@@ -15,7 +15,7 @@ describe('SignalsRuntime', () => {
   beforeEach(() => {
     signal1 = createInstrumentationSignal({ type: 'track' })
     signal2 = createInteractionSignal({ eventType: 'submit', submitter: {} })
-    signal3 = createInteractionSignal({ eventType: 'change' })
+    signal3 = createInteractionSignal({ eventType: 'change', target: {} })
     signalsRuntime = createSignalsRuntime([signal1, signal2, signal3])
   })
 

--- a/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
@@ -53,7 +53,7 @@ describe(NetworkInterceptor, () => {
         this.responseURL = url
       }
 
-      async send() {
+      send() {
         setTimeout(() => {
           this.readyState = this.HEADERS_RECEIVED
           this._emitter.emit('readystatechange')

--- a/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
@@ -1,18 +1,16 @@
 import { NetworkInterceptor } from '../network-interceptor'
 import { Response } from 'node-fetch'
+import { EventEmitter } from 'events'
 
 describe(NetworkInterceptor, () => {
   let interceptor: NetworkInterceptor
-
-  beforeEach(() => {
-    interceptor = new NetworkInterceptor()
-  })
 
   afterEach(() => {
     interceptor.cleanup()
   })
 
   it('should intercept fetch requests and responses', async () => {
+    interceptor = new NetworkInterceptor()
     const mockRequestHandler = jest.fn()
     const mockResponseHandler = jest.fn()
     const mockResponse = new Response(JSON.stringify({ data: 'test' }), {
@@ -29,21 +27,77 @@ describe(NetworkInterceptor, () => {
     expect(mockResponseHandler).toHaveBeenCalled()
   })
 
+  // Very primitive mock for XMLHttpRequest -- better tests are at the integration level
   it('should intercept XHR requests and responses', async () => {
     const mockRequestHandler = jest.fn()
     const mockResponseHandler = jest.fn()
-    const xhr = new XMLHttpRequest()
+
+    class MockXMLHttpRequest {
+      UNSENT = 0
+      OPENED = 1
+      HEADERS_RECEIVED = 2
+      LOADING = 3
+      DONE = 4
+
+      private _emitter = new EventEmitter()
+      public readyState = 0
+      public status = 0
+      public responseText = ''
+      public onreadystatechange: (() => void) | null = null
+
+      open = jest.fn().mockImplementation(() => {
+        setTimeout(() => {
+          this.readyState = this.OPENED
+          this._emitter.emit('readystatechange')
+        }, 10)
+
+        setTimeout(() => {
+          this.readyState = this.HEADERS_RECEIVED
+          this._emitter.emit('readystatechange')
+        }, 20)
+
+        setTimeout(() => {
+          this.readyState = this.LOADING
+          this._emitter.emit('readystatechange')
+        }, 30)
+      })
+
+      send = jest.fn().mockImplementation(() => {
+        setTimeout(() => {
+          this.readyState = 4
+          this.status = 200
+          this.responseText = JSON.stringify({ data: 'test' })
+          this._emitter.emit('readystatechange')
+          if (this.onreadystatechange) {
+            this.onreadystatechange()
+          }
+        }, 0)
+      })
+
+      setRequestHeader = jest.fn()
+
+      addEventListener(event: string, listener: () => void) {
+        this._emitter.on(event, listener)
+      }
+
+      getAllResponseHeaders() {
+        return 'Content-Type: application/json'
+      }
+    }
+
+    ;(globalThis as any).XMLHttpRequest = MockXMLHttpRequest
+    interceptor = new NetworkInterceptor()
 
     interceptor.addXhrInterceptor(mockRequestHandler, mockResponseHandler)
 
+    const xhr = new XMLHttpRequest()
     xhr.open('GET', 'http://example.com')
     xhr.send()
 
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState === xhr.DONE) {
-        expect(mockRequestHandler).toHaveBeenCalled()
-        expect(mockResponseHandler).toHaveBeenCalled()
-      }
-    }
+    // Simulate the readyState change
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(mockRequestHandler).toHaveBeenCalled()
+    expect(mockResponseHandler).toHaveBeenCalled()
   })
 })

--- a/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-interceptor.test.ts
@@ -101,7 +101,7 @@ describe(NetworkInterceptor, () => {
     xhr.open('POST', 'http://example.com')
     xhr.send()
 
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    await new Promise((resolve) => setTimeout(resolve, 100))
 
     expect(mockRequestHandler).toHaveBeenCalled()
     expect(mockResponseHandler).toHaveBeenCalled()

--- a/packages/signals/signals/src/types/signals.ts
+++ b/packages/signals/signals/src/types/signals.ts
@@ -35,7 +35,7 @@ type SubmitData = {
 
 type ChangeData = {
   eventType: 'change'
-  [key: string]: unknown
+  target: SerializedTarget
 }
 
 export type InteractionSignal = AppSignal<'interaction', InteractionData>


### PR DESCRIPTION
- only redact 'target.value' in `interaction` signals
- do not redact instrumentation signals or navigation signals