### PR TITLE
Add signals enums

### DIFF
--- a/.changeset/modern-plums-glow.md
+++ b/.changeset/modern-plums-glow.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-signals': minor
+---
+
+Add enums

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
@@ -4,7 +4,7 @@ import { promiseTimeout } from '@internal/test-helpers'
 const edgeFn = `
     // this is a process signal function
     const processSignal = (signal) => {
-      if (signal.type === SignalType.Interaction) {
+      if (signal.type === 'interaction') {
         const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
         analytics.track(eventName, signal.data)
       }

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index-page.ts
@@ -4,7 +4,7 @@ import { promiseTimeout } from '@internal/test-helpers'
 const edgeFn = `
     // this is a process signal function
     const processSignal = (signal) => {
-      if (signal.type === 'interaction') {
+      if (signal.type === SignalType.Interaction) {
         const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
         analytics.track(eventName, signal.data)
       }

--- a/packages/signals/signals/src/core/processor/sandbox.ts
+++ b/packages/signals/signals/src/core/processor/sandbox.ts
@@ -7,7 +7,7 @@ import {
 import { logger } from '../../lib/logger'
 import createWorkerBox from 'workerboxjs'
 
-import { AnalyticsRuntimePublicApi, Signal } from '../../types'
+import { AnalyticsRuntimePublicApi, Signal, AnalyticsEnums } from '../../types'
 import { createSignalsRuntime } from './signals-runtime'
 import { replaceBaseUrl } from '../../lib/replace-base-url'
 
@@ -176,6 +176,7 @@ export class Sandbox {
     const analytics = new AnalyticsRuntime()
     const scope = {
       analytics,
+      ...AnalyticsEnums,
     }
     logger.debug('processing signal', { signal, scope, signals })
     const code = [

--- a/packages/signals/signals/src/core/processor/sandbox.ts
+++ b/packages/signals/signals/src/core/processor/sandbox.ts
@@ -185,7 +185,7 @@ export class Sandbox {
       `const signals = createSignalsRuntime(${JSON.stringify(signals)})`,
       'try { processSignal(' +
         JSON.stringify(signal) +
-        ', { analytics, signals }); } catch(err) { console.error("Process signal failed.", err); }',
+        ', { analytics, signals, SignalType, EventType, NavigationAction }); } catch(err) { console.error("Process signal failed.", err); }',
     ].join('\n')
     await this.jsSandbox.run(code, scope)
 

--- a/packages/signals/signals/src/types/process-signal.ts
+++ b/packages/signals/signals/src/types/process-signal.ts
@@ -16,7 +16,27 @@ export interface AnalyticsRuntimePublicApi {
 export type ProcessSignalScope = {
   analytics: AnalyticsRuntimePublicApi
   signals: SignalsRuntime
-}
+} & typeof AnalyticsEnums
+
 export interface ProcessSignal {
   (signal: Signal, ctx: ProcessSignalScope): void
+}
+
+export const AnalyticsEnums = {
+  SignalType: Object.freeze({
+    Interaction: 'interaction',
+    Navigation: 'navigation',
+    Network: 'network',
+    LocalData: 'localData',
+    Instrumentation: 'instrumentation',
+    UserDefined: 'userDefined',
+  }),
+  EventType: Object.freeze({
+    Track: 'track',
+    Page: 'page',
+    Screen: 'screen',
+    Identify: 'identify',
+    Group: 'group',
+    Alias: 'alias',
+  }),
 }

--- a/packages/signals/signals/src/types/process-signal.ts
+++ b/packages/signals/signals/src/types/process-signal.ts
@@ -39,4 +39,8 @@ export const AnalyticsEnums = {
     Group: 'group',
     Alias: 'alias',
   }),
+  NavigationAction: Object.freeze({
+    URLChange: 'urlChange',
+    PageLoad: 'pageLoad',
+  }),
 }


### PR DESCRIPTION
Adding for closer doc parity with mobile -- they are interchangeable with the string form (I think having it part of the public API is harmless, regardless of whether our doc examples show strings or enums). 


Differences
- Web has a "Page" call, whereas mobile only uses screen.
- Web has fewer navigation actions due to granularity limitations.