### PR TITLE
Create global.js consent script where withOneTrust is stored in global scope

### DIFF
--- a/.changeset/warm-yaks-arrive.md
+++ b/.changeset/warm-yaks-arrive.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-consent-wrapper-onetrust': patch
+---
+
+Fix consent namespace issue

--- a/packages/consent/consent-wrapper-onetrust/README.md
+++ b/packages/consent/consent-wrapper-onetrust/README.md
@@ -36,7 +36,7 @@ If you don't see a "Consent Management" option like the one below, please contac
   </script>
 
   <!-- Add Segment's OneTrust Consent Wrapper -->
-  <script src="https://cdn.jsdelivr.net/npm/@segment/analytics-consent-wrapper-onetrust@latest/dist/umd/analytics-onetrust.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@segment/analytics-consent-wrapper-onetrust@latest/dist/umd/analytics-onetrust.umd.js"></script>
 
   <!--
     Add / Modify Segment Analytics Snippet

--- a/packages/consent/consent-wrapper-onetrust/README.md
+++ b/packages/consent/consent-wrapper-onetrust/README.md
@@ -103,11 +103,14 @@ withOneTrust(analytics, { consentModel: () => 'opt-in' | 'opt-out' })
 
 ### Build Artifacts
 
-- We build three versions of the library:
+- We build the following versions of the library
 
-1. `cjs` (CommonJS modules) - for npm library users
-2. `esm` (es6 modules) - for npm library users
-3. `umd` (bundle) - for snippet users (typically)
+| Format | Description | Path |
+|--------|-------------|------|
+| `cjs` (CommonJS modules) | For npm library users | `/dist/cjs` |
+| `esm` (ES6 modules) | For npm library users | `/dist/esm` |
+| `window` (window bundle) | This is the least amount of code. When you load this bundle via script tag, it simply exposes `window.withOneTrust` | `/dist/umd/analytics-onetrust.js` |
+| `umd` (umd bundle) | For more unusual cases, when a UMD bundle is required | `/dist/umd/analytics-onetrust.umd.js` |
 
 ### Browser Support
 

--- a/packages/consent/consent-wrapper-onetrust/README.md
+++ b/packages/consent/consent-wrapper-onetrust/README.md
@@ -107,16 +107,16 @@ withOneTrust(analytics, { consentModel: () => 'opt-in' | 'opt-out' })
 
 | Format | Description | Path |
 |--------|-------------|------|
-| `cjs` (CommonJS modules) | For npm library users | `/dist/cjs` |
-| `esm` (ES6 modules) | For npm library users | `/dist/esm` |
-| `window` (window bundle) | This is the least amount of code. When you load this bundle via script tag, it simply exposes `window.withOneTrust` | `/dist/umd/analytics-onetrust.js` |
-| `umd` (umd bundle) | For more unusual cases, when a UMD bundle is required | `/dist/umd/analytics-onetrust.umd.js` |
+| `cjs` (CommonJS modules) | For npm library users | `/dist/cjs/index.js` |
+| `esm` (ES6 modules) | For npm library users | `/dist/esm/index.js` |
+| `global` (window bundle) | This is the least amount of code. When you load this bundle via script tag, it simply exposes `window.withOneTrust` | `/dist/umd/analytics-onetrust.global.js` |
+| `umd` (umd bundle) | When a UMD bundle is required | `/dist/umd/analytics-onetrust.umd.js` |
 
 ### Browser Support
 
 - `cjs/esm` - Support modern JS syntax (ES2020). These are our npm library users, so we expect them to transpile this module themselves using something like babel/webpack if they need extra legacy browser support.
 
-- `umd` - Support back to IE11, but **do not** polyfill . See our docs on [supported browsers](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/supported-browsers).
+- `umd/global` - Support back to IE11, but **do not** polyfill . See our docs on [supported browsers](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/supported-browsers).
 
 In order to get full ie11 support, you are expected to bring your own polyfills. e.g. adding the following to your script tag:
 

--- a/packages/consent/consent-wrapper-onetrust/bundle-build-tests/global.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/bundle-build-tests/global.test.ts
@@ -1,0 +1,31 @@
+import { JSDOM } from 'jsdom'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('Global Scope Test', () => {
+  let dom: JSDOM
+  beforeAll(() => {
+    // Load the built file
+    const filePath = path.resolve(
+      __dirname,
+      '../dist/umd/analytics-onetrust.global.js'
+    )
+    const scriptContent = fs.readFileSync(filePath, 'utf-8')
+
+    // Create a new JSDOM instance
+    dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+    })
+
+    // Execute the script in the JSDOM context
+    const scriptElement = dom.window.document.createElement('script')
+    scriptElement.textContent = scriptContent
+    dom.window.document.head.appendChild(scriptElement)
+  })
+
+  test('should expose withOneTrust in the global scope', () => {
+    expect(dom.window.withOneTrust).toBeDefined()
+    expect(typeof dom.window.withOneTrust).toBe('function')
+  })
+})

--- a/packages/consent/consent-wrapper-onetrust/bundle-build-tests/umd.test.ts
+++ b/packages/consent/consent-wrapper-onetrust/bundle-build-tests/umd.test.ts
@@ -1,0 +1,55 @@
+import { JSDOM } from 'jsdom'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('UMD Scope Test', () => {
+  let dom: JSDOM
+  let scriptContent: string
+
+  beforeAll(() => {
+    // Load the built file
+    const filePath = path.resolve(
+      __dirname,
+      '../dist/umd/analytics-onetrust.umd.js'
+    )
+    scriptContent = fs.readFileSync(filePath, 'utf-8')
+
+    // Create a new JSDOM instance
+    dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+    })
+
+    // Execute the script in the JSDOM context
+    const scriptElement = dom.window.document.createElement('script')
+    scriptElement.textContent = scriptContent
+    dom.window.document.head.appendChild(scriptElement)
+  })
+
+  test('should expose withOneTrust in the global scope', () => {
+    expect(dom.window.withOneTrust).toBeDefined()
+    expect(typeof dom.window.withOneTrust).toBe('function')
+  })
+
+  test('should build a proper UMD module', () => {
+    // Check if the module is available as a global variable
+    expect(dom.window.AnalyticsOneTrust).toBeDefined()
+    expect(typeof dom.window.AnalyticsOneTrust).toBe('object')
+    expect(typeof dom.window.AnalyticsOneTrust.withOneTrust).toBe('function')
+
+    // Simulate a CommonJS environment
+    const module = { exports: {} }
+    const evalRequire = (id: string): { withOneTrust: any } => {
+      if (id === 'analytics-onetrust') {
+        eval(scriptContent)
+        return module.exports as any
+      }
+      throw new Error(`Cannot find module '${id}'`)
+    }
+
+    const commonJsModule = evalRequire('analytics-onetrust')
+    expect(commonJsModule).toBeDefined()
+    expect(commonJsModule.withOneTrust).toBeDefined()
+    expect(typeof commonJsModule.withOneTrust).toBe('function')
+  })
+})

--- a/packages/consent/consent-wrapper-onetrust/jest.setup.js
+++ b/packages/consent/consent-wrapper-onetrust/jest.setup.js
@@ -1,4 +1,9 @@
 const fetch = require('node-fetch')
+const { TextEncoder, TextDecoder } = require('util')
+
+// fix: "ReferenceError: TextEncoder is not defined" after upgrading JSDOM
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder
 
 // eslint-disable-next-line no-undef
 globalThis.fetch = fetch // polyfill fetch so nock will work correctly on node 18 (https://github.com/nock/nock/issues/2336)

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     ".": "yarn run -T turbo run --filter=@segment/analytics-consent-wrapper-onetrust...",
     "test": "yarn jest",
+    "bundle-build-test": "yarn webpack && yarn test ./bundle-build-tests/*",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",
     "build:esm": "yarn tsc -p tsconfig.build.json",

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -63,6 +63,8 @@
   },
   "devDependencies": {
     "@internal/config-webpack": "workspace:^",
-    "@internal/test-helpers": "workspace:^"
+    "@internal/test-helpers": "workspace:^",
+    "@types/jsdom": "^16.2.14",
+    "jsdom": "^19.0.0"
   }
 }

--- a/packages/consent/consent-wrapper-onetrust/package.json
+++ b/packages/consent/consent-wrapper-onetrust/package.json
@@ -12,10 +12,10 @@
   "types": "./dist/types/index.d.ts",
   "sideEffects": [
     "./dist/umd/analytics-onetrust.umd.js",
-    "./dist/umd/analytics-onetrust.js"
+    "./dist/umd/analytics-onetrust.global.js"
   ],
-  "jsdelivr": "./dist/umd/analytics-onetrust.js",
-  "unpkg": "./dist/umd/analytics-onetrust.js",
+  "jsdelivr": "./dist/umd/analytics-onetrust.umd.js",
+  "unpkg": "./dist/umd/analytics-onetrust.umd.js",
   "files": [
     "LICENSE",
     "dist/",

--- a/packages/consent/consent-wrapper-onetrust/webpack.config.js
+++ b/packages/consent/consent-wrapper-onetrust/webpack.config.js
@@ -14,10 +14,9 @@ module.exports = merge(common, {
         type: 'umd',
       },
     },
-    'analytics-onetrust': {
+    'analytics-onetrust.global': {
       import: path.resolve(__dirname, 'src/index.ts'),
       library: {
-        // no name, attach everything exported to global scope
         type: 'window',
       },
     },

--- a/packages/consent/consent-wrapper-onetrust/webpack.config.js
+++ b/packages/consent/consent-wrapper-onetrust/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = merge(common, {
     'analytics-onetrust': {
       import: path.resolve(__dirname, 'src/index.ts'),
       library: {
-        name: 'AnalyticsOneTrust',
+        // no name, attach everything exported to global scope
         type: 'window',
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,6 +4109,8 @@ __metadata:
     "@internal/config-webpack": "workspace:^"
     "@internal/test-helpers": "workspace:^"
     "@segment/analytics-consent-tools": 2.0.1
+    "@types/jsdom": ^16.2.14
+    jsdom: ^19.0.0
     tslib: ^2.4.1
   peerDependencies:
     "@segment/analytics-next": ">=1.67.0"


### PR DESCRIPTION
- add analytics-onetrust.global.js, as analytics-onetrust.js is confusing 
- update analytics-onetrust.global.js to not namespace exports under window.AnalyticsOneTrust.