### PR TITLE
Update signal buffer max

### DIFF
--- a/.changeset/dull-poets-repeat.md
+++ b/.changeset/dull-poets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-signals': minor
+---
+
+Update max buffer size to 50

--- a/packages/signals/signals/src/core/buffer/index.ts
+++ b/packages/signals/signals/src/core/buffer/index.ts
@@ -31,7 +31,7 @@ export class SignalStore implements SignalPersistentStorage {
   }
 
   constructor(settings: { maxBufferSize?: number } = {}) {
-    this.maxBufferSize = settings.maxBufferSize ?? 100 // TODO: increase this number after development
+    this.maxBufferSize = settings.maxBufferSize ?? 50
     this.signalStore = this.createSignalStore()
     void this.initializeSignalCount()
   }

--- a/packages/signals/signals/src/core/buffer/index.ts
+++ b/packages/signals/signals/src/core/buffer/index.ts
@@ -31,7 +31,7 @@ export class SignalStore implements SignalPersistentStorage {
   }
 
   constructor(settings: { maxBufferSize?: number } = {}) {
-    this.maxBufferSize = settings.maxBufferSize ?? 25 // TODO: increase this number after development
+    this.maxBufferSize = settings.maxBufferSize ?? 100 // TODO: increase this number after development
     this.signalStore = this.createSignalStore()
     void this.initializeSignalCount()
   }


### PR DESCRIPTION
Update max buffer size to 50 -- it was at 25 for development, but kinda forgot. Could go higher but marginally afraid of performance issues, as current architecture deserializes every signal item on every new single.