### PR TITLE
Adding apiHost from segment.io settings, or default

### DIFF
--- a/.changeset/strong-worms-clap.md
+++ b/.changeset/strong-worms-clap.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Adding apiHost to the readonly data available from Analytics.settings

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -1046,6 +1046,7 @@ describe('public settings api', () => {
       cdnSettings: cdnSettingsMinimal,
       timeout: 300,
       cdnURL: 'https://cdn.segment.com',
+      apiHost: 'api.segment.io/v1',
     })
   })
 

--- a/packages/browser/src/browser/__tests__/integration.test.ts
+++ b/packages/browser/src/browser/__tests__/integration.test.ts
@@ -1041,13 +1041,15 @@ describe('public settings api', () => {
       cdnSettings: cdnSettingsMinimal,
     })
 
-    expect(analytics.settings).toEqual({
-      writeKey,
-      cdnSettings: cdnSettingsMinimal,
-      timeout: 300,
-      cdnURL: 'https://cdn.segment.com',
-      apiHost: 'api.segment.io/v1',
-    })
+    expect(analytics.settings).toEqual(
+      expect.objectContaining({
+        writeKey,
+        cdnSettings: cdnSettingsMinimal,
+        timeout: 300,
+        cdnURL: 'https://cdn.segment.com',
+        apiHost: 'api.segment.io/v1',
+      })
+    )
   })
 
   it('should have a writeKey', async () => {

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -95,7 +95,7 @@ export class AnalyticsInstanceSettings {
    */
   timeout = 300
 
-  constructor(settings: AnalyticsInstanceSettingsOptions, queue: EventQueue) {
+  constructor(settings: AnalyticsSettings, queue: EventQueue) {
     this._getSegmentPluginMetadata = () =>
       queue.plugins.find(isSegmentPlugin)?.metadata
     this.writeKey = settings.writeKey
@@ -114,10 +114,6 @@ export interface AnalyticsSettings {
   writeKey: string
   cdnSettings?: CDNSettings
   cdnURL?: string
-}
-
-interface AnalyticsInstanceSettingsOptions extends AnalyticsSettings {
-  getSegmentPluginMetadata?: () => SegmentIOPluginMetadata | undefined
 }
 
 export interface InitOptions {

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -50,6 +50,19 @@ function onAlias(analytics: Analytics, json: JSON): JSON {
   return json
 }
 
+export type SegmentIOPluginMetadata = {
+  writeKey: string
+  apiHost: string
+  protocol: string
+}
+export interface SegmentIOPlugin extends Plugin {
+  metadata: SegmentIOPluginMetadata
+}
+
+export const isSegmentPlugin = (plugin: Plugin): plugin is SegmentIOPlugin => {
+  return plugin.name === 'Segment.io'
+}
+
 export function segmentio(
   analytics: Analytics,
   settings?: SegmentioSettings,
@@ -129,7 +142,12 @@ export function segmentio(
       })
   }
 
-  const segmentio: Plugin = {
+  const segmentio: SegmentIOPlugin = {
+    metadata: {
+      writeKey,
+      apiHost,
+      protocol,
+    },
     name: 'Segment.io',
     type: 'destination',
     version: '0.1.0',


### PR DESCRIPTION
Note that cdnURL has to include protocol (https://), but apiHost must not)

<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [ ] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
