### PR TITLE
Add requirejs support

### DIFF
--- a/.changeset/rotten-papayas-flash.md
+++ b/.changeset/rotten-papayas-flash.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-wrapper-onetrust': minor
+---
+
+Add RequireJS support (analytics-onetrust.js)

--- a/packages/consent/consent-wrapper-onetrust/README.md
+++ b/packages/consent/consent-wrapper-onetrust/README.md
@@ -36,7 +36,7 @@ If you don't see a "Consent Management" option like the one below, please contac
   </script>
 
   <!-- Add Segment's OneTrust Consent Wrapper -->
-  <script src="https://cdn.jsdelivr.net/npm/@segment/analytics-consent-wrapper-onetrust@latest/dist/umd/analytics-onetrust.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@segment/analytics-consent-wrapper-onetrust@latest/dist/umd/analytics-onetrust.js"></script>
 
   <!--
     Add / Modify Segment Analytics Snippet

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -11,10 +11,11 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "sideEffects": [
-    "./dist/umd/analytics-onetrust.umd.js"
+    "./dist/umd/analytics-onetrust.umd.js",
+    "./dist/umd/analytics-onetrust.js"
   ],
-  "jsdelivr": "./dist/umd/analytics-onetrust.umd.js",
-  "unpkg": "./dist/umd/analytics-onetrust.umd.js",
+  "jsdelivr": "./dist/umd/analytics-onetrust.js",
+  "unpkg": "./dist/umd/analytics-onetrust.js",
   "files": [
     "LICENSE",
     "dist/",

--- a/packages/consent/consent-wrapper-onetrust/webpack.config.js
+++ b/packages/consent/consent-wrapper-onetrust/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = merge(common, {
     'analytics-onetrust.umd': {
       import: path.resolve(__dirname, 'src/index.umd.ts'),
       library: {
+        umdNamedDefine: true,
         name: 'AnalyticsOneTrust',
         type: 'umd',
       },

--- a/packages/consent/consent-wrapper-onetrust/webpack.config.js
+++ b/packages/consent/consent-wrapper-onetrust/webpack.config.js
@@ -10,9 +10,15 @@ module.exports = merge(common, {
     'analytics-onetrust.umd': {
       import: path.resolve(__dirname, 'src/index.umd.ts'),
       library: {
-        umdNamedDefine: true,
         name: 'AnalyticsOneTrust',
         type: 'umd',
+      },
+    },
+    'analytics-onetrust': {
+      import: path.resolve(__dirname, 'src/index.ts'),
+      library: {
+        name: 'AnalyticsOneTrust',
+        type: 'window',
       },
     },
   },


### PR DESCRIPTION
A customer who is using `RequireJS` got an error when using the umd version. `umdNamedDefine: true` removed the requirejs error, but then none of the globals were available in that scope. Rather than debugging it further, I'm publishing a vanilla script version, similar to what we do in analytics.js with `standalone.js`.

```
<script src="https://cdn.jsdelivr.net/npm/@segment/analytics-consent-wrapper-onetrust@latest/dist/umd/analytics-onetrust.js"></script>
```