### PR TITLE
Fix debug experience

### DIFF
--- a/.changeset/clever-pots-smash.md
+++ b/.changeset/clever-pots-smash.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Update init to allow for asset path overriding and fix debugging experience

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -32,7 +32,7 @@
     "tsc": "yarn run -T tsc",
     "jest": "yarn run -T jest",
     "concurrently": "yarn run -T concurrently",
-    "watch": "yarn concurrently 'NODE_ENV=production WATCH=true yarn umd --watch' 'yarn pkg --watch'",
+    "watch": "yarn concurrently 'WATCH=true yarn umd --watch' 'yarn pkg --watch'",
     "build": "yarn clean && yarn build-prep && yarn concurrently 'NODE_ENV=production yarn umd' 'yarn pkg' 'yarn cjs'",
     "release:cdn": "yarn . build && NODE_ENV=production bash scripts/release.sh && NODE_ENV=stage bash scripts/release.sh",
     "pkg": "yarn tsc -p tsconfig.build.json",

--- a/packages/browser/src/browser/browser-umd.ts
+++ b/packages/browser/src/browser/browser-umd.ts
@@ -1,13 +1,13 @@
 import { getCDN, setGlobalCDNUrl } from '../lib/parse-cdn'
 import { setVersionType } from '../lib/version-type'
 
-if (process.env.ASSET_PATH) {
-  if (process.env.ASSET_PATH === '/dist/umd/') {
+if (process.env.IS_WEBPACK_BUILD) {
+  if (process.env.ASSET_PATH) {
     // @ts-ignore
-    __webpack_public_path__ = '/dist/umd/'
+    __webpack_public_path__ = process.env.ASSET_PATH
   } else {
     const cdn = getCDN()
-    setGlobalCDNUrl(cdn) // preserving original behavior -- TODO: neccessary?
+    setGlobalCDNUrl(cdn)
 
     // @ts-ignore
     __webpack_public_path__ = cdn + '/analytics-next/bundles/'

--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -2,10 +2,10 @@
 import { getCDN, setGlobalCDNUrl } from '../lib/parse-cdn'
 import { setVersionType } from '../lib/version-type'
 
-if (process.env.ASSET_PATH) {
-  if (process.env.ASSET_PATH === '/dist/umd/') {
+if (process.env.IS_WEBPACK_BUILD) {
+  if (process.env.ASSET_PATH) {
     // @ts-ignore
-    __webpack_public_path__ = '/dist/umd/'
+    __webpack_public_path__ = process.env.ASSET_PATH
   } else {
     const cdn = getCDN()
     setGlobalCDNUrl(cdn)

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -12,10 +12,10 @@ const ASSET_PATH = process.env.ASSET_PATH
   ? process.env.ASSET_PATH
   : !isProd
   ? '/dist/umd/'
-  : undefined
+  : ''
 
 const envPluginConfig = {
-  ASSET_PATH: ASSET_PATH || '',
+  ASSET_PATH: ASSET_PATH,
   IS_WEBPACK_BUILD: true,
 }
 

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -7,15 +7,26 @@ const BundleAnalyzerPlugin =
 const CircularDependencyPlugin = require('circular-dependency-plugin')
 
 const isProd = process.env.NODE_ENV === 'production'
-const ASSET_PATH = isProd
-  ? 'https://cdn.segment.com/analytics-next/bundles/'
-  : '/dist/umd/'
+
+const ASSET_PATH = process.env.ASSET_PATH
+  ? process.env.ASSET_PATH
+  : !isProd
+  ? '/dist/umd/'
+  : undefined
+
+const envPluginConfig = {
+  ASSET_PATH: ASSET_PATH || '',
+  IS_WEBPACK_BUILD: true,
+}
+
+console.log('Running Webpack Build', {
+  NODE_ENV: process.env.NODE_ENV,
+  'Webpack Environment Plugin': envPluginConfig,
+})
 
 const plugins = [
   new CompressionPlugin({}),
-  new webpack.EnvironmentPlugin({
-    ASSET_PATH,
-  }),
+  new webpack.EnvironmentPlugin(envPluginConfig),
   new CircularDependencyPlugin({
     failOnError: true,
   }),

--- a/playgrounds/standalone-playground/package.json
+++ b/playgrounds/standalone-playground/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     ".": "yarn run -T turbo run --filter=@playground/standalone-playground...",
     "start": "yarn http-server . -o /pages",
-    "dev": "yarn concurrently 'yarn . build && yarn start' 'sleep 10 && yarn . watch'",
+    "dev": "yarn concurrently 'yarn start' 'sleep 3 && ASSET_PATH='/node_modules/@segment/analytics-next/dist/umd/' yarn . watch'",
     "concurrently": "yarn run -T concurrently"
   },
   "dependencies": {


### PR DESCRIPTION
There was previous no way to actually debug ajs-destinations because of hash mismatches locally. This has been an issue serveral times for people who’ve had to debug important destination related code. The workaround has been to use chrome’s local overrides and paste code, which extremely manual and not intutitive.

![image](https://github.com/user-attachments/assets/9d16ccbc-de34-417d-b42e-279dab9f3547)

This fixes that issue:

![image](https://github.com/user-attachments/assets/397b8443-ca75-481b-bd74-4e0264700aa6)

