### PR TITLE
expose analytics to initialize

### DIFF
--- a/.changeset/fast-snakes-promise.md
+++ b/.changeset/fast-snakes-promise.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Add analytics itself as argument to on('initialize'

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -417,7 +417,7 @@ async function loadAnalytics(
   }
 
   analytics.initialized = true
-  analytics.emit('initialize', settings, options)
+  analytics.emit('initialize', settings, options, analytics)
 
   await flushFinalBuffer(analytics, preInitBuffer)
 


### PR DESCRIPTION
// this supports the following for the snippet:

```ts
analytics.on('initialize', (_settings,  _opts, analytics) => console.log(analytics.user())
```

`analytics.ready(() =>`  waits for _all_ destinations to be loaded -- this method would not.