### PR TITLE
Update documentation for expo-web example

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -145,6 +145,41 @@ export default defineComponent({
 </script>
 ```
 
+### Expo Web
+Expo web leverages Metro as it's bundler. Since Analytics.js ships as a precompiled library we will want to ignore any transformations to avoid running into an error on build.
+
+1. Setup the custom transformer in `metro.config.js`
+
+```js
+module.exports = {
+  ...config,
+  transformer: {
+    ...transformer,
+    babelTransformerPath: require.resolve('./metroTransformer.cjs'),
+  }
+  // Your other metro config options
+}
+```
+
+2. Create a new `metroTransformer.js`
+
+```js
+
+const { transform } = require('metro-babel-transformer')
+
+module.exports.transform = async function customTransform(props) {
+  // Skipping transformation for precompiled file
+  if (
+    props.filename.includes('node_modules/@segment/analytics-next')
+  ) {
+    return { code: props.src, map: null }
+  }
+
+  return await transform(props)
+}
+```
+
+
 ## Support for Web Workers (Experimental)
  While this package does not support web workers out of the box, there are options:
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

I was working to try to get segment working with my expo 52 react native project. I noticed that it would pass the metro build and then throw an error at runtime

```
TypeError: Class extends value undefined is not a constructor or null
```

I happened to create this custom transformer as a fix for a custom component library package that I have. I decided to give it a try since everything else I did wasn't working and to my surprise it worked.

I figured others might be fighting this in the future so I decided to update the docs in case folks can get saved by my solution. 

I didn't run a changeset as a part of this PR since I only updated a markdown file. Please let me know if you still want one. Thanks :)

- [ ] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
