### PR TITLE
Add signals middleware

### DIFF
--- a/.changeset/warm-lies-rush.md
+++ b/.changeset/warm-lies-rush.md
@@ -1,0 +1,23 @@
+---
+'@segment/analytics-signals': minor
+---
+
+Allow registration of middleware
+
+```ts
+class MyMiddleware implements SignalsMiddleware {
+  process(signal: Signal) {
+    if (
+      signal.type === 'network' &&
+      signal.data.action === 'request' &&
+      signal.data.contentType.includes('api-keys')
+    ) {
+      // drop signal
+      return null
+    } else {
+      return signal
+    }
+  }
+}
+signalsPlugin.register(new MyMiddleware())
+```

--- a/.changeset/warm-lies-rush.md
+++ b/.changeset/warm-lies-rush.md
@@ -19,5 +19,7 @@ class MyMiddleware implements SignalsMiddleware {
     }
   }
 }
-signalsPlugin.register(new MyMiddleware())
+const signalsPlugin = new SignalsPlugin({
+  middleware: [new MyMiddleware()]
+})
 ```

--- a/.changeset/warm-lies-rush.md
+++ b/.changeset/warm-lies-rush.md
@@ -2,7 +2,7 @@
 '@segment/analytics-signals': minor
 ---
 
-Allow registration of middleware
+Allow registration of middleware to allow for dropping and modification of signals
 
 ```ts
 class MyMiddleware implements SignalsMiddleware {
@@ -10,9 +10,9 @@ class MyMiddleware implements SignalsMiddleware {
     if (
       signal.type === 'network' &&
       signal.data.action === 'request' &&
-      signal.data.contentType.includes('api-keys')
+      ...
     ) {
-      // drop signal
+      // drop or modify signal
       return null
     } else {
       return signal

--- a/packages/signals/signals-integration-tests/package.json
+++ b/packages/signals/signals-integration-tests/package.json
@@ -9,7 +9,7 @@
     ".": "yarn run -T turbo run --filter=@internal/signals-integration-tests...",
     "build": "webpack",
     "test": "playwright test",
-    "test:vanilla": "playwright test src/tests/vanilla",
+    "test:vanilla": "playwright test src/tests/signals-vanilla",
     "test:perf": "playwright test src/tests/performance",
     "test:custom": "playwright test src/tests/custom",
     "watch": "webpack -w",

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -10,6 +10,6 @@ export const logConsole = (page: Page) => {
     console.log(`console.${msg.type()}:`, text)
   })
   page.on('pageerror', (error) => {
-    console.error('Page error:', error, `[name]: ${error.name}`)
+    console.error('Page error:', error)
   })
 }

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -4,8 +4,8 @@ export const logConsole = (page: Page) => {
   page.on('console', (msg) => {
     const text = msg.text()
     // keep stdout clean, e.g. by not printing intentional errors
-    const blacklist = ['Bad Request']
-    if (blacklist.some((str) => text.includes(str))) {
+    const ignoreList = ['Bad Request']
+    if (ignoreList.some((str) => text.includes(str))) {
       return
     }
     console.log(`console.${msg.type()}:`, text)

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -1,10 +1,10 @@
 import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
+  const CONSOLE_BLACKLIST = ['Bad Request']
   page.on('console', (msg) => {
-    const CONSOLE_BLACKLIST = ['Bad Request']
     const text = msg.text()
-    // do not print errors that are expected -- e.g. network errors set up to test the unhappy path.
+    // keep stdout clean, e.g. by not printing intentional errors
     if (CONSOLE_BLACKLIST.some((str) => text.includes(str))) {
       return
     }

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -2,12 +2,7 @@ import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
   page.on('console', (msg) => {
-    const text = msg.text()
-    if (text.includes('NAME_NOT_RESOLVED')) {
-      // dns error spam started showing up -- either a chrome change or a vpn issue
-      return
-    }
-    console.log(`console.${msg.type()}:`, text)
+    console.log(`console.${msg.type()}:`, msg.text())
   })
   page.on('pageerror', (error) => {
     console.error('Page error:', error)

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -1,11 +1,11 @@
 import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
-  const CONSOLE_BLACKLIST = ['Bad Request']
   page.on('console', (msg) => {
     const text = msg.text()
     // keep stdout clean, e.g. by not printing intentional errors
-    if (CONSOLE_BLACKLIST.some((str) => text.includes(str))) {
+    const blacklist = ['Bad Request']
+    if (blacklist.some((str) => text.includes(str))) {
       return
     }
     console.log(`console.${msg.type()}:`, text)

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -2,9 +2,13 @@ import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
   page.on('console', (msg) => {
+    if (msg.text().includes('NAME_NOT_RESOLVED')) {
+      // dns error spam started showing up -- either a chrome change or a vpn issue
+      return
+    }
     console.log(`console.${msg.type()}:`, msg.text())
   })
   page.on('pageerror', (error) => {
-    console.error('Page error:', error)
+    console.error('Page error:', error, `[name]: ${error.name}`)
   })
 }

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -2,11 +2,12 @@ import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
   page.on('console', (msg) => {
-    if (msg.text().includes('NAME_NOT_RESOLVED')) {
+    const text = msg.text()
+    if (text.includes('NAME_NOT_RESOLVED')) {
       // dns error spam started showing up -- either a chrome change or a vpn issue
       return
     }
-    console.log(`console.${msg.type()}:`, msg.text())
+    console.log(`console.${msg.type()}:`, text)
   })
   page.on('pageerror', (error) => {
     console.error('Page error:', error, `[name]: ${error.name}`)

--- a/packages/signals/signals-integration-tests/src/helpers/log-console.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/log-console.ts
@@ -2,7 +2,13 @@ import { Page } from '@playwright/test'
 
 export const logConsole = (page: Page) => {
   page.on('console', (msg) => {
-    console.log(`console.${msg.type()}:`, msg.text())
+    const CONSOLE_BLACKLIST = ['Bad Request']
+    const text = msg.text()
+    // do not print errors that are expected -- e.g. network errors set up to test the unhappy path.
+    if (CONSOLE_BLACKLIST.some((str) => text.includes(str))) {
+      return
+    }
+    console.log(`console.${msg.type()}:`, text)
   })
   page.on('pageerror', (error) => {
     console.error('Page error:', error)

--- a/packages/signals/signals-integration-tests/src/tests/custom-elements/index.html
+++ b/packages/signals/signals-integration-tests/src/tests/custom-elements/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <!-- Dummy favicon -->
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+ <link rel="shortcut icon" href="#">>
 </head>
 
 <body>

--- a/packages/signals/signals-integration-tests/src/tests/performance/index.html
+++ b/packages/signals/signals-integration-tests/src/tests/performance/index.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../../../dist/signals-vanilla.bundle.js"></script>
   <!-- Dummy favicon -->
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="shortcut icon" href="#">
 </head>
 
 <body>

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.bundle.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.bundle.ts
@@ -2,7 +2,7 @@ import { AnalyticsBrowser } from '@segment/analytics-next'
 import { SignalsPlugin } from '@segment/analytics-signals'
 
 /**
- * Not instantiating the analytics object here, as it will be instantiated in the test
+ * Not calling analytics.load() or instantiating Signals Plugin here, as all this configuration happens in the page object.
  */
 window.SignalsPlugin = SignalsPlugin
 window.analytics = new AnalyticsBrowser()

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.html
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../../../dist/signals-vanilla.bundle.js"></script>
   <!-- Dummy favicon -->
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="shortcut icon" href="#">
 </head>
 
 <body>

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.html
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/index.html
@@ -10,7 +10,7 @@
 <body>
   <button id="some-button">Click me</button>
   <button id="complex-button">
-    <img id="some-image" src="https://via.placeholder.com/150" alt="Placeholder Image">
+    <img id="some-image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgEBAyX8UgAAAABJRU5ErkJggg==" alt="Placeholder Image">
     <div>
       Other Example Button with <h1>Nested Text</h1>
     </div>

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/middleware.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/middleware.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { IndexPage } from './index-page'
+
+const basicEdgeFn = `const processSignal = (signal) => {}`
+
+let indexPage: IndexPage
+
+test('middleware', async ({ page }) => {
+  indexPage = await new IndexPage().load(
+    page,
+    basicEdgeFn,
+    {},
+    {
+      skipSignalsPluginInit: true,
+    }
+  )
+
+  await page.evaluate(
+    ({ settings }) => {
+      window.signalsPlugin = new window.SignalsPlugin({
+        middleware: [
+          {
+            load() {
+              return undefined
+            },
+            process: function (signal) {
+              // @ts-ignore
+              signal.data['middleware'] = 'test'
+              return signal
+            },
+          },
+        ],
+        ...settings,
+      })
+      window.analytics.load({
+        writeKey: '<SOME_WRITE_KEY>',
+        plugins: [window.signalsPlugin],
+      })
+    },
+    {
+      settings: {
+        ...indexPage.defaultSignalsPluginTestSettings,
+        flushAt: 1,
+      },
+    }
+  )
+
+  /**
+   * Make an analytics.page() call, see that the middleware can modify the event
+   */
+  await Promise.all([
+    indexPage.makeAnalyticsPageCall(),
+    indexPage.waitForSignalsApiFlush(),
+  ])
+
+  const instrumentationEvents =
+    indexPage.signalsAPI.getEvents('instrumentation')
+  expect(instrumentationEvents).toHaveLength(1)
+  const ev = instrumentationEvents[0]
+  expect(ev.properties!.data['middleware']).toEqual('test')
+})

--- a/packages/signals/signals/README.md
+++ b/packages/signals/signals/README.md
@@ -95,6 +95,30 @@ signalsPlugin.onSignal((signal) => console.log(signal))
 ```
 
 
+### Middleware / Plugins
+#### Drop or modify signals
+```ts
+import { SignalsPlugin, SignalsMiddleware } from '@segment/analytics-signals'
+
+class MyMiddleware implements SignalsMiddleware {
+  process(signal: Signal) {
+    // drop the event if some conditions are met
+    if (
+       signal.type === 'network' &&
+       signal.data.action === 'request' &&
+       ...
+    ) {
+      return null;
+    } else {
+      return signal;
+    }
+  }
+}
+const signalsPlugin = new SignalsPlugin({ middleware: [myMiddleware]})
+analytics.register(signalsPlugin)
+```
+
+
 ### Playground / Development / Testing
 See the [signals example repo](../signals-example).
 

--- a/packages/signals/signals/src/core/emitter/index.ts
+++ b/packages/signals/signals/src/core/emitter/index.ts
@@ -1,6 +1,6 @@
-import { Emitter } from '@segment/analytics-generic-utils'
 import { logger } from '../../lib/logger'
 import { Signal } from '@segment/analytics-signals-runtime'
+import { SignalGlobalSettings } from '../signals'
 
 export interface EmitSignal {
   emit: (signal: Signal) => void
@@ -17,31 +17,95 @@ const logSignal = (signal: Signal) => {
   )
 }
 
-export class SignalEmitter implements EmitSignal {
-  private emitter = new Emitter<{ add: [Signal] }>()
-  private listeners = new Set<(signal: Signal) => void>()
+export type LoadContext = {
+  settings: SignalGlobalSettings
+  writeKey: string
+}
 
-  emit(signal: Signal) {
-    logSignal(signal)
-    this.emitter.emit('add', signal)
+interface SignalPlugin {
+  /**
+   * Wait for this to complete before emitting signals
+   * Like a 'before' plugin, blocks the event pipeline
+   */
+  load(ctx: LoadContext): Promise<void> | void
+  process(signal: Signal): Signal | null
+}
+
+export class SignalEmitter implements EmitSignal {
+  private listeners = new Set<(signal: Signal) => void>()
+  private middlewares: SignalPlugin[] = []
+  private initialized = false // Controls buffering vs eager signal processing
+  private signalQueue: Signal[] = [] // Buffer for signals emitted before initialization
+
+  // Add a plugin
+  addPlugin(plugin: SignalPlugin): void {
+    this.middlewares.push(plugin)
   }
 
-  subscribe(listener: (signal: Signal) => void) {
-    // Prevent duplicate subscriptions
+  // Emit a signal
+  emit(signal: Signal): void {
+    logSignal(signal)
+    if (!this.initialized) {
+      // Buffer the signal if not initialized
+      this.signalQueue.push(signal)
+      return
+    }
+
+    // Process and notify listeners
+    this.processAndEmit(signal)
+  }
+
+  // Process and emit a signal
+  private processAndEmit(signal: Signal): void {
+    // Apply plugin; drop the signal if any plugin returns null
+    for (const plugin of this.middlewares) {
+      const processed = plugin.process(signal)
+      if (processed === null) return // Drop the signal
+    }
+
+    // Notify listeners
+    for (const listener of this.listeners) {
+      listener(signal)
+    }
+  }
+
+  // Initialize the emitter, load plugin, flush the buffer, and enable eager processing
+  async initialize(settings: LoadContext): Promise<void> {
+    if (this.initialized) return
+
+    // Wait for all plugin to complete their load method
+    await Promise.all(this.middlewares.map((mw) => mw.load(settings)))
+
+    this.initialized = true
+
+    // Process and emit all buffered signals
+    while (this.signalQueue.length > 0) {
+      const signal = this.signalQueue.shift() as Signal
+      this.processAndEmit(signal)
+    }
+  }
+
+  // Subscribe a listener to signals
+  subscribe(listener: (signal: Signal) => void): void {
     if (!this.listeners.has(listener)) {
       logger.debug('subscribed')
       this.listeners.add(listener)
     }
-    this.emitter.on('add', listener)
   }
 
-  unsubscribe(listener: (signal: Signal) => void) {
-    this.listeners.delete(listener)
-    logger.debug('unsubscribed')
-    this.emitter.off('add', listener)
+  // Unsubscribe a listener
+  unsubscribe(listener: (signal: Signal) => void): void {
+    if (this.listeners.delete(listener)) {
+      logger.debug('unsubscribed')
+    }
   }
 
-  once(listener: (signal: Signal) => void) {
-    this.emitter.once('add', listener)
+  // Subscribe a listener to a single signal
+  once(listener: (signal: Signal) => void): void {
+    const wrappedListener = (signal: Signal) => {
+      this.unsubscribe(wrappedListener)
+      listener(signal)
+    }
+    this.subscribe(wrappedListener)
   }
 }

--- a/packages/signals/signals/src/core/emitter/index.ts
+++ b/packages/signals/signals/src/core/emitter/index.ts
@@ -85,7 +85,7 @@ export class SignalEmitter implements EmitSignal {
     }
   }
 
-  // Subscribe a listener to signals
+  // Subscribe a listener to signals --  equivilant to a destination plugin?
   subscribe(listener: (signal: Signal) => void): void {
     if (!this.listeners.has(listener)) {
       logger.debug('subscribed')

--- a/packages/signals/signals/src/core/emitter/index.ts
+++ b/packages/signals/signals/src/core/emitter/index.ts
@@ -1,20 +1,8 @@
-import { logger } from '../../lib/logger'
 import { Signal } from '@segment/analytics-signals-runtime'
 import { SignalGlobalSettings } from '../signals'
 
 export interface EmitSignal {
   emit: (signal: Signal) => void
-}
-
-const logSignal = (signal: Signal) => {
-  logger.info(
-    'New signal:',
-    signal.type,
-    signal.data,
-    ...(signal.type === 'interaction' && 'change' in signal.data
-      ? ['change:', JSON.stringify(signal.data.change, null, 2)]
-      : [])
-  )
 }
 
 export interface SignalsMiddlewareContext {
@@ -54,7 +42,6 @@ export class SignalEmitter implements EmitSignal {
 
   // Emit a signal
   emit(signal: Signal): void {
-    logSignal(signal)
     if (!this.initialized) {
       // Buffer the signal if not initialized
       this.signalQueue.push(signal)
@@ -111,15 +98,12 @@ export class SignalEmitter implements EmitSignal {
    */
   subscribe(listener: (signal: Signal) => void): void {
     if (!this.listeners.has(listener)) {
-      logger.debug('subscribed')
       this.listeners.add(listener)
     }
   }
 
   // Unsubscribe a listener
   unsubscribe(listener: (signal: Signal) => void): void {
-    if (this.listeners.delete(listener)) {
-      logger.debug('unsubscribed')
-    }
+    this.listeners.delete(listener)
   }
 }

--- a/packages/signals/signals/src/core/emitter/index.ts
+++ b/packages/signals/signals/src/core/emitter/index.ts
@@ -39,11 +39,18 @@ export interface SignalsMiddleware {
   process(signal: Signal): Signal | null
 }
 
+export interface SignalEmitterSettings {
+  middleware?: SignalsMiddleware[]
+}
 export class SignalEmitter implements EmitSignal {
   private listeners = new Set<(signal: Signal) => void>()
   private middlewares: SignalsMiddleware[] = []
   private initialized = false // Controls buffering vs eager signal processing
   private signalQueue: Signal[] = [] // Buffer for signals emitted before initialization
+
+  constructor(settings?: SignalEmitterSettings) {
+    if (settings?.middleware) this.middlewares.push(...settings.middleware)
+  }
 
   // Emit a signal
   emit(signal: Signal): void {
@@ -56,11 +63,6 @@ export class SignalEmitter implements EmitSignal {
 
     // Process and notify listeners
     this.processAndEmit(signal)
-  }
-
-  // Register custom signals middleware, to drop signals or modify them before they are emitted.
-  register(...middleware: SignalsMiddleware[]): void {
-    this.middlewares.push(...middleware)
   }
 
   // Process and emit a signal

--- a/packages/signals/signals/src/core/middleware/network-signals-filter/__tests__/network-signals-filter.test.ts
+++ b/packages/signals/signals/src/core/middleware/network-signals-filter/__tests__/network-signals-filter.test.ts
@@ -1,0 +1,72 @@
+import {
+  NetworkSettingsConfig,
+  NetworkSettingsConfigSettings,
+  NetworkSignalsFilter,
+} from '../network-signals-filter'
+import { setLocation } from '../../../../test-helpers/set-location'
+
+describe(NetworkSignalsFilter, () => {
+  class TestNetworkSignalsFilter extends NetworkSignalsFilter {
+    constructor(settings: Partial<NetworkSettingsConfigSettings> = {}) {
+      super(new NetworkSettingsConfig(settings))
+    }
+  }
+
+  beforeEach(() => {
+    setLocation({ hostname: 'localhost' })
+  })
+
+  it('should respect the allow/disallow list', () => {
+    const filter = new TestNetworkSignalsFilter({
+      networkSignalsAllowList: [
+        new RegExp(`allowed.com/api/v1`),
+        'foo.com/api/v2',
+      ],
+      networkSignalsDisallowList: [new RegExp(`allowed.com/api/v666`)],
+    })
+
+    // allowed
+    expect(filter.isAllowed(`http://allowed.com/api/v1/test`)).toBe(true)
+    // not allowed
+    expect(filter.isAllowed(`http://allowed.com/api/v666`)).toBe(false)
+  })
+
+  it('will not allow signals for same domain if networkSignalsAllowSameDomain = false', () => {
+    const filter = new TestNetworkSignalsFilter({
+      networkSignalsAllowList: ['foo.com'],
+      networkSignalsDisallowList: [],
+      networkSignalsAllowSameDomain: false,
+    })
+
+    expect(filter.isAllowed(`http://${window.location.hostname}/test`)).toBe(
+      false
+    )
+    expect(filter.isAllowed(`http://foo.com/test`)).toBe(true)
+  })
+
+  it('disallows the signal if it matches in both the allow and disallow list', () => {
+    const filter = new TestNetworkSignalsFilter({
+      networkSignalsAllowList: ['disallowed-api.com'],
+      networkSignalsDisallowList: ['https://disallowed-api.com'],
+    })
+
+    expect(filter.isAllowed(`https://disallowed-api.com/api/foo`)).toBe(false)
+  })
+
+  it('allows an explicit disallow list to override same-domain signals', () => {
+    const filter = new TestNetworkSignalsFilter({
+      networkSignalsDisallowList: ['/foo'],
+    })
+
+    expect(filter.isAllowed(`/test/foo`)).toBe(false)
+    expect(filter.isAllowed(`/test/bar`)).toBe(true)
+  })
+
+  it('always disallows segment api network signals', () => {
+    const filter = new TestNetworkSignalsFilter({
+      networkSignalsAllowList: ['.*'],
+    })
+
+    expect(filter.isAllowed(`https://api.segment.io`)).toBe(false)
+  })
+})

--- a/packages/signals/signals/src/core/signal-generators/dom-gen/__tests__/change-gen.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/dom-gen/__tests__/change-gen.test.ts
@@ -6,9 +6,10 @@ describe('OnChangeGenerator', () => {
   let onChangeGenerator: OnChangeGenerator
   let emitter: SignalEmitter
   let unregister: () => void
-  beforeEach(() => {
+  beforeEach(async () => {
     onChangeGenerator = new OnChangeGenerator()
     emitter = new SignalEmitter()
+    await emitter.initialize({} as any)
   })
 
   afterEach(() => {

--- a/packages/signals/signals/src/core/signals/settings.ts
+++ b/packages/signals/signals/src/core/signals/settings.ts
@@ -3,10 +3,10 @@ import { logger } from '../../lib/logger'
 import { SignalBufferSettingsConfig, SignalPersistentStorage } from '../buffer'
 import { SignalsIngestSettingsConfig } from '../client'
 import { SandboxSettingsConfig } from '../processor/sandbox'
-import { NetworkSettingsConfig } from '../signal-generators/network-gen'
 import { SignalsPluginSettingsConfig } from '../../types'
 import { WebStorage } from '../../lib/storage/web-storage'
 import { MutationGeneratorSettings } from '../signal-generators/dom-gen/change-gen'
+import { NetworkSettingsConfig } from '../middleware/network-signals-filter/network-signals-filter'
 
 export type SignalsSettingsConfig = Pick<
   SignalsPluginSettingsConfig,

--- a/packages/signals/signals/src/core/signals/settings.ts
+++ b/packages/signals/signals/src/core/signals/settings.ts
@@ -10,6 +10,7 @@ import { MutationGeneratorSettings } from '../signal-generators/dom-gen/change-g
 
 export type SignalsSettingsConfig = Pick<
   SignalsPluginSettingsConfig,
+  | 'middleware'
   | 'maxBufferSize'
   | 'apiHost'
   | 'functionHost'

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -41,7 +41,9 @@ export class Signals implements ISignals {
     /**
      * TODO: add an event queue inside the signal emitter
      */
-    this.signalEmitter = new SignalEmitter()
+    this.signalEmitter = new SignalEmitter({
+      middleware: settingsConfig.middleware ?? [],
+    })
     this.signalsClient = new SignalsIngestClient(
       this.globalSettings.ingestClient
     )

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -109,7 +109,7 @@ export class Signals implements ISignals {
 
     // load emitter and flush any queued signals to all subscribers
     void this.signalEmitter.initialize({
-      settings: this.globalSettings,
+      globalSettings: this.globalSettings,
       writeKey: analyticsService.instance.settings.writeKey,
     })
   }

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -87,7 +87,6 @@ export class Signals implements ISignals {
     this.preStartBuffer = []
 
     // listen + process new signals - meaning, executing them in the analytics runtime
-    // This could be implemented as a plugin?
     this.signalEmitter.subscribe(async (signal) => {
       void processor.process(signal, await this.buffer.getAll())
     })

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -56,6 +56,7 @@ export class Signals implements ISignals {
      * It can be set at the emitter level, so that no signals actually get emitted until the middleware has initialized.
      */
     this.signalEmitter.subscribe((signal) => {
+      logger.logSignal(signal)
       void this.signalsClient.send(signal)
       void this.buffer.add(signal)
     })

--- a/packages/signals/signals/src/index.ts
+++ b/packages/signals/signals/src/index.ts
@@ -6,6 +6,10 @@ export { SignalsPlugin } from './plugin/signals-plugin'
 export { Signals } from './core/signals'
 export type { Signal } from '@segment/analytics-signals-runtime'
 export type {
+  SignalsMiddleware,
+  SignalsMiddlewareContext,
+} from './core/emitter'
+export type {
   ProcessSignal,
   AnalyticsRuntimePublicApi,
   SignalsPluginSettingsConfig,

--- a/packages/signals/signals/src/lib/logger/index.ts
+++ b/packages/signals/signals/src/lib/logger/index.ts
@@ -1,3 +1,4 @@
+import type { Signal } from '../..'
 import {
   LogLevelOptions,
   parseDebugModeQueryString,
@@ -47,6 +48,17 @@ class Logger {
     if (this.logLevel === 'debug') {
       this.log('debug', ...args)
     }
+  }
+
+  logSignal = (signal: Signal): void => {
+    this.info(
+      'New signal:',
+      signal.type,
+      signal.data,
+      ...(signal.type === 'interaction' && 'change' in signal.data
+        ? ['change:', JSON.stringify(signal.data.change, null, 2)]
+        : [])
+    )
   }
 }
 

--- a/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
+++ b/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
@@ -1,4 +1,3 @@
-import { analyticsMock } from '../../test-helpers/mocks'
 import { SignalsPlugin } from '../signals-plugin'
 
 // this specific test was throwing a bunch of warnings:

--- a/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
+++ b/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
@@ -1,3 +1,4 @@
+import { analyticsMock } from '../../test-helpers/mocks'
 import { SignalsPlugin } from '../signals-plugin'
 
 // this specific test was throwing a bunch of warnings:
@@ -39,7 +40,7 @@ describe(SignalsPlugin, () => {
     expect(emitterSpy.mock.calls[0][0]).toEqual(callback)
   })
 
-  test('addSignal method emits signal', () => {
+  test('addSignal method emits signal', async () => {
     const plugin = new SignalsPlugin()
     const signal = { data: 'test' } as any
     const emitterSpy = jest.spyOn(plugin.signals.signalEmitter, 'emit')

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -83,10 +83,7 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
   }
 
   addSignal(signal: Signal): this {
-    signal.type === 'network' &&
-      signal.data.action === 'request' &&
-      typeof signal.data.data === 'object' &&
-      this.signals.signalEmitter.emit(signal)
+    this.signals.signalEmitter.emit(signal)
     return this
   }
 

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -83,7 +83,10 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
   }
 
   addSignal(signal: Signal): this {
-    this.signals.signalEmitter.emit(signal)
+    signal.type === 'network' &&
+      signal.data.action === 'request' &&
+      typeof signal.data.data === 'object' &&
+      this.signals.signalEmitter.emit(signal)
     return this
   }
 

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -92,14 +92,7 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
    * @param example
    *```ts
    * class MyMiddleware implements SignalsMiddleware {
-   *   private unstableGlobalSettings!: SignalsMiddlewareContext['settings'];
-   *
-   *   load({ unstableGlobalSettings, analytics }: SignalsMiddlewareContext) {
-   *     this.settings = unstableGlobalSettings;
-   *   }
-   *
    *   process(signal: Signal) {
-   *     // drop signal if it does not match the filter list
    *     if (
    *        signal.type === 'network' &&
    *        signal.data.action === 'request' &&

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -5,7 +5,6 @@ import { AnyAnalytics, SignalsPluginSettingsConfig } from '../types'
 import { Signal } from '@segment/analytics-signals-runtime'
 import { assertBrowserEnv } from '../lib/assert-browser-env'
 import { version } from '../generated/version'
-import { SignalsMiddleware } from '../core/emitter'
 
 export type OnSignalCb = (signal: Signal) => void
 
@@ -57,6 +56,7 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
       networkSignalsDisallowList: settings.networkSignalsDisallowList,
       signalStorage: settings.signalStorage,
       signalStorageType: settings.signalStorageType,
+      middleware: settings.middleware,
     })
   }
 
@@ -85,32 +85,6 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
   addSignal(signal: Signal): this {
     this.signals.signalEmitter.emit(signal)
     return this
-  }
-
-  /**
-   * Register custom signals middleware, to drop signals or modify them before they are emitted.
-   * @param example
-   *```ts
-   * class MyMiddleware implements SignalsMiddleware {
-   *   process(signal: Signal) {
-   *     if (
-   *        signal.type === 'network' &&
-   *        signal.data.action === 'request' &&
-   *        signal.data.contentType.includes('api-keys')
-   *     ) {
-   *       return null;
-   *     } else {
-   *       return signal;
-   *     }
-   *   }
-   * }
-   *
-   * signalsPlugin.register(new MyMiddleware());
-   * ````
-   *
-   */
-  register(...middleware: SignalsMiddleware[]): void {
-    this.signals.signalEmitter.register(...middleware)
   }
 
   /**

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -101,11 +101,9 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
    *   process(signal: Signal) {
    *     // drop signal if it does not match the filter list
    *     if (
-   *       signal.type === 'network' &&
-   *       networkSignalIsInvalid(
-   *         signal,
-   *         this.unstableGlobalSettings.network.networkSignalsFilterList
-   *       )
+   *        signal.type === 'network' &&
+   *        signal.data.action === 'request' &&
+   *        signal.data.contentType.includes('api-keys')
    *     ) {
    *       return null;
    *     } else {

--- a/packages/signals/signals/src/types/factories.ts
+++ b/packages/signals/signals/src/types/factories.ts
@@ -1,5 +1,3 @@
-// types/factories.ts
-
 import {
   InstrumentationSignal,
   InteractionData,
@@ -58,7 +56,7 @@ export const createUserDefinedSignal = (
 
 export const createNetworkSignal = (
   data: NetworkData,
-  metadata: NetworkSignalMetadata
+  metadata?: NetworkSignalMetadata
 ): NetworkSignal => {
   return {
     type: 'network',
@@ -66,6 +64,11 @@ export const createNetworkSignal = (
       ...data,
       url: normalizeUrl(data.url),
     },
-    metadata: metadata,
+    metadata: metadata ?? {
+      filters: {
+        allowed: [],
+        disallowed: [],
+      },
+    },
   }
 }

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -59,15 +59,15 @@ export interface SignalsPluginSettingsConfig {
    *```ts
    * class MyMiddleware implements SignalsMiddleware {
    *   process(signal: Signal) {
+   *     // drop the event if some conditions are met
    *     if (
    *        signal.type === 'network' &&
    *        signal.data.action === 'request' &&
-   *        signal.data.contentType.includes('api-keys')
+   *       ... etc
    *     ) {
    *       return null;
    *     } else {
    *       return signal;
-   *     }
    *   }
    * }
    * const myMiddleware = new MyMiddleware()

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -1,3 +1,4 @@
+import { SignalsMiddleware } from '../core/emitter'
 import { ProcessSignal } from './process-signal'
 
 export interface SignalsPluginSettingsConfig {
@@ -67,6 +68,30 @@ export interface SignalsPluginSettingsConfig {
    * @default true
    */
   networkSignalsAllowSameDomain?: boolean | undefined
+
+  /**
+   * Add custom signals middleware
+   * @param example
+   *```ts
+   * class MyMiddleware implements SignalsMiddleware {
+   *   process(signal: Signal) {
+   *     if (
+   *        signal.type === 'network' &&
+   *        signal.data.action === 'request' &&
+   *        signal.data.contentType.includes('api-keys')
+   *     ) {
+   *       return null;
+   *     } else {
+   *       return signal;
+   *     }
+   *   }
+   * }
+   * const myMiddleware = new MyMiddleware()
+   * ...
+   * middleware: [myMiddleware]
+   * ````
+   */
+  middleware?: SignalsMiddleware[] | undefined
 
   /**
    * Custom signal storage implementation

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -52,6 +52,7 @@ export interface SignalsPluginSettingsConfig {
    * @default 2000
    */
   flushInterval?: number
+
   /**
    * Add custom signals middleware
    * @param example

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -55,7 +55,7 @@ export interface SignalsPluginSettingsConfig {
 
   /**
    * Add custom signals middleware
-   * @param example
+   * @example
    *```ts
    * class MyMiddleware implements SignalsMiddleware {
    *   process(signal: Signal) {

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -52,23 +52,6 @@ export interface SignalsPluginSettingsConfig {
    * @default 2000
    */
   flushInterval?: number
-
-  /**
-   * Allow network requests for URLs that match the specified regex.
-   * Same domain signals will be automatically included, unless `networkSignalsAllowSameDomain` is `false`.
-   * @example  new RegExp("api.foo.com|api.bar.com")  // match api.foo.com/bar and api.foo.com/baz and api.bar.com/baz
-   * @example  new RegExp("api.foo.com/bar$") // match api.foo.com/bar but NOT api.foo.com/baz
-   * @example  "api.foo.com" // match api.foo.com/bar and api.foo.com/baz
-   */
-  networkSignalsAllowList?: RegexLike[] | undefined
-  networkSignalsDisallowList?: RegexLike[] | undefined
-
-  /**
-   * Allow network requests if originated from the same domain
-   * @default true
-   */
-  networkSignalsAllowSameDomain?: boolean | undefined
-
   /**
    * Add custom signals middleware
    * @param example
@@ -92,6 +75,22 @@ export interface SignalsPluginSettingsConfig {
    * ````
    */
   middleware?: SignalsMiddleware[] | undefined
+
+  /**
+   * Allow network requests for URLs that match the specified regex.
+   * Same domain signals will be automatically included, unless `networkSignalsAllowSameDomain` is `false`.
+   * @example  new RegExp("api.foo.com|api.bar.com")  // match api.foo.com/bar and api.foo.com/baz and api.bar.com/baz
+   * @example  new RegExp("api.foo.com/bar$") // match api.foo.com/bar but NOT api.foo.com/baz
+   * @example  "api.foo.com" // match api.foo.com/bar and api.foo.com/baz
+   */
+  networkSignalsAllowList?: RegexLike[] | undefined
+  networkSignalsDisallowList?: RegexLike[] | undefined
+
+  /**
+   * Allow network requests if originated from the same domain
+   * @default true
+   */
+  networkSignalsAllowSameDomain?: boolean | undefined
 
   /**
    * Custom signal storage implementation


### PR DESCRIPTION
- Allow registration of middleware to allow for dropping and modification of signals
- Refactor to use middleware for network filter, rather than having that logic live in the network generator. 


```ts
class MyMiddleware implements SignalsMiddleware {
 load(ctx: SignalsMiddlewareContext) {
   // this will block any signals from being emitted until resolved, like a segment 'before' plugin -- it will be invoked before processSignal
   // we can access ctx.unstableGlobalSettings from inside this plugin and assign it to the instance if needed
    return 
 }
  process(signal: Signal) {
    if (
      signal.type === 'network' &&
      signal.data.action === 'request' &&
      ...
    ) {
      // null = drop signal
      return null
    } else {
      return signal
    }
  }
}
const signalsPlugin = new SignalsPlugin({
  middleware: [new MyMiddleware()]
})
```