### PR TITLE
CDN URL on Analytics Settings

### DIFF
--- a/.changeset/angry-items-change.md
+++ b/.changeset/angry-items-change.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Refactoring CDN Url to be available from analytics settings

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -1045,6 +1045,7 @@ describe('public settings api', () => {
       writeKey,
       cdnSettings: cdnSettingsMinimal,
       timeout: 300,
+      cdnURL: 'https://cdn.segment.com',
     })
   })
 

--- a/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
+++ b/packages/browser/src/browser/__tests__/standalone-analytics.test.ts
@@ -132,7 +132,9 @@ describe('standalone bundle', () => {
       // @ts-ignore ignore Response required fields
       .mockImplementation((): Promise<Response> => fetchSettings)
 
-    await loadCDNSettings(segmentDotCom)
+    const mockCdn = 'https://cdn.foo.com'
+
+    await loadCDNSettings(segmentDotCom, mockCdn)
 
     expect(unfetch).toHaveBeenCalledWith(
       'https://cdn.foo.com/v1/projects/foo/settings'
@@ -147,7 +149,7 @@ describe('standalone bundle', () => {
     const mockCdn = 'http://my-overridden-cdn.com'
 
     getGlobalAnalytics()!._cdn = mockCdn
-    await loadCDNSettings(segmentDotCom)
+    await loadCDNSettings(segmentDotCom, mockCdn)
 
     expect(unfetch).toHaveBeenCalledWith(expect.stringContaining(mockCdn))
   })

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -148,10 +148,8 @@ export interface AnalyticsBrowserSettings {
 
 export function loadCDNSettings(
   writeKey: string,
-  cdnURL?: string
+  baseUrl: string
 ): Promise<CDNSettings> {
-  const baseUrl = cdnURL ?? getCDN()
-
   return fetch(`${baseUrl}/v1/projects/${writeKey}/settings`)
     .then((res) => {
       if (!res.ok) {
@@ -355,9 +353,9 @@ async function loadAnalytics(
     preInitBuffer.add(new PreInitMethodCall('page', []))
   }
 
+  const cdnURL = settings.cdnURL ?? getCDN()
   let cdnSettings =
-    settings.cdnSettings ??
-    (await loadCDNSettings(settings.writeKey, settings.cdnURL))
+    settings.cdnSettings ?? (await loadCDNSettings(settings.writeKey, cdnURL))
 
   if (options.updateCDNSettings) {
     cdnSettings = options.updateCDNSettings(cdnSettings)
@@ -379,7 +377,7 @@ async function loadAnalytics(
     ...options,
   }
 
-  const analytics = new Analytics({ ...settings, cdnSettings }, options)
+  const analytics = new Analytics({ ...settings, cdnSettings, cdnURL }, options)
 
   attachInspector(analytics)
 

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -80,9 +80,10 @@ export class AnalyticsInstanceSettings {
    * This is an unstable API, it may change in the future without warning.
    */
   readonly cdnSettings: CDNSettings
+  readonly cdnURL?: string
 
   /**
-   * Auto-track specific timeout setting   for legacy purposes.
+   * Auto-track specific timeout setting for legacy purposes.
    */
   timeout = 300
 
@@ -92,6 +93,7 @@ export class AnalyticsInstanceSettings {
       integrations: {},
       edgeFunction: {},
     }
+    this.cdnURL = settings.cdnURL
   }
 }
 
@@ -101,6 +103,7 @@ export class AnalyticsInstanceSettings {
 export interface AnalyticsSettings {
   writeKey: string
   cdnSettings?: CDNSettings
+  cdnURL?: string
 }
 
 export interface InitOptions {

--- a/packages/browser/src/plugins/segmentio/__tests__/retries.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/retries.test.ts
@@ -52,6 +52,7 @@ describe('Segment.io retries 500s and 429', () => {
   })
 
   test('delays retry on 429', async () => {
+    jest.useFakeTimers({ advanceTimers: true })
     const headers = new Headers()
     const resetTime = 1234
     headers.set('x-ratelimit-reset', resetTime.toString())


### PR DESCRIPTION
CDN Url has been added to analytics.settings
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [X] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
