### PR TITLE
Fix conflict between window.analytics AND npm library in same scope.

### DIFF
--- a/.changeset/green-moles-provide.md
+++ b/.changeset/green-moles-provide.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+If npm version, do not read buffered events from window.analytics

--- a/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/analytics-pre-init.integration.test.ts
@@ -7,6 +7,7 @@ import { sleep } from '../../lib/sleep'
 import { setGlobalCDNUrl } from '../../lib/parse-cdn'
 import { User } from '../../core/user'
 import { getBufferedPageCtxFixture } from '../../test-helpers/fixtures'
+import { setVersionType } from '../../lib/version-type'
 
 jest.mock('unfetch')
 
@@ -235,6 +236,9 @@ describe('Pre-initialization', () => {
   })
 
   describe('Snippet / standalone', () => {
+    beforeAll(() => {
+      setVersionType('web')
+    })
     test('If a snippet user sends multiple events, all of those event gets flushed', async () => {
       const onTrackCb = jest.fn()
       const onTrack = ['on', 'track', onTrackCb]

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -10,6 +10,7 @@ import * as Factory from '../../test-helpers/factories'
 import { EventQueue } from '../../core/queue/event-queue'
 import { AnalyticsStandalone } from '../standalone-interface'
 import { getBufferedPageCtxFixture } from '../../test-helpers/fixtures'
+import { setVersionType } from '../../lib/version-type'
 
 const track = jest.fn()
 const identify = jest.fn()
@@ -45,6 +46,7 @@ describe('standalone bundle', () => {
   const segmentDotCom = `foo`
 
   beforeEach(async () => {
+    setVersionType('web')
     ;(window as any).analytics = undefined
     const html = `
     <!DOCTYPE html>

--- a/packages/browser/src/core/buffer/__tests__/index.test.ts
+++ b/packages/browser/src/core/buffer/__tests__/index.test.ts
@@ -12,9 +12,11 @@ import { sleep } from '../../../lib/sleep'
 import { User } from '../../user'
 import { getBufferedPageCtxFixture } from '../../../test-helpers/fixtures'
 import * as GlobalAnalytics from '../../../lib/global-analytics-helper'
+import { setVersionType } from '../../../lib/version-type'
 
 describe(PreInitMethodCallBuffer, () => {
   beforeEach(() => {
+    setVersionType('npm')
     GlobalAnalytics.setGlobalAnalytics(undefined as any)
   })
 
@@ -28,6 +30,7 @@ describe(PreInitMethodCallBuffer, () => {
     })
 
     it('should also read from global analytics buffer', () => {
+      setVersionType('web')
       const call1 = new PreInitMethodCall('identify', ['foo'], jest.fn())
       ;(window as any).analytics = [['track', 'snippet']]
 
@@ -75,6 +78,7 @@ describe(PreInitMethodCallBuffer, () => {
       expect(buffer.getCalls('group')).toEqual([call3])
     })
     it('should read from Snippet Buffer', () => {
+      setVersionType('web')
       const call1 = new PreInitMethodCall('identify', ['foo'], jest.fn())
       GlobalAnalytics.setGlobalAnalytics([['identify', 'snippet']] as any)
 
@@ -92,6 +96,7 @@ describe(PreInitMethodCallBuffer, () => {
   })
   describe('clear()', () => {
     it('should clear calls', () => {
+      setVersionType('web')
       const call1 = new PreInitMethodCall('identify', [], jest.fn())
       const call2 = new PreInitMethodCall('identify', [], jest.fn())
       const call3 = new PreInitMethodCall('group', [], jest.fn())
@@ -105,6 +110,7 @@ describe(PreInitMethodCallBuffer, () => {
 
   describe('Snippet buffer (method calls)', () => {
     it('should be read from the global analytics instance', () => {
+      setVersionType('web')
       const getGlobalAnalyticsSpy = jest.spyOn(
         GlobalAnalytics,
         'getGlobalAnalytics'

--- a/packages/browser/src/core/buffer/index.ts
+++ b/packages/browser/src/core/buffer/index.ts
@@ -11,6 +11,7 @@ import {
   createPageContext,
   PageContext,
 } from '../page'
+import { getVersionType } from '../../lib/version-type'
 
 /**
  * The names of any AnalyticsBrowser methods that also exist on Analytics
@@ -220,6 +221,11 @@ export class PreInitMethodCallBuffer {
    * This removes existing buffered calls from the window object.
    */
   private _pushSnippetWindowBuffer(): void {
+    // if this is the npm version, we don't want to read from the window object.
+    // This avoids namespace conflicts if there is a seperate analytics library on the page.
+    if (getVersionType() === 'npm') {
+      return undefined
+    }
     const wa = getGlobalAnalytics()
     if (!Array.isArray(wa)) return undefined
     const buffered: SnippetBuffer = wa.splice(0, wa.length)


### PR DESCRIPTION
This partly addresses: https://github.com/segmentio/analytics-next/issues/785, so we don't read buffered window.analytics events in the npm version.

Now we support using both a snippet version of analytics and a separate npm version of analytics instance (different writeKeys) in the same scope, and they shouldn't clobber eachother.

No need for `globalAnalyticsKey: 'SEG_DISABLE'` workaround.

For posterity, there is an existing gap is around if a user needs to override the global cdn on a specific instance.
