### PR TITLE
Do not make plugin.version mandatory

### DIFF
--- a/.changeset/ninety-fireants-explain.md
+++ b/.changeset/ninety-fireants-explain.md
@@ -1,0 +1,7 @@
+---
+'@segment/analytics-core': minor
+'@segment/analytics-next': minor
+'@segment/analytics-node': minor
+---
+
+Do not make plugin.version required

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -21,7 +21,7 @@ export interface CorePlugin<
   // This is only used for disabling plugins. An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'Braze Web Mode (Actions) updateUserProfile'. Which meant customers had to set that individual action to false to disable it before. Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName, which is when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility, we still needed to support disabling based on the concatenation since customers were doing that in the wild, so we can filter based on checking both name fields.
   /**
    * A concatenation of the current destination name and the specific action. This field is only relevant for destination plugins.
-   * @example ['Braze Web Mode (Actions) updateUserProfile'] // (and the plugin name would be "Braze Web Mode (Actions)"")
+   * @example ['Braze Web Mode (Actions) updateUserProfile'] // (and the plugin name would be 'Braze Web Mode (Actions)')
    */
   alternativeNames?: string[]
   /**

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -17,13 +17,10 @@ export interface CorePlugin<
   Analytics extends CoreAnalytics = any
 > {
   name: string
-  // An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'amplitude actions sessionId'
-  // Which meant customers had to set that individual action to false to disable it before.
-  // Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName
-  // that's when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility,
-  // we still needed to support disabling based on the concatenation since customers were doing that in the wild - those are stored in ‘alternativeNames’
-  // so we can filter based on checking both name fields.
+
+  // This is only used for disabling plugins. An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'Braze Web Mode (Actions) updateUserProfile'. Which meant customers had to set that individual action to false to disable it before. Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName, which is when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility, we still needed to support disabling based on the concatenation since customers were doing that in the wild, so we can filter based on checking both name fields.
   /**
+   * A concatenation of the current destination name and the specific action. This field is only relevant for destination plugins.
    * @example ['Braze Web Mode (Actions) updateUserProfile'] // (and the plugin name would be "Braze Web Mode (Actions)"")
    */
   alternativeNames?: string[]

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -17,7 +17,20 @@ export interface CorePlugin<
   Analytics extends CoreAnalytics = any
 > {
   name: string
+  // An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'amplitude actions sessionId'
+  // Which meant customers had to set that individual action to false to disable it before.
+  // Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName
+  // that's when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility,
+  // we still needed to support disabling based on the concatenation since customers were doing that in the wild - those are stored in ‘alternativeNames’
+  // so we can filter based on checking both name fields.
+  /**
+   * @example ['Braze Web Mode (Actions) updateUserProfile'] // (and the plugin name would be "Braze Web Mode (Actions)"")
+   */
   alternativeNames?: string[]
+  /**
+   * The version of the plugin.
+   * @example '1.0.0'
+   */
   version?: string
   type: PluginType
   isLoaded: () => boolean

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -18,11 +18,11 @@ export interface CorePlugin<
 > {
   name: string
 
-  // This is only used for disabling plugins. An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'Braze Web Mode (Actions) updateUserProfile'. Which meant customers had to set that individual action to false to disable it before. Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName, which is when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility, we still needed to support disabling based on the concatenation since customers were doing that in the wild, so we can filter based on checking both name fields.
   /**
    * A concatenation of the current destination name and the specific action. This field is only relevant for destination plugins.
    * @example ['Braze Web Mode (Actions) updateUserProfile'] // (and the plugin name would be 'Braze Web Mode (Actions)')
    */
+  // This is only used for disabling action plugins. An action destination plugin name used to be the concatenation of the current destination name, and the specific action (like 'Braze Web Mode (Actions) updateUserProfile'. Which meant customers had to set that individual action to false to disable it before. Then with the destination filter route, we created a new wrapper around actions to make it easy to disable based on the creationName, which is when we added creationName to the objects in remotePlugin. However, to preserve backwards compatibility, we still needed to support disabling based on the concatenation since customers were doing that in the wild, so we can filter based on checking both name fields.
   alternativeNames?: string[]
   /**
    * The version of the plugin.

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -18,7 +18,7 @@ export interface CorePlugin<
 > {
   name: string
   alternativeNames?: string[]
-  version: string
+  version?: string
   type: PluginType
   isLoaded: () => boolean
   load: (ctx: Ctx, instance: Analytics) => Promise<unknown>


### PR DESCRIPTION
There's no reason to force specifying a version -- it's only used for metrics, and typically for action destinations. It's just  extra boilerplate.