### PR TITLE
Add anonymousId and timestamp to web signalData

### DIFF
--- a/.changeset/late-bikes-notice.md
+++ b/.changeset/late-bikes-notice.md
@@ -1,0 +1,6 @@
+---
+'@segment/analytics-signals': minor
+'@segment/analytics-signals-runtime': minor
+---
+
+Add anonymousID and timestamp to signals

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,6 @@ module.exports = () =>
       '<rootDir>/packages/consent/consent-wrapper-onetrust',
       '<rootDir>/scripts',
       '<rootDir>/packages/signals/signals',
+      '<rootDir>/packages/test-helpers',
     ],
   })

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
@@ -35,10 +35,7 @@ test('network signals fetch', async () => {
     (el) => el.properties!.data.action === 'response'
   )
   expect(responses).toHaveLength(1)
-  const signalData = responses[0].properties!.data
-  expect(signalData.data).toEqual({ someResponse: 'yep' })
-  expect(signalData.anonymousId).toBe(responses[0].anonymousId)
-  expect(signalData.timestamp).toMatch(isoDateRegEx)
+  expect(responses[0].properties!.data.data).toEqual({ someResponse: 'yep' })
 })
 
 test('network signals xhr', async () => {
@@ -64,8 +61,7 @@ test('network signals xhr', async () => {
   expect(responses[0].properties!.data.page).toEqual(commonSignalData.page)
 })
 
-const isoDateRegEx = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
-test.only('instrumentation signals', async () => {
+test('instrumentation signals', async () => {
   /**
    * Make an analytics.page() call, see if it gets sent to the signals endpoint
    */
@@ -74,6 +70,7 @@ test.only('instrumentation signals', async () => {
     indexPage.waitForSignalsApiFlush(),
   ])
 
+  const isoDateRegEx = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
   const instrumentationEvents =
     indexPage.signalsAPI.getEvents('instrumentation')
   expect(instrumentationEvents).toHaveLength(1)
@@ -81,13 +78,9 @@ test.only('instrumentation signals', async () => {
   expect(ev.event).toBe('Segment Signal Generated')
   expect(ev.type).toBe('track')
   const rawEvent = ev.properties!.data.rawEvent
-  expect(ev.properties!.type).toBe('instrumentation')
-  expect(ev.properties!.timestamp).toMatch(isoDateRegEx)
-  expect(ev.properties!.anonymousId).toBe(ev.anonymousId)
-  expect(ev.properties)
   expect(rawEvent).toMatchObject({
     type: 'page',
-    anonymousId: ev.anonymousId,
+    anonymousId: expect.any(String),
     timestamp: expect.stringMatching(isoDateRegEx),
   })
 })
@@ -130,8 +123,6 @@ test('interaction signals', async () => {
     type: 'track',
     properties: {
       type: 'interaction',
-      anonymousId: interactionSignals[0].anonymousId,
-      timestamp: expect.stringMatching(isoDateRegEx),
       data,
     },
   })
@@ -163,8 +154,6 @@ test('navigation signals', async ({ page }) => {
     const ev = indexPage.signalsAPI.lastEvent('navigation')
     expect(ev.properties).toMatchObject({
       type: 'navigation',
-      anonymousId: ev.anonymousId,
-      timestamp: expect.stringMatching(isoDateRegEx),
       data: {
         action: 'pageLoad',
         url: indexPage.url,
@@ -187,8 +176,6 @@ test('navigation signals', async ({ page }) => {
     const ev = indexPage.signalsAPI.lastEvent('navigation')
     expect(ev.properties).toMatchObject({
       index: expect.any(Number),
-      anonymousId: ev.anonymousId,
-      timestamp: expect.stringMatching(isoDateRegEx),
       type: 'navigation',
       data: {
         action: 'urlChange',

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
@@ -35,7 +35,10 @@ test('network signals fetch', async () => {
     (el) => el.properties!.data.action === 'response'
   )
   expect(responses).toHaveLength(1)
-  expect(responses[0].properties!.data.data).toEqual({ someResponse: 'yep' })
+  const signalData = responses[0].properties!.data
+  expect(signalData.data).toEqual({ someResponse: 'yep' })
+  expect(signalData.anonymousId).toBe(responses[0].anonymousId)
+  expect(signalData.timestamp).toMatch(isoDateRegEx)
 })
 
 test('network signals xhr', async () => {
@@ -61,7 +64,8 @@ test('network signals xhr', async () => {
   expect(responses[0].properties!.data.page).toEqual(commonSignalData.page)
 })
 
-test('instrumentation signals', async () => {
+const isoDateRegEx = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+test.only('instrumentation signals', async () => {
   /**
    * Make an analytics.page() call, see if it gets sent to the signals endpoint
    */
@@ -70,7 +74,6 @@ test('instrumentation signals', async () => {
     indexPage.waitForSignalsApiFlush(),
   ])
 
-  const isoDateRegEx = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
   const instrumentationEvents =
     indexPage.signalsAPI.getEvents('instrumentation')
   expect(instrumentationEvents).toHaveLength(1)
@@ -78,9 +81,13 @@ test('instrumentation signals', async () => {
   expect(ev.event).toBe('Segment Signal Generated')
   expect(ev.type).toBe('track')
   const rawEvent = ev.properties!.data.rawEvent
+  expect(ev.properties!.type).toBe('instrumentation')
+  expect(ev.properties!.timestamp).toMatch(isoDateRegEx)
+  expect(ev.properties!.anonymousId).toBe(ev.anonymousId)
+  expect(ev.properties)
   expect(rawEvent).toMatchObject({
     type: 'page',
-    anonymousId: expect.any(String),
+    anonymousId: ev.anonymousId,
     timestamp: expect.stringMatching(isoDateRegEx),
   })
 })
@@ -123,6 +130,8 @@ test('interaction signals', async () => {
     type: 'track',
     properties: {
       type: 'interaction',
+      anonymousId: interactionSignals[0].anonymousId,
+      timestamp: expect.stringMatching(isoDateRegEx),
       data,
     },
   })
@@ -154,6 +163,8 @@ test('navigation signals', async ({ page }) => {
     const ev = indexPage.signalsAPI.lastEvent('navigation')
     expect(ev.properties).toMatchObject({
       type: 'navigation',
+      anonymousId: ev.anonymousId,
+      timestamp: expect.stringMatching(isoDateRegEx),
       data: {
         action: 'pageLoad',
         url: indexPage.url,
@@ -176,6 +187,8 @@ test('navigation signals', async ({ page }) => {
     const ev = indexPage.signalsAPI.lastEvent('navigation')
     expect(ev.properties).toMatchObject({
       index: expect.any(Number),
+      anonymousId: ev.anonymousId,
+      timestamp: expect.stringMatching(isoDateRegEx),
       type: 'navigation',
       data: {
         action: 'urlChange',

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { IndexPage } from './index-page'
+
+const basicEdgeFn = `
+    // this is a process signal function
+    const processSignal = (signal) => {
+      if (signal.type === 'interaction') {
+        const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
+        analytics.track(eventName, signal.data)
+      }
+  }`
+
+let indexPage: IndexPage
+
+const isoDateRegEx = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+test.beforeEach(async ({ page }) => {
+  indexPage = await new IndexPage().loadAndWait(page, basicEdgeFn)
+})
+
+test('signal events should have anonymousId and timestamp at top level', async () => {
+  /**
+   * Make a fetch call, see if it gets sent to the signals endpoint
+   */
+  await indexPage.network.mockTestRoute()
+  await indexPage.network.makeFetchCall()
+  await Promise.all([
+    indexPage.clickButton(),
+    indexPage.makeAnalyticsPageCall(),
+    indexPage.waitForSignalsApiFlush(),
+    indexPage.waitForTrackingApiFlush(),
+  ])
+
+  const types = [
+    'network',
+    'interaction',
+    'instrumentation',
+    'navigation',
+  ] as const
+
+  const evs = types.map((type) => ({
+    type,
+    networkCalls: indexPage.signalsAPI.getEvents(type),
+  }))
+
+  evs.forEach((events) => {
+    if (!events.networkCalls.length) {
+      throw new Error(`No events found for type ${events.type}`)
+    }
+    events.networkCalls.forEach((event) => {
+      const expected = {
+        anonymousId: event.anonymousId,
+        timestamp: expect.stringMatching(isoDateRegEx),
+        type: event.properties!.type,
+      }
+      expect(event.properties).toMatchObject(expected)
+    })
+  })
+})

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
@@ -18,10 +18,7 @@ test.beforeEach(async ({ page }) => {
   indexPage = await new IndexPage().loadAndWait(page, basicEdgeFn)
 })
 
-test('signal events should have anonymousId and timestamp at top level', async () => {
-  /**
-   * Make a fetch call, see if it gets sent to the signals endpoint
-   */
+test('Signals should have anonymousId and timestamp at top level', async () => {
   await indexPage.network.mockTestRoute()
   await indexPage.network.makeFetchCall()
   await Promise.all([

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
@@ -3,12 +3,8 @@ import { IndexPage } from './index-page'
 
 const basicEdgeFn = `
     // this is a process signal function
-    const processSignal = (signal) => {
-      if (signal.type === 'interaction') {
-        const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
-        analytics.track(eventName, signal.data)
-      }
-  }`
+    const processSignal = (signal) => {}
+`
 
 let indexPage: IndexPage
 

--- a/packages/signals/signals-runtime/package.json
+++ b/packages/signals/signals-runtime/package.json
@@ -26,7 +26,7 @@
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "build:global": "node build-signals-runtime-global.js",
     "assert-generated": "bash scripts/assert-generated.sh",
-    "watch": "rm -rf dist/esm && yarn build:esm --watch",
+    "watch": "rm -rf dist/esm && yarn build:esm && yarn build:esm --watch",
     "watch:test": "yarn test --watch",
     "tsc": "yarn run -T tsc",
     "eslint": "yarn run -T eslint",

--- a/packages/signals/signals-runtime/src/shared/shared-types.ts
+++ b/packages/signals/signals-runtime/src/shared/shared-types.ts
@@ -1,5 +1,9 @@
+export type ID = string | null | undefined
+
 export interface BaseSignal {
   type: string
+  anonymousId: ID
+  timestamp: string
 }
 
 export type SignalOfType<

--- a/packages/signals/signals-runtime/src/test-helpers/mocks/mock-signal-types-web.ts
+++ b/packages/signals/signals-runtime/src/test-helpers/mocks/mock-signal-types-web.ts
@@ -1,3 +1,4 @@
+import { BaseSignal } from '../../shared/shared-types'
 import {
   InteractionSignal,
   NavigationSignal,
@@ -7,6 +8,13 @@ import {
   PageData,
 } from '../../web/web-signals-types'
 // Mock data for testing
+
+type DefaultProps = Pick<BaseSignal, 'anonymousId' | 'timestamp'>
+
+const baseSignalProps: DefaultProps = {
+  anonymousId: '123',
+  timestamp: '2020-01-01T00:00:00.000Z',
+}
 
 export const mockPageData: PageData = {
   url: 'https://www.segment.com/docs/connections/sources/catalog/libraries/website/javascript/',
@@ -29,7 +37,7 @@ export const mockInteractionSignal: InteractionSignal = {
       attributes: { id: 'button1', class: 'btn-primary' },
     },
   },
-  metadata: { timestamp: Date.now() },
+  ...baseSignalProps,
 }
 
 export const mockNavigationSignal: NavigationSignal = {
@@ -41,7 +49,7 @@ export const mockNavigationSignal: NavigationSignal = {
     hash: '#section1',
     prevUrl: 'https://example.com/home',
   },
-  metadata: { timestamp: Date.now() },
+  ...baseSignalProps,
 }
 
 export const mockInstrumentationSignal: InstrumentationSignal = {
@@ -50,7 +58,7 @@ export const mockInstrumentationSignal: InstrumentationSignal = {
     page: mockPageData,
     rawEvent: { type: 'customEvent', detail: 'example' },
   },
-  metadata: { timestamp: Date.now() },
+  ...baseSignalProps,
 }
 
 export const mockNetworkSignal: NetworkSignal = {
@@ -63,7 +71,7 @@ export const mockNetworkSignal: NetworkSignal = {
     method: 'GET',
     data: { key: 'value' },
   },
-  metadata: { timestamp: Date.now() },
+  ...baseSignalProps,
 }
 
 export const mockUserDefinedSignal: UserDefinedSignal = {
@@ -72,5 +80,5 @@ export const mockUserDefinedSignal: UserDefinedSignal = {
     page: mockPageData,
     customField: 'customValue',
   },
-  metadata: { timestamp: Date.now() },
+  ...baseSignalProps,
 }

--- a/packages/signals/signals/jest.config.js
+++ b/packages/signals/signals/jest.config.js
@@ -2,5 +2,5 @@ const { createJestTSConfig } = require('@internal/config')
 
 module.exports = createJestTSConfig(__dirname, {
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  setupFilesAfterEnv: ['./jest.setup.ts'],
 })

--- a/packages/signals/signals/jest.setup.js
+++ b/packages/signals/signals/jest.setup.js
@@ -1,3 +1,0 @@
-/* eslint-disable no-undef */
-require('fake-indexeddb/auto')
-globalThis.structuredClone = (v) => JSON.parse(JSON.stringify(v))

--- a/packages/signals/signals/jest.setup.ts
+++ b/packages/signals/signals/jest.setup.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-undef */
+import './src/test-helpers/jest-extended'
+import { JestSerializers } from '@internal/test-helpers'
+import 'fake-indexeddb/auto'
+globalThis.structuredClone = (v: any) => JSON.parse(JSON.stringify(v))
+expect.addSnapshotSerializer(JestSerializers.jestSnapshotSerializerTimestamp)

--- a/packages/signals/signals/package.json
+++ b/packages/signals/signals/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     ".": "yarn run -T turbo run --filter=@segment/analytics-signals...",
+    "..": "yarn run -T turbo run --filter=...@segment/analytics-signals...",
     "test": "yarn jest",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "build": "rm -rf dist && yarn concurrently 'yarn:build:*'",

--- a/packages/signals/signals/src/core/analytics-service/__tests__/analytics-service.test.ts
+++ b/packages/signals/signals/src/core/analytics-service/__tests__/analytics-service.test.ts
@@ -42,6 +42,7 @@ describe(AnalyticsService, () => {
       delete call.data.page
       expect(call).toMatchInlineSnapshot(`
         {
+          "anonymousId": "",
           "data": {
             "rawEvent": {
               "context": {
@@ -50,6 +51,7 @@ describe(AnalyticsService, () => {
               "type": "track",
             },
           },
+          "timestamp": <ISO Timestamp>,
           "type": "instrumentation",
         }
       `)

--- a/packages/signals/signals/src/core/middleware/signals-ingest/__tests__/client.test.ts
+++ b/packages/signals/signals/src/core/middleware/signals-ingest/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import { ISO_TIMESTAMP_REGEX } from '@internal/test-helpers'
 import { createSuccess } from '@segment/analytics-next/src/test-helpers/factories'
 import unfetch from 'unfetch'
 import { getPageData } from '../../../../lib/page-data'
@@ -29,7 +30,9 @@ describe(SignalsIngestClient, () => {
     const ctx = await client.send(signal)
 
     expect(ctx!.event.type).toEqual('track')
-    expect(ctx!.event.properties).toEqual({
+    expect(ctx!.event.properties).toMatchObject({
+      anonymousId: expect.any(String),
+      timestamp: expect.stringMatching(ISO_TIMESTAMP_REGEX),
       type: 'instrumentation',
       index: 0,
       data: {
@@ -53,26 +56,36 @@ describe(SignalsIngestClient, () => {
     })
 
     const ctx = await client.send(signal)
-    expect(ctx!.event.type).toEqual('track')
-    expect(ctx!.event.properties!.type).toBe('network')
-    expect(ctx!.event.properties!.data).toMatchInlineSnapshot(`
+    expect(ctx!.event.properties!).toMatchInlineSnapshot(`
       {
-        "action": "request",
-        "contentType": "application/json",
+        "anonymousId": "",
         "data": {
-          "hello": "XXX",
+          "action": "request",
+          "contentType": "application/json",
+          "data": {
+            "hello": "XXX",
+          },
+          "method": "POST",
+          "page": {
+            "hash": "",
+            "hostname": "localhost",
+            "path": "/",
+            "referrer": "",
+            "search": "",
+            "title": "",
+            "url": "http://localhost/",
+          },
+          "url": "http://foo.com",
         },
-        "method": "POST",
-        "page": {
-          "hash": "",
-          "hostname": "localhost",
-          "path": "/",
-          "referrer": "",
-          "search": "",
-          "title": "",
-          "url": "http://localhost/",
+        "index": 0,
+        "metadata": {
+          "filters": {
+            "allowed": [],
+            "disallowed": [],
+          },
         },
-        "url": "http://foo.com",
+        "timestamp": <ISO Timestamp>,
+        "type": "network",
       }
     `)
   })

--- a/packages/signals/signals/src/core/middleware/signals-ingest/__tests__/redact.test.ts
+++ b/packages/signals/signals/src/core/middleware/signals-ingest/__tests__/redact.test.ts
@@ -93,7 +93,7 @@ describe(redactSignalData, () => {
       listener: 'onchange',
       target: createMockTarget({ value: 'XXX', formData: { password: 'XXX' } }),
     })
-    expect(redactSignalData(signal)).toEqual(expected)
+    expect(redactSignalData(signal)).toMatchSignal(expected)
   })
 
   it('should redact attributes in change and in target if the listener is "mutation"', () => {
@@ -117,7 +117,7 @@ describe(redactSignalData, () => {
         innerText: 'XXX',
       }),
     })
-    expect(redactSignalData(signal)).toEqual(expected)
+    expect(redactSignalData(signal)).toMatchSignal(expected)
   })
 
   it('should redact the textContent and innerText in the "target" property if the listener is "contenteditable"', () => {
@@ -133,7 +133,7 @@ describe(redactSignalData, () => {
       change: { textContent: 'XXX' },
       target: createMockTarget({ textContent: 'XXX', innerText: 'XXX' }),
     })
-    expect(redactSignalData(signal)).toEqual(expected)
+    expect(redactSignalData(signal)).toMatchSignal(expected)
   })
 
   it('should redact the values in the "data" property if the type is "network"', () => {
@@ -157,7 +157,7 @@ describe(redactSignalData, () => {
       },
       metadataFixture
     )
-    expect(redactSignalData(signal)).toEqual(expected)
+    expect(redactSignalData(signal)).toMatchSignal(expected)
   })
 
   it('should not mutate the original signal object', () => {

--- a/packages/signals/signals/src/core/middleware/signals-ingest/signals-ingest-client.ts
+++ b/packages/signals/signals/src/core/middleware/signals-ingest/signals-ingest-client.ts
@@ -85,8 +85,7 @@ export class SignalsIngestClient {
 
     return analytics.track(MAGIC_EVENT_NAME, {
       index: this.index++,
-      type: signal.type,
-      data: cleanSignal.data,
+      ...cleanSignal,
     })
   }
 

--- a/packages/signals/signals/src/core/middleware/user-info/index.ts
+++ b/packages/signals/signals/src/core/middleware/user-info/index.ts
@@ -1,0 +1,17 @@
+import { Signal } from '@segment/analytics-signals-runtime'
+import { UserInfo } from '../../../types'
+import { SignalsMiddleware, SignalsMiddlewareContext } from '../../emitter'
+
+export class UserInfoMiddleware implements SignalsMiddleware {
+  user!: UserInfo
+
+  async load(ctx: SignalsMiddlewareContext) {
+    this.user = await ctx.analyticsInstance.user()
+  }
+
+  process(signal: Signal): Signal {
+    // anonymousId should always exist here unless the user is explicitly setting it to null
+    signal.anonymousId = this.user.anonymousId()
+    return signal
+  }
+}

--- a/packages/signals/signals/src/core/middleware/user-info/index.ts
+++ b/packages/signals/signals/src/core/middleware/user-info/index.ts
@@ -5,8 +5,8 @@ import { SignalsMiddleware, SignalsMiddlewareContext } from '../../emitter'
 export class UserInfoMiddleware implements SignalsMiddleware {
   user!: UserInfo
 
-  async load(ctx: SignalsMiddlewareContext) {
-    this.user = await ctx.analyticsInstance.user()
+  load(ctx: SignalsMiddlewareContext) {
+    this.user = ctx.analyticsInstance.user()
   }
 
   process(signal: Signal): Signal {

--- a/packages/signals/signals/src/core/signal-generators/dom-gen/__tests__/change-gen.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/dom-gen/__tests__/change-gen.test.ts
@@ -1,8 +1,7 @@
-import { createInteractionSignal } from '../../../../types/factories'
 import { SignalEmitter } from '../../../emitter'
 import { OnChangeGenerator } from '../change-gen'
 
-describe('OnChangeGenerator', () => {
+describe(OnChangeGenerator, () => {
   let onChangeGenerator: OnChangeGenerator
   let emitter: SignalEmitter
   let unregister: () => void
@@ -28,14 +27,49 @@ describe('OnChangeGenerator', () => {
     unregister = onChangeGenerator.register(emitter)
     document.dispatchEvent(event)
 
-    expect(emitSpy).toHaveBeenCalledWith(
-      createInteractionSignal({
-        eventType: 'change',
-        listener: 'onchange',
-        target: expect.any(Object),
-        change: { value: 'new value' },
-      })
-    )
+    expect(emitSpy.mock.calls.length).toBe(1)
+    expect(emitSpy.mock.calls[0][0]).toMatchInlineSnapshot(`
+      {
+        "anonymousId": "",
+        "data": {
+          "change": {
+            "value": "new value",
+          },
+          "eventType": "change",
+          "listener": "onchange",
+          "page": {
+            "hash": "",
+            "hostname": "localhost",
+            "path": "/",
+            "referrer": "",
+            "search": "",
+            "title": "",
+            "url": "http://localhost/",
+          },
+          "target": {
+            "attributes": {
+              "type": "text",
+            },
+            "checked": false,
+            "classList": [],
+            "describedBy": undefined,
+            "id": "",
+            "innerText": undefined,
+            "label": undefined,
+            "labels": [],
+            "name": "",
+            "nodeName": "INPUT",
+            "tagName": "INPUT",
+            "textContent": "",
+            "title": "",
+            "type": "text",
+            "value": "new value",
+          },
+        },
+        "timestamp": <ISO Timestamp>,
+        "type": "interaction",
+      }
+    `)
   })
 
   it('should not emit a signal for ignored elements', () => {
@@ -85,15 +119,58 @@ describe('OnChangeGenerator', () => {
     unregister = onChangeGenerator.register(emitter)
     document.dispatchEvent(event)
 
-    expect(emitSpy).toHaveBeenCalledWith(
-      createInteractionSignal({
-        eventType: 'change',
-        listener: 'onchange',
-        target: expect.any(Object),
-        change: {
-          selectedOptions: [{ value: 'value1', label: 'label1' }],
+    expect(emitSpy.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "anonymousId": "",
+          "data": {
+            "change": {
+              "selectedOptions": [
+                {
+                  "label": "label1",
+                  "value": "value1",
+                },
+              ],
+            },
+            "eventType": "change",
+            "listener": "onchange",
+            "page": {
+              "hash": "",
+              "hostname": "localhost",
+              "path": "/",
+              "referrer": "",
+              "search": "",
+              "title": "",
+              "url": "http://localhost/",
+            },
+            "target": {
+              "attributes": {},
+              "classList": [],
+              "describedBy": undefined,
+              "id": "",
+              "innerText": undefined,
+              "label": undefined,
+              "labels": [],
+              "name": "",
+              "nodeName": "SELECT",
+              "selectedIndex": 0,
+              "selectedOptions": [
+                {
+                  "label": "label1",
+                  "value": "value1",
+                },
+              ],
+              "tagName": "SELECT",
+              "textContent": "",
+              "title": "",
+              "type": "select-one",
+              "value": "value1",
+            },
+          },
+          "timestamp": <ISO Timestamp>,
+          "type": "interaction",
         },
-      })
-    )
+      ]
+    `)
   })
 })

--- a/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-generator.test.ts
+++ b/packages/signals/signals/src/core/signal-generators/network-gen/__tests__/network-generator.test.ts
@@ -97,6 +97,7 @@ describe(NetworkGenerator, () => {
 
     expect(first[0]).toMatchInlineSnapshot(`
       {
+        "anonymousId": "",
         "data": {
           "action": "request",
           "contentType": "application/json",
@@ -121,12 +122,14 @@ describe(NetworkGenerator, () => {
             "disallowed": [],
           },
         },
+        "timestamp": <ISO Timestamp>,
         "type": "network",
       }
     `)
 
     expect(second[0]).toMatchInlineSnapshot(`
       {
+        "anonymousId": "",
         "data": {
           "action": "response",
           "contentType": "application/json",
@@ -152,6 +155,7 @@ describe(NetworkGenerator, () => {
             "disallowed": [],
           },
         },
+        "timestamp": <ISO Timestamp>,
         "type": "network",
       }
     `)

--- a/packages/signals/signals/src/core/signals/settings.ts
+++ b/packages/signals/signals/src/core/signals/settings.ts
@@ -27,6 +27,7 @@ export type SignalsSettingsConfig = Pick<
   | 'mutationGenObservedTags'
   | 'mutationGenPollInterval'
   | 'mutationGenObservedAttributes'
+  | 'debug'
 > & {
   signalStorage?: SignalPersistentStorage
   processSignal?: string

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -16,6 +16,7 @@ import { LogLevelOptions } from '../debug-mode'
 import { SignalsIngestSubscriber } from '../middleware/signals-ingest'
 import { SignalsEventProcessorSubscriber } from '../middleware/event-processor'
 import { NetworkSignalsFilterMiddleware } from '../middleware/network-signals-filter/network-signals-filter'
+import { UserInfoMiddleware } from '../middleware/user-info'
 
 interface ISignals {
   start(analytics: AnyAnalytics): Promise<void>
@@ -39,6 +40,9 @@ export class Signals implements ISignals {
     this.globalSettings = new SignalGlobalSettings(settingsConfig)
     this.buffer = getSignalBuffer(this.globalSettings.signalBuffer)
     this.signalEmitter = this.getSignalEmitter(settingsConfig.middleware)
+    if (settingsConfig.debug) {
+      this.debug()
+    }
 
     // We register the generators (along with the signal emitter) so they start collecting signals before the plugin is started.
     // Otherwise, we would wait until analytics is loaded, which would skip things like page network URL changes.
@@ -123,6 +127,7 @@ export class Signals implements ISignals {
     // we initialize the emitter here so that registerGenerator can be called before start
     return new SignalEmitter()
       .addMiddleware(
+        new UserInfoMiddleware(),
         new NetworkSignalsFilterMiddleware(),
         ...(middleware || [])
       )

--- a/packages/signals/signals/src/core/signals/signals.ts
+++ b/packages/signals/signals/src/core/signals/signals.ts
@@ -38,11 +38,11 @@ export class Signals implements ISignals {
   private globalSettings: SignalGlobalSettings
   constructor(settingsConfig: SignalsSettingsConfig = {}) {
     this.globalSettings = new SignalGlobalSettings(settingsConfig)
-    this.buffer = getSignalBuffer(this.globalSettings.signalBuffer)
-    this.signalEmitter = this.getSignalEmitter(settingsConfig.middleware)
     if (settingsConfig.debug) {
       this.debug()
     }
+    this.buffer = getSignalBuffer(this.globalSettings.signalBuffer)
+    this.signalEmitter = this.getSignalEmitter(settingsConfig.middleware)
 
     // We register the generators (along with the signal emitter) so they start collecting signals before the plugin is started.
     // Otherwise, we would wait until analytics is loaded, which would skip things like page network URL changes.

--- a/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
+++ b/packages/signals/signals/src/plugin/__tests__/signals-plugin.test.ts
@@ -46,7 +46,7 @@ describe(SignalsPlugin, () => {
     const userDefinedData = { foo: 'bar' }
     plugin.addSignal(userDefinedData)
     expect(emitterSpy).toHaveBeenCalledTimes(1)
-    expect(emitterSpy.mock.calls[0][0]).toEqual(
+    expect(emitterSpy.mock.calls[0][0]).toMatchSignal(
       createUserDefinedSignal(userDefinedData)
     )
   })

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -29,16 +29,9 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
   public signals: Signals
   constructor(settings: SignalsPluginSettingsConfig = {}) {
     assertBrowserEnv()
-    // assign to window for debugging purposes
+
+    // assign to window.SegmentSignalsPlugin for debugging purposes (e.g window.SegmentSignalsPlugin.debug())
     Object.assign(window, { SegmentSignalsPlugin: this })
-
-    if (settings.enableDebugLogging) {
-      logger.enableLogging('debug')
-    }
-
-    logger.debug(`SignalsPlugin v${version} initializing`, {
-      settings,
-    })
 
     this.signals = new Signals({
       debug: settings.debug,
@@ -59,6 +52,10 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
       signalStorage: settings.signalStorage,
       signalStorageType: settings.signalStorageType,
       middleware: settings.middleware,
+    })
+
+    logger.debug(`SignalsPlugin v${version} initializing`, {
+      settings,
     })
   }
 
@@ -92,7 +89,8 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
   /**
    * Enable redaction and disable ingestion of signals. Also, logs signals to the console.
    */
-  debug(...args: Parameters<typeof this.signals['debug']>): void {
+  debug(...args: Parameters<typeof this.signals['debug']>): this {
     this.signals.debug(...args)
+    return this
   }
 }

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -41,6 +41,7 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
     })
 
     this.signals = new Signals({
+      debug: settings.debug,
       disableSignalsRedaction: settings.disableSignalsRedaction,
       enableSignalsIngestion: settings.enableSignalsIngestion,
       flushAt: settings.flushAt,

--- a/packages/signals/signals/src/test-helpers/jest-extended.ts
+++ b/packages/signals/signals/src/test-helpers/jest-extended.ts
@@ -1,0 +1,47 @@
+import { Signal } from '@segment/analytics-signals-runtime'
+
+export function toMatchSignal(
+  this: jest.MatcherContext,
+  received: Signal,
+  expected: Signal
+) {
+  const cleanSignal = (signal: Signal) => {
+    const { timestamp, ...rest } = signal
+    return rest
+  }
+
+  const pass = this.equals(cleanSignal(received), cleanSignal(expected))
+  if (pass) {
+    return {
+      message: () =>
+        `expected ${this.utils.printReceived(
+          received
+        )} not to match ${this.utils.printExpected(expected)}`,
+      pass: true,
+    }
+  } else {
+    return {
+      message: () =>
+        `expected ${this.utils.printReceived(
+          received
+        )} to match ${this.utils.printExpected(expected)}`,
+      pass: false,
+    }
+  }
+}
+
+/***
+ * Add special matcher to compare signals
+ * usage:
+ * expect(signal).toMatchSignal(expectedSignal)
+ */
+expect.extend({ toMatchSignal })
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toMatchSignal(expected: Signal): R
+    }
+  }
+}

--- a/packages/signals/signals/src/test-helpers/mocks/analytics-mock.ts
+++ b/packages/signals/signals/src/test-helpers/mocks/analytics-mock.ts
@@ -26,4 +26,8 @@ export const analyticsMock: jest.Mocked<AnyAnalytics> = {
   addSourceMiddleware: jest.fn(),
   reset: jest.fn(),
   on: jest.fn(),
+  user: jest.fn().mockReturnValue({
+    id: jest.fn(),
+    anonymousId: jest.fn(),
+  }),
 }

--- a/packages/signals/signals/src/types/__tests__/create-network-signal.test.ts
+++ b/packages/signals/signals/src/types/__tests__/create-network-signal.test.ts
@@ -16,7 +16,6 @@ describe(createNetworkSignal, () => {
       disallowed: ['disallowed1', 'disallowed2'],
     },
   }
-
   it('should create a network signal for a request', () => {
     const data: NetworkData = {
       action: 'request',
@@ -30,6 +29,7 @@ describe(createNetworkSignal, () => {
 
     expect(signal).toMatchInlineSnapshot(`
       {
+        "anonymousId": "",
         "data": {
           "action": "request",
           "contentType": "application/json",
@@ -60,6 +60,7 @@ describe(createNetworkSignal, () => {
             ],
           },
         },
+        "timestamp": <ISO Timestamp>,
         "type": "network",
       }
     `)
@@ -80,6 +81,7 @@ describe(createNetworkSignal, () => {
 
     expect(signal).toMatchInlineSnapshot(`
       {
+        "anonymousId": "",
         "data": {
           "action": "response",
           "contentType": "application/json",
@@ -111,6 +113,7 @@ describe(createNetworkSignal, () => {
             ],
           },
         },
+        "timestamp": <ISO Timestamp>,
         "type": "network",
       }
     `)

--- a/packages/signals/signals/src/types/analytics-api.ts
+++ b/packages/signals/signals/src/types/analytics-api.ts
@@ -50,6 +50,13 @@ export interface DestinationMiddlewareParams {
   integration: string
 }
 
+export type ID = string | null | undefined
+
+export interface UserInfo {
+  id(): ID
+  anonymousId(): ID
+}
+
 export interface AnyAnalytics {
   settings: {
     cdnSettings: CDNSettings
@@ -67,6 +74,7 @@ export interface AnyAnalytics {
   alias(...args: any[]): void
   screen(...args: any[]): void
   reset(): void
+  user(): UserInfo
   on(name: 'reset', fn: (...args: any[]) => void): void
 }
 

--- a/packages/signals/signals/src/types/factories.ts
+++ b/packages/signals/signals/src/types/factories.ts
@@ -17,12 +17,17 @@ import {
 import { normalizeUrl } from '../lib/normalize-url'
 import { getPageData } from '../lib/page-data'
 
+type BaseData<T extends SignalTypes> = Omit<
+  SignalOfType<Signal, T>['data'],
+  'page'
+>
+
 /**
  * Base Signal Factory
  */
 const createBaseSignal = <
   Type extends SignalTypes,
-  Data extends Omit<SignalOfType<Signal, Type>['data'], 'page'>
+  Data extends BaseData<Type>
 >(
   type: Type,
   data: Data
@@ -35,7 +40,7 @@ const createBaseSignal = <
       ...data,
       page: getPageData(),
     },
-  } as SignalOfType<Signal, Type>
+  }
 }
 
 export const createInstrumentationSignal = (

--- a/packages/signals/signals/src/types/factories.ts
+++ b/packages/signals/signals/src/types/factories.ts
@@ -29,7 +29,7 @@ const createBaseSignal = <
 ) => {
   return {
     timestamp: new Date().toISOString(),
-    anonymousId: '', // not set yet -- will be set by the runtime // TODO
+    anonymousId: '', // to be set by a middleware (that runs once analytics is instantiated)
     type,
     data: {
       ...data,

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -13,6 +13,13 @@ export interface SignalsPluginSettingsConfig {
   processSignal?: string | ProcessSignal
 
   /**
+   * Enable debug mode. Same as ?debug=true in the URL or SignalsPlugin.debug(true)
+   * This sets the log level to 'info', disables redaction, and enables signals ingestion
+   * @default false
+   */
+  debug?: boolean
+
+  /**
    * Add console debug logging
    * @default false
    */

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -13,17 +13,11 @@ export interface SignalsPluginSettingsConfig {
   processSignal?: string | ProcessSignal
 
   /**
-   * Enable debug mode. Same as ?debug=true in the URL or SignalsPlugin.debug(true)
-   * This sets the log level to 'info', disables redaction, and enables signals ingestion
+   * Enable debug mode. Same as ?segment_signals_debug=true in the URL
+   * This sets the log level to 'info', disables redaction, and enables signals ingestion (sending signals to segment)
    * @default false
    */
   debug?: boolean
-
-  /**
-   * Add console debug logging
-   * @default false
-   */
-  enableDebugLogging?: boolean
 
   /**
    * Disable redaction of signals

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -12,7 +12,6 @@
     "build:cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "build:esm": "yarn tsc -p tsconfig.build.json",
     "tsc": "yarn run -T tsc",
-    "watch": "yarn build:esm --watch",
     "eslint": "yarn run -T eslint",
     "concurrently": "yarn run -T concurrently"
   },

--- a/packages/test-helpers/src/constants/index.ts
+++ b/packages/test-helpers/src/constants/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Matches an ISO 8601 timestamp string.
+ * @example
+ * expect('2022-01-01T00:00:00.000Z').toEqual(expect.any(ISO_TIMESTAMP_REGEX))
+ */
+export const ISO_TIMESTAMP_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -1,2 +1,4 @@
 export * from './utils'
 export * from './analytics'
+export * from './constants'
+export * as JestSerializers from './jest/serializers'

--- a/packages/test-helpers/src/jest/serializers/index.ts
+++ b/packages/test-helpers/src/jest/serializers/index.ts
@@ -1,0 +1,1 @@
+export * from './timestamp'

--- a/packages/test-helpers/src/jest/serializers/timestamp.ts
+++ b/packages/test-helpers/src/jest/serializers/timestamp.ts
@@ -1,0 +1,13 @@
+import { ISO_TIMESTAMP_REGEX } from '../../constants'
+
+/**
+ * Jest snapshot serializer for ISO 8601 timestamp strings.
+ */
+export const jestSnapshotSerializerTimestamp: jest.SnapshotSerializerPlugin = {
+  test(value: any) {
+    return typeof value === 'string' && ISO_TIMESTAMP_REGEX.test(value)
+  },
+  print() {
+    return '<ISO Timestamp>'
+  },
+}


### PR DESCRIPTION
Support:
```ts
{
 type: '...', // e.g. 'interaction'
 timestamp: '2025-03-18T20:27:01.459Z', // added
 anonymousId: '12345' // added
 data: { ... }
}
```