### PR TITLE
Allow the request "credentials" option to be configured

### DIFF
--- a/.changeset/plenty-camels-accept.md
+++ b/.changeset/plenty-camels-accept.md
@@ -2,4 +2,4 @@
 '@segment/analytics-next': minor
 ---
 
-Add the possibility to configure the Request "credentials" option. Currently, the library uses the default "same-site" value, which does not include cookies for cross-origin requests.
+Add the possibility to configure the Request "credentials" option. Currently, the library only uses the default "same-site" value, which does not include cookies for cross-origin requests.

--- a/.changeset/plenty-camels-accept.md
+++ b/.changeset/plenty-camels-accept.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Add the possibility to configure the Request "credentials" option. Currently, the library uses the default "same-site" value, which does not include cookies for cross-origin requests.

--- a/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/batched-dispatcher.test.ts
@@ -97,6 +97,7 @@ describe('Batching', () => {
         "https://https://api.segment.io/b",
         {
           "body": "{"batch":[{"event":"first"},{"event":"second"},{"event":"third"}],"sentAt":"1993-06-09T00:00:00.000Z"}",
+          "credentials": undefined,
           "headers": {
             "Content-Type": "text/plain",
           },
@@ -181,6 +182,7 @@ describe('Batching', () => {
         "https://https://api.segment.io/b",
         {
           "body": "{"batch":[{"event":"first"},{"event":"second"}],"sentAt":"1993-06-09T00:00:10.000Z"}",
+          "credentials": undefined,
           "headers": {
             "Content-Type": "text/plain",
           },
@@ -217,6 +219,7 @@ describe('Batching', () => {
         "https://https://api.segment.io/b",
         {
           "body": "{"batch":[{"event":"first"}],"sentAt":"1993-06-09T00:00:10.000Z"}",
+          "credentials": undefined,
           "headers": {
             "Content-Type": "text/plain",
           },
@@ -232,6 +235,7 @@ describe('Batching', () => {
         "https://https://api.segment.io/b",
         {
           "body": "{"batch":[{"event":"second"}],"sentAt":"1993-06-09T00:00:21.000Z"}",
+          "credentials": undefined,
           "headers": {
             "Content-Type": "text/plain",
           },
@@ -264,6 +268,7 @@ describe('Batching', () => {
         "https://https://api.segment.io/b",
         {
           "body": "{"batch":[{"event":"first"},{"event":"second"}],"sentAt":"1993-06-09T00:00:00.000Z"}",
+          "credentials": undefined,
           "headers": {
             "Content-Type": "text/plain",
           },

--- a/packages/browser/src/plugins/segmentio/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/segmentio/__tests__/index.test.ts
@@ -74,6 +74,27 @@ describe('Segment.io', () => {
     })
   })
 
+  describe('configuring fetch credentials', () => {
+    it('should accept fetch credentials configuration', async () => {
+      const analytics = new Analytics({ writeKey: 'foo' })
+
+      await analytics.register(
+        await segmentio(analytics, {
+          apiKey: '',
+          deliveryStrategy: {
+            config: {
+              credentials: 'include',
+            },
+          },
+        })
+      )
+
+      await analytics.track('foo')
+      const [_, params] = spyMock.mock.lastCall
+      expect(params.credentials).toBe('include')
+    })
+  })
+
   describe('configuring headers', () => {
     it('should accept additional headers', async () => {
       const analytics = new Analytics({ writeKey: 'foo' })

--- a/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/batched-dispatcher.ts
@@ -77,6 +77,7 @@ export default function batch(
     })
 
     return fetch(`https://${apiHost}/b`, {
+      credentials: config?.credentials,
       keepalive: config?.keepalive || pageUnloaded,
       headers: createHeaders(config?.headers),
       method: 'post',

--- a/packages/browser/src/plugins/segmentio/fetch-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/fetch-dispatcher.ts
@@ -8,6 +8,7 @@ export default function (config?: StandardDispatcherConfig): {
 } {
   function dispatch(url: string, body: object): Promise<unknown> {
     return fetch(url, {
+      credentials: config?.credentials,
       keepalive: config?.keepalive,
       headers: createHeaders(config?.headers),
       method: 'post',

--- a/packages/browser/src/plugins/segmentio/shared-dispatcher.ts
+++ b/packages/browser/src/plugins/segmentio/shared-dispatcher.ts
@@ -19,12 +19,19 @@ export type AdditionalHeaders =
   | (() => Record<string, string>)
 
 export type RequestPriority = 'high' | 'low' | 'auto'
+export type RequestCredentials = 'include' | 'same-origin' | 'omit'
 
 /**
  * These are the options that can be passed to the fetch dispatcher.
  * They more/less map to the Fetch RequestInit type.
  */
 interface DispatchFetchConfig {
+  /**
+   * Request credentials configuration
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+   */
+  credentials?: RequestCredentials
   /**
    * This is useful for ensuring that an event is sent even if the user navigates away from the page.
    * However, it may increase the likelihood of events being lost, as there is a 64kb limit for *all* fetch requests (not just ones to segment) with keepalive (which is why it's disabled by default). So, if you're sending a lot of data, this will likely cause events to be dropped.


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).


Description
---
The segment library does not allow the `credentials` option on the request to be configured, that limits the possibility to send cookies with cross-origin requests (ex: website lives on `www.awesome.com` and the Segment proxy lives on `segment.awesome.com`). This PR adds the possibility to configure the `credentials` option as part of the `deliveryStrategy` `config`.

How it was tested
---
1. The library was built and referenced locally.
2. The library was tested with and without the `credentials` option. 
<details>
<summary>Here are some examples:</summary>
<img width="1650" alt="image" src="https://github.com/user-attachments/assets/82dd3de9-63e7-4a7c-832e-f4b9d9f88e0c" />
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/45b7b588-b4ab-413e-8ff0-8c3d6ae8891b" />
<img width="1668" alt="image" src="https://github.com/user-attachments/assets/578e5377-8e12-4972-b0c9-300b04f19f9b" />
<img width="1663" alt="image" src="https://github.com/user-attachments/assets/268be2ac-263a-4b9a-94c8-4a4e52d067b3" />
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/c9796371-b41a-4652-9c43-75f473f078bd" />
<img width="1658" alt="image" src="https://github.com/user-attachments/assets/7e0f1b1e-e5ec-43e0-b5ac-0a33490406b3" />
<img width="1656" alt="image" src="https://github.com/user-attachments/assets/c1eecb46-87e0-4ee2-b92d-c04977ea5185" />
</details>