### PR TITLE
Check attempts before dispatching to segment

### DIFF
--- a/.changeset/nasty-sloths-rhyme.md
+++ b/.changeset/nasty-sloths-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Fix retry behavior

--- a/packages/browser/src/plugins/segmentio/index.ts
+++ b/packages/browser/src/plugins/segmentio/index.ts
@@ -112,6 +112,11 @@ export function segmentio(
       json = onAlias(analytics, json)
     }
 
+    if (buffer.getAttempts(ctx) >= buffer.maxAttempts) {
+      inflightEvents.delete(ctx)
+      return ctx
+    }
+
     return client
       .dispatch(
         `${remote}/${path}`,


### PR DESCRIPTION
This PR changes the retry behavior for Segment.io by checking the number of attempts before it attempts to send the event to Segment, which was causing an extra retry.

Tested locally by verifying that a cancelled event was not retried when retryQueue was disabled, and 4 total attempts were made when retryQueue was enabled.

<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [ ] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
