### PR TITLE
Fix plugin pipeline race condition

### DIFF
--- a/.changeset/giant-monkeys-count.md
+++ b/.changeset/giant-monkeys-count.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix enrichment plugins not waiting for .load to resolve when plugin is registered manually

--- a/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-lazy-init.integration.test.ts
@@ -170,19 +170,19 @@ describe('Lazy destination loading', () => {
       analytics.load({ writeKey: 'abc', plugins: [dest1Harness.factory] })
       await dest1Harness.loadingGuard.resolve()
 
-      await sleep(0)
+      await sleep(50)
       expect(testEnrichmentHarness.trackSpy).not.toHaveBeenCalled()
       expect(dest1Harness.trackSpy).not.toHaveBeenCalled()
 
       // now we'll let the enrichment plugin load
       await testEnrichmentHarness.loadingGuard.resolve()
-      await sleep(0)
+      await sleep(50)
       expect(testEnrichmentHarness.trackSpy).toHaveBeenCalledTimes(1)
       expect(dest1Harness.trackSpy).toHaveBeenCalledTimes(1)
     })
   })
 
-  describe.only('non-critical plugins (plugins that do not block the event pipeline)', () => {
+  describe('non-critical plugins (plugins that do not block the event pipeline)', () => {
     it('destination loading does not block the event pipeline', async () => {
       const testEnrichmentHarness = createTestPluginFactory(
         'enrichIt',
@@ -206,7 +206,7 @@ describe('Lazy destination loading', () => {
 
       testEnrichmentHarness.loadingGuard.resolve()
 
-      await sleep(0)
+      await sleep(50)
 
       // and we'll also let one destination load so we can assert some behaviours
       dest1Harness.loadingGuard.resolve()

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -1091,6 +1091,8 @@ describe('register', () => {
       ...googleAnalytics,
       load: () => Promise.resolve('foo'),
     })
+
+    await analytics
     const goodPluginSpy = jest.spyOn(goodPlugin, 'track')
 
     await analytics.register(goodPlugin, errorPlugin)

--- a/packages/browser/src/core/buffer/__tests__/index.test.ts
+++ b/packages/browser/src/core/buffer/__tests__/index.test.ts
@@ -18,6 +18,58 @@ describe(PreInitMethodCallBuffer, () => {
     GlobalAnalytics.setGlobalAnalytics(undefined as any)
   })
 
+  describe('getAndRemove()', () => {
+    let buffer: PreInitMethodCallBuffer
+    let mockCalls: PreInitMethodCall[]
+    beforeEach(() => {
+      mockCalls = [
+        new PreInitMethodCall('track', ['arg1']),
+        new PreInitMethodCall('identify', ['arg2']),
+        new PreInitMethodCall('track', ['arg3']),
+        new PreInitMethodCall('group', ['arg4']),
+      ]
+      buffer = new PreInitMethodCallBuffer(...mockCalls)
+    })
+
+    test('should return the correct buffered method calls', () => {
+      const trackCalls = buffer.getAndRemove('track')
+      expect(trackCalls).toEqual([
+        expect.objectContaining<Partial<PreInitMethodCall>>({
+          method: 'track',
+          args: ['arg1', getBufferedPageCtxFixture()],
+        }),
+        expect.objectContaining<Partial<PreInitMethodCall>>({
+          method: 'track',
+          args: ['arg3', getBufferedPageCtxFixture()],
+        }),
+      ])
+      expect(buffer.get('track')).toEqual([])
+
+      const identifyCalls = buffer.getAndRemove('identify')
+      expect(identifyCalls).toEqual([
+        expect.objectContaining({
+          method: 'identify',
+          args: ['arg2', getBufferedPageCtxFixture()],
+        }),
+      ])
+      expect(buffer.get('identify')).toEqual([])
+      expect(buffer.get('group').length).toBe(1)
+    })
+
+    test('should clear the buffered method calls after returning them', () => {
+      buffer.getAndRemove('track')
+      expect(buffer.get('track')).toEqual([])
+
+      buffer.getAndRemove('identify')
+      expect(buffer.get('identify')).toEqual([])
+    })
+
+    test('should return an empty array if there are no buffered method calls', () => {
+      const aliasCalls = buffer.getAndRemove('alias')
+      expect(aliasCalls).toEqual([])
+    })
+  })
+
   describe('toArray()', () => {
     it('should convert the map back to an array', () => {
       const call1 = new PreInitMethodCall('identify', [], jest.fn())
@@ -44,11 +96,11 @@ describe(PreInitMethodCallBuffer, () => {
     })
   })
 
-  describe('push()', () => {
+  describe('add()', () => {
     it('should add method calls', () => {
       const call1 = new PreInitMethodCall('identify', [], jest.fn())
       const buffer = new PreInitMethodCallBuffer()
-      buffer.push(call1)
+      buffer.add(call1)
       expect(buffer.toArray()).toEqual([call1])
     })
 
@@ -58,28 +110,28 @@ describe(PreInitMethodCallBuffer, () => {
       const call3 = new PreInitMethodCall('group', [], jest.fn())
       const call4 = new PreInitMethodCall('group', [], jest.fn())
       const buffer = new PreInitMethodCallBuffer(call1)
-      buffer.push(call2, call3)
-      buffer.push(call4)
+      buffer.add(call2, call3)
+      buffer.add(call4)
       expect(buffer.toArray()).toEqual([call1, call2, call3, call4])
     })
   })
 
-  describe('getCalls()', () => {
+  describe('get()', () => {
     it('should fetch calls by name', async () => {
       const buffer = new PreInitMethodCallBuffer()
       const call1 = new PreInitMethodCall('identify', [], jest.fn())
       const call2 = new PreInitMethodCall('identify', [], jest.fn())
       const call3 = new PreInitMethodCall('group', [], jest.fn())
-      buffer.push(call1, call2, call3)
-      expect(buffer.getCalls('identify')).toEqual([call1, call2])
-      expect(buffer.getCalls('group')).toEqual([call3])
+      buffer.add(call1, call2, call3)
+      expect(buffer.get('identify')).toEqual([call1, call2])
+      expect(buffer.get('group')).toEqual([call3])
     })
     it('should read from Snippet Buffer', () => {
       const call1 = new PreInitMethodCall('identify', ['foo'], jest.fn())
       GlobalAnalytics.setGlobalAnalytics([['identify', 'snippet']] as any)
 
       const buffer = new PreInitMethodCallBuffer(call1)
-      const calls = buffer.getCalls('identify')
+      const calls = buffer.get('identify')
       expect(calls.length).toBe(2)
       expect(calls[0]).toEqual(
         expect.objectContaining<Partial<PreInitMethodCall>>({
@@ -128,7 +180,7 @@ describe(PreInitMethodCallBuffer, () => {
       const buffer = new PreInitMethodCallBuffer(
         new PreInitMethodCall(method, ['foo'], jest.fn())
       )
-      expect(buffer.getCalls(method)[0].args).toEqual([
+      expect(buffer.get(method)[0].args).toEqual([
         'foo',
         getBufferedPageCtxFixture(),
       ])

--- a/packages/browser/src/lib/__tests__/load-script.test.ts
+++ b/packages/browser/src/lib/__tests__/load-script.test.ts
@@ -1,0 +1,98 @@
+import { loadScript } from '../load-script'
+
+describe(loadScript, () => {
+  const clearDocumentHTML = () => {
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+  }
+
+  beforeEach(() => {
+    clearDocumentHTML()
+  })
+
+  it('should create and load a new script if not already present', async () => {
+    const src = 'https://example.com/bar.js'
+    const attributes = { 'data-test': 'test' }
+    const loadScriptP = loadScript(src, attributes)
+    setTimeout(() => {
+      const script = document.querySelector(`script[src="${src}"]`)!
+      expect(script!.getAttribute('status')).toBe('loading')
+      script!.dispatchEvent(new Event('load'))
+    }, 0)
+
+    const script = await loadScriptP
+    expect(script).not.toBeNull()
+    expect(script!.getAttribute('data-test')).toBe('test')
+    expect(script!.getAttribute('status')).toBe('loaded')
+  })
+
+  it('should resolve with the script element if the script is already loading', async () => {
+    const src = 'https://example.com/script.js'
+    const script = document.createElement('script')
+    script.src = src
+    script.setAttribute('status', 'loading')
+    document.head.appendChild(script)
+
+    setTimeout(() => {
+      script.dispatchEvent(new Event('load'))
+    }, 0)
+
+    const result = await loadScript(src)
+    expect(result).toBe(script)
+  })
+
+  it('should reject if the script fails to load', async () => {
+    const src = 'https://example.com/foo.js'
+    const loadScriptP = loadScript(src)
+
+    setTimeout(() => {
+      const script = document.querySelector(`script[src="${src}"]`)
+      script!.dispatchEvent(new Event('error'))
+    }, 0)
+
+    await expect(loadScriptP).rejects.toThrow(`Failed to load ${src}`)
+  })
+
+  it('should append above the nearest script tag if there is an existing script tag', async () => {
+    document.head.innerHTML = ''
+    document.body.innerHTML = '<h1>Hello</h1><script id="foo"></script>'
+    const src = 'https://example.com/bar.js'
+    const loadScriptP = loadScript(src)
+    setTimeout(() => {
+      const script = document.querySelector(`script[src="${src}"]`)!
+      script!.dispatchEvent(new Event('load'))
+    }, 0)
+
+    await loadScriptP
+    expect(document.body).toMatchInlineSnapshot(`
+      <body>
+        <h1>
+          Hello
+        </h1>
+        <script
+          src="https://example.com/bar.js"
+          status="loaded"
+          type="text/javascript"
+        />
+        <script
+          id="foo"
+        />
+      </body>
+    `)
+  })
+
+  it('should append to head if no existing script tags', async () => {
+    document.head.innerHTML = '<title>Some Title</title>'
+    const src = 'https://example.com/bar.js'
+    const loadScriptP = loadScript(src)
+    setTimeout(() => {
+      const script = document.querySelector(`script[src="${src}"]`)!
+      script!.dispatchEvent(new Event('load'))
+    }, 0)
+
+    await loadScriptP
+    expect(document.head.innerHTML).toMatchInlineSnapshot(
+      `"<title>Some Title</title><script type="text/javascript" src="https://example.com/bar.js" status="loaded"></script>"`
+    )
+  })
+})

--- a/packages/browser/src/lib/load-script.ts
+++ b/packages/browser/src/lib/load-script.ts
@@ -50,7 +50,6 @@ export function loadScript(
     script.onerror = (): void => {
       script.onerror = script.onload = null
       script.setAttribute('status', 'error')
-      console.error(`Failed to load ${src}`)
       reject(new Error(`Failed to load ${src}`))
     }
 

--- a/packages/browser/src/lib/load-script.ts
+++ b/packages/browser/src/lib/load-script.ts
@@ -50,6 +50,7 @@ export function loadScript(
     script.onerror = (): void => {
       script.onerror = script.onload = null
       script.setAttribute('status', 'error')
+      console.error(`Failed to load ${src}`)
       reject(new Error(`Failed to load ${src}`))
     }
 

--- a/packages/browser/src/lib/load-script.ts
+++ b/packages/browser/src/lib/load-script.ts
@@ -5,6 +5,9 @@ function findScript(src: string): HTMLScriptElement | undefined {
   return scripts.find((s) => s.src === src)
 }
 
+/**
+ * Load a script from a URL and append it to the document.
+ */
 export function loadScript(
   src: string,
   attributes?: Record<string, string>
@@ -50,8 +53,15 @@ export function loadScript(
       reject(new Error(`Failed to load ${src}`))
     }
 
-    const tag = window.document.getElementsByTagName('script')[0]
-    tag.parentElement?.insertBefore(script, tag)
+    const firstExistingScript = window.document.querySelector('script')
+    if (!firstExistingScript) {
+      window.document.head.appendChild(script)
+    } else {
+      firstExistingScript.parentElement?.insertBefore(
+        script,
+        firstExistingScript
+      )
+    }
   })
 }
 

--- a/packages/browser/src/test-helpers/fixtures/cdn-settings.ts
+++ b/packages/browser/src/test-helpers/fixtures/cdn-settings.ts
@@ -1,4 +1,5 @@
 import { AnalyticsBrowserSettings } from '../..'
+import type { RemotePlugin } from '../../plugins/remote-loader'
 import { mockIntegrationName } from './classic-destination'
 
 type CDNSettings = NonNullable<AnalyticsBrowserSettings['cdnSettings']>
@@ -298,4 +299,17 @@ export const cdnSettingsMinimal: CDNSettings = {
   integrations: {
     [mockIntegrationName]: {},
   },
+}
+
+export const createRemotePlugin = (
+  name: string,
+  creationName?: string
+): RemotePlugin => {
+  return {
+    name,
+    url: 'https://foo.com/v1/projects/abc/plugins/def.js',
+    creationName: creationName || name,
+    libraryName: name,
+    settings: {},
+  }
 }


### PR DESCRIPTION
Fixes a race condition in our plugin pipeline:

https://github.com/segmentio/analytics-next/issues/1120

There is currently inconsistencies between whether or not plugins are loaded in the Plugins[] array, or whether or not they are registered using .register. If they are loaded using .register, we don't wait wait for .load to finish resolving before invoking methods in that plugin. This is specifically an issue around plugins that are manually registered before analytics is initialized (i.e., most uses of analytics.register). The bug doesn't affect plugins loaded via action destinations, only plugins that are manually registered using analytics.register.

Bug repro:
Currently, this results in "page()!" being logged before  ".load()!".

```ts
 export const BugPlugin: Plugin = {
   type: "enrichment",
   name: "My Buggy Plugin",
   version: "1.0.0",
   load: async () => {
     await new Promise((resolve) => setTimeout(() => resolve("data"), 3000));
     console.log(
       ".load()! I should come before page"
     );
   },
   page: (ctx) => {
     console.log("page()! I should come after .load()")
     return ctx;
   },
   isLoaded: () => true,
 } 
  analytics.register(BugPlugin);
  analytics.page()
  analytics.load({ writeKey: 'MY_WRITEKEY' })
}
```