### PR TITLE
Fix signals peer deps for 1.78.0

### DIFF
--- a/packages/signals/signals/package.json
+++ b/packages/signals/signals/package.json
@@ -49,7 +49,7 @@
     "tslib": "^2.4.1"
   },
   "peerDependencies": {
-    "@segment/analytics-next": ">1.78.0"
+    "@segment/analytics-next": ">=1.78.0"
   },
   "peerDependenciesMeta": {
     "@segment/analytics-next": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6026,7 +6026,7 @@ __metadata:
     node-fetch: ^2.6.7
     tslib: ^2.4.1
   peerDependencies:
-    "@segment/analytics-next": ">1.78.0"
+    "@segment/analytics-next": ">=1.78.0"
   peerDependenciesMeta:
     "@segment/analytics-next":
       optional: true


### PR DESCRIPTION
When we release 1.78.0 analytics.js, we want 1.78.0 to be a valid peer dependency for Signals.