### PR TITLE
Fix query string api not respecting source middleware

### DIFF
--- a/.changeset/few-starfishes-bake.md
+++ b/.changeset/few-starfishes-bake.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Fix query string API not respecting source middleware

--- a/packages/browser/src/browser/__tests__/query-string.integration.test.ts
+++ b/packages/browser/src/browser/__tests__/query-string.integration.test.ts
@@ -1,9 +1,23 @@
 import { JSDOM } from 'jsdom'
 import { Analytics } from '../../core/analytics'
-// @ts-ignore loadCDNSettings mocked dependency is accused as unused
 import { AnalyticsBrowser } from '..'
 import { setGlobalCDNUrl } from '../../lib/parse-cdn'
 import { TEST_WRITEKEY } from '../../test-helpers/test-writekeys'
+import { createMockFetchImplementation } from '../../test-helpers/fixtures/create-fetch-method'
+import { parseFetchCall } from '../../test-helpers/fetch-parse'
+import { cdnSettingsKitchenSink } from '../../test-helpers/fixtures/cdn-settings'
+
+const fetchCalls: ReturnType<typeof parseFetchCall>[] = []
+jest.mock('unfetch', () => {
+  return {
+    __esModule: true,
+    default: (url: RequestInfo, body?: RequestInit) => {
+      const call = parseFetchCall([url, body])
+      fetchCalls.push(call)
+      return createMockFetchImplementation(cdnSettingsKitchenSink)(url, body)
+    },
+  }
+})
 
 const writeKey = TEST_WRITEKEY
 
@@ -11,9 +25,6 @@ describe('queryString', () => {
   let jsd: JSDOM
 
   beforeEach(async () => {
-    jest.restoreAllMocks()
-    jest.resetAllMocks()
-
     const html = `
     <!DOCTYPE html>
       <head>
@@ -37,33 +48,41 @@ describe('queryString', () => {
     setGlobalCDNUrl(undefined as any)
   })
 
-  it('applies query string logic before analytics is finished initializing', async () => {
-    let analyticsInitializedBeforeQs: boolean | undefined
-    const originalQueryString = Analytics.prototype.queryString
-    const mockQueryString = jest
-      .fn()
-      .mockImplementation(async function (this: Analytics, ...args) {
-        // simulate network latency when retrieving the bundle
-        await new Promise((r) => setTimeout(r, 500))
-        return originalQueryString.apply(this, args).then((result) => {
-          // ensure analytics has not finished initializing before querystring completes
-          analyticsInitializedBeforeQs = this.initialized
-          return result
-        })
-      })
-    Analytics.prototype.queryString = mockQueryString
+  it('querystring events that update anonymousId have priority over other buffered events', async () => {
+    const queryStringSpy = jest.spyOn(Analytics.prototype, 'queryString')
 
     jsd.reconfigure({
       url: 'https://localhost/?ajs_aid=123',
     })
 
-    const [analytics] = await AnalyticsBrowser.load({ writeKey })
-    expect(mockQueryString).toHaveBeenCalledWith('?ajs_aid=123')
-    expect(analyticsInitializedBeforeQs).toBe(false)
-    // check that calls made immediately after analytics is loaded use correct anonymousId
-    const pageContext = await analytics.page()
+    const analytics = new AnalyticsBrowser()
+    const pagePromise = analytics.page()
+    await analytics.load({ writeKey })
+    expect(queryStringSpy).toHaveBeenCalledWith('?ajs_aid=123')
+    const pageContext = await pagePromise
     expect(pageContext.event.anonymousId).toBe('123')
-    expect(analytics.user().anonymousId()).toBe('123')
+    const user = await analytics.user()
+    expect(user.anonymousId()).toBe('123')
+  })
+
+  it('querystring events have middleware applied like any other event', async () => {
+    jsd.reconfigure({
+      url: 'https://localhost/?ajs_event=Clicked',
+    })
+
+    const analytics = new AnalyticsBrowser()
+    void analytics.addSourceMiddleware(({ next, payload }) => {
+      payload.obj.event = payload.obj.event + ' Middleware Applied'
+      return next(payload)
+    })
+    await analytics.load({ writeKey })
+    const trackCalls = fetchCalls.filter(
+      (call) => call.url === 'https://api.segment.io/v1/t'
+    )
+    expect(trackCalls.length).toBe(1)
+    expect(trackCalls[0].body.event).toMatchInlineSnapshot(
+      `"Clicked Middleware Applied"`
+    )
   })
 
   it('applies query string logic if window.location.search is present', async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -44,7 +44,7 @@
     },
     "lint": {
       "dependsOn": ["build"],
-      "inputs": ["**/tsconfig*.json", "**/*.ts", "**/*.tsx", "**/*.js"],
+      "inputs": ["**/tsconfig*.json", "**/*.ts", "**/*.tsx"],
       "outputs": []
     },
     "test:cloudflare-workers": {


### PR DESCRIPTION
Fixes bug where addSourceMiddleware  would not be applied to events picked up via query string:
## example
```ts
  analytics.addSourceMiddleware(({ payload, next, integrations }) => {
    console.log(page.type)
    next(payload);
  };);
  analytics.load()
  analytics.page()
```