### PR TITLE
Add signals strategy configuration for customers with restrictive CSPs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,6 +84,7 @@ steps:
       - yarn install --immutable
       - echo "+++ Run Browser integration tests :pray:"
       - yarn turbo run --filter=@internal/browser-integration-tests test:int
+      - yarn turbo run --filter=@internal/browser-integration-tests test:int
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,7 +84,6 @@ steps:
       - yarn install --immutable
       - echo "+++ Run Browser integration tests :pray:"
       - yarn turbo run --filter=@internal/browser-integration-tests test:int
-      - yarn turbo run --filter=@internal/browser-integration-tests test:int
     retry:
       automatic:
         - exit_status: '*'

--- a/.changeset/eight-adults-type.md
+++ b/.changeset/eight-adults-type.md
@@ -2,4 +2,4 @@
 '@segment/analytics-signals': minor
 ---
 
-Add globalscope strategy
+Fix CSP errors with sandboxStrategy: global

--- a/.changeset/eight-adults-type.md
+++ b/.changeset/eight-adults-type.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-signals': minor
+---
+
+Add globalscope strategy

--- a/.changeset/empty-eagles-buy.md
+++ b/.changeset/empty-eagles-buy.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-signals': minor
+---
+
+Update max signals in buffer to 100

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,7 @@ module.exports = {
             '@typescript-eslint/no-restricted-imports': [
               'error',
               {
+                patterns: [],
                 paths: [
                   {
                     // Prevent accidental imports from 'lodash'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,6 @@ module.exports = {
             '@typescript-eslint/no-restricted-imports': [
               'error',
               {
-                patterns: [],
                 paths: [
                   {
                     // Prevent accidental imports from 'lodash'

--- a/packages/signals/signals-example/public/index.html
+++ b/packages/signals/signals-example/public/index.html
@@ -5,8 +5,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>React TypeScript App</title>
+  <!---
+  
+1. Requres 'unsafe-inline'
+- Refused to execute inline script because it violates the following Content Security Policy directive: [directive] Either the 'unsafe-inline' keyword, a hash ('sha256-XDT/UwTV/dYYXFad1cmKD+q1zZNK8KGVRYvIdvkmo7I='), or a nonce ('nonce-...') is required to enable inline execution.
+2. Requires 'unsafe-eval'
+processSignal() error in sandbox Error: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive
+  -->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.segment.com https://*.googletagmanager.com blob:">
 </head>
-
 <body>
   <div id="root"></div>
 </body>

--- a/packages/signals/signals-example/src/lib/analytics.ts
+++ b/packages/signals/signals-example/src/lib/analytics.ts
@@ -33,7 +33,7 @@ const isStage = process.env.STAGE === 'true'
 
 const signalsPlugin = new SignalsPlugin({
   ...(isStage ? { apiHost: 'signals.segment.build/v1' } : {}),
-  // enableDebugLogging: true,
+  sandboxStrategy: 'global',
   // processSignal: processSignalExample,
 })
 

--- a/packages/signals/signals-integration-tests/package.json
+++ b/packages/signals/signals-integration-tests/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     ".": "yarn run -T turbo run --filter=@internal/signals-integration-tests...",
     "build": "webpack",
-    "test:int": "playwright test && yarn test:global-sandbox",
+    "test:int": "playwright test && SKIP_BUILD=true yarn test:global-sandbox",
     "test:vanilla": "playwright test src/tests/signals-vanilla",
     "test:perf": "playwright test src/tests/performance",
     "test:custom": "playwright test src/tests/custom",
-    "test:global-sandbox": "SANDBOX_STRATEGY=global yarn test:vanilla && SANDBOX_STRATEGY=global yarn test:custom",
+    "test:global-sandbox": "SANDBOX_STRATEGY=global playwright test src/tests/signals-vanilla src/tests/custom",
     "watch": "webpack -w",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "concurrently": "yarn run -T concurrently",

--- a/packages/signals/signals-integration-tests/package.json
+++ b/packages/signals/signals-integration-tests/package.json
@@ -8,10 +8,11 @@
   "scripts": {
     ".": "yarn run -T turbo run --filter=@internal/signals-integration-tests...",
     "build": "webpack",
-    "test:int": "playwright test",
+    "test:int": "playwright test && yarn test:global-sandbox",
     "test:vanilla": "playwright test src/tests/signals-vanilla",
     "test:perf": "playwright test src/tests/performance",
     "test:custom": "playwright test src/tests/custom",
+    "test:global-sandbox": "SANDBOX_STRATEGY=global yarn test:vanilla && SANDBOX_STRATEGY=global yarn test:custom",
     "watch": "webpack -w",
     "lint": "yarn concurrently 'yarn:eslint .' 'yarn:tsc --noEmit'",
     "concurrently": "yarn run -T concurrently",

--- a/packages/signals/signals-integration-tests/playwright.global-setup.ts
+++ b/packages/signals/signals-integration-tests/playwright.global-setup.ts
@@ -5,6 +5,9 @@ import { envConfig } from './src/helpers/env-config'
 export default function globalSetup(_cfg: FullConfig) {
   console.log(`Executing playwright.global-setup.ts...\n`)
   console.log(`Using envConfig: ${JSON.stringify(envConfig, undefined, 2)}\n`)
-  execSync('yarn build', { stdio: 'inherit' })
-  console.log('Finished global setup.\n')
+  if (process.env.SKIP_BUILD !== 'true') {
+    console.log(`Executing yarn build:\n`)
+    execSync('yarn build', { stdio: 'inherit' })
+  }
+  console.log('Finished global setup. Should start running tests.\n')
 }

--- a/packages/signals/signals-integration-tests/playwright.global-setup.ts
+++ b/packages/signals/signals-integration-tests/playwright.global-setup.ts
@@ -1,8 +1,10 @@
 import type { FullConfig } from '@playwright/test'
 import { execSync } from 'child_process'
+import { envConfig } from './src/helpers/env-config'
 
 export default function globalSetup(_cfg: FullConfig) {
-  console.log('Executing global setup...')
+  console.log(`Executing playwright.global-setup.ts...\n`)
+  console.log(`Using envConfig: ${JSON.stringify(envConfig, undefined, 2)}\n`)
   execSync('yarn build', { stdio: 'inherit' })
-  console.log('Finished global setup.')
+  console.log('Finished global setup.\n')
 }

--- a/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
@@ -7,6 +7,7 @@ import {
   SignalAPIRequestBuffer,
   TrackingAPIRequestBuffer,
 } from './network-utils'
+import { envConfig } from './env-config'
 
 export class BasePage {
   protected page!: Page
@@ -63,6 +64,7 @@ export class BasePage {
     await this.page.goto(url, { waitUntil: 'domcontentloaded' })
     if (!options.skipSignalsPluginInit) {
       void this.invokeAnalyticsLoad({
+        sandboxStrategy: envConfig.SANDBOX_STRATEGY ?? 'iframe',
         flushInterval: 500,
         ...signalSettings,
       })

--- a/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/base-page-object.ts
@@ -64,7 +64,7 @@ export class BasePage {
     await this.page.goto(url, { waitUntil: 'domcontentloaded' })
     if (!options.skipSignalsPluginInit) {
       void this.invokeAnalyticsLoad({
-        sandboxStrategy: envConfig.SANDBOX_STRATEGY ?? 'iframe',
+        sandboxStrategy: envConfig.SANDBOX_STRATEGY,
         flushInterval: 500,
         ...signalSettings,
       })

--- a/packages/signals/signals-integration-tests/src/helpers/env-config.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/env-config.ts
@@ -1,0 +1,11 @@
+import { SignalsSettingsConfig } from '@segment/analytics-signals/dist/types/core/signals'
+
+// This is for testing with the global sandbox strategy with an npm script, that executes processSignal in the global scope
+// If we change this to be the default, this can be rejiggered
+const SANDBOX_STRATEGY = process.env.SANDBOX_STRATEGY as
+  | SignalsSettingsConfig['sandboxStrategy']
+  | undefined
+
+export const envConfig = {
+  SANDBOX_STRATEGY,
+}

--- a/packages/signals/signals-integration-tests/src/helpers/env-config.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/env-config.ts
@@ -2,9 +2,8 @@ import { SignalsSettingsConfig } from '@segment/analytics-signals/dist/types/cor
 
 // This is for testing with the global sandbox strategy with an npm script, that executes processSignal in the global scope
 // If we change this to be the default, this can be rejiggered
-const SANDBOX_STRATEGY = process.env.SANDBOX_STRATEGY as
-  | SignalsSettingsConfig['sandboxStrategy']
-  | undefined
+const SANDBOX_STRATEGY = (process.env.SANDBOX_STRATEGY ??
+  'iframe') as SignalsSettingsConfig['sandboxStrategy']
 
 export const envConfig = {
   SANDBOX_STRATEGY,

--- a/packages/signals/signals-integration-tests/src/helpers/env-config.ts
+++ b/packages/signals/signals-integration-tests/src/helpers/env-config.ts
@@ -1,9 +1,9 @@
-import { SignalsSettingsConfig } from '@segment/analytics-signals/dist/types/core/signals'
+import { SignalsPluginSettingsConfig } from '@segment/analytics-signals'
 
 // This is for testing with the global sandbox strategy with an npm script, that executes processSignal in the global scope
 // If we change this to be the default, this can be rejiggered
 const SANDBOX_STRATEGY = (process.env.SANDBOX_STRATEGY ??
-  'iframe') as SignalsSettingsConfig['sandboxStrategy']
+  'iframe') as SignalsPluginSettingsConfig['sandboxStrategy']
 
 export const envConfig = {
   SANDBOX_STRATEGY,

--- a/packages/signals/signals-integration-tests/src/tests/custom-elements/custom-select.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/custom-elements/custom-select.test.ts
@@ -3,7 +3,7 @@ import { waitForCondition } from '../../helpers/playwright-utils'
 import { IndexPage } from './index-page'
 import type { SegmentEvent } from '@segment/analytics-next'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('Collecting signals whenever a user selects an item', async ({ page }) => {
   const indexPage = await new IndexPage().loadAndWait(page, basicEdgeFn, {

--- a/packages/signals/signals-integration-tests/src/tests/custom-elements/custom-textfield.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/custom-elements/custom-textfield.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { waitForCondition } from '../../helpers/playwright-utils'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('Collecting signals whenever a user enters text input and focuses out', async ({
   page,

--- a/packages/signals/signals-integration-tests/src/tests/performance/memory-leak.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/performance/memory-leak.test.ts
@@ -16,7 +16,7 @@ declare global {
 
 const basicEdgeFn = `
     // this is a process signal function
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
       if (signal.type === 'interaction') {
         const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
         analytics.track(eventName, signal.data)

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/all-segment-events.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/all-segment-events.test.ts
@@ -37,7 +37,7 @@ const snapshot = (
 test('Segment events', async ({ page }) => {
   const basicEdgeFn = `
     // this is a process signal function
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
       if (signal.type === 'interaction' && signal.data.eventType === 'click') {
         analytics.identify('john', { found: true })
         analytics.group('foo', { hello: 'world' })
@@ -65,7 +65,7 @@ test('Should dispatch events from signals that occurred before analytics was ins
   page,
 }) => {
   const edgeFn = `
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
        if (signal.type === 'navigation' && signal.data.action === 'pageLoad') {
           analytics.page('dispatched from signals - navigation')
       }

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/basic.test.ts
@@ -4,7 +4,7 @@ import { IndexPage } from './index-page'
 
 const basicEdgeFn = `
     // this is a process signal function
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
       if (signal.type === 'interaction') {
         const eventName = signal.data.eventType + ' ' + '[' + signal.type + ']'
         analytics.track(eventName, signal.data)

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/button-click-complex.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/button-click-complex.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 let indexPage: IndexPage
 test.beforeEach(async ({ page }) => {
   indexPage = await new IndexPage().loadAndWait(page, basicEdgeFn)

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/change-input.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/change-input.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { waitForCondition } from '../../helpers/playwright-utils'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('Collecting signals whenever a user enters text input', async ({
   page,

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/middleware.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/middleware.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 let indexPage: IndexPage
 

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-allow-list.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-allow-list.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('network signals allow and disallow list', async ({ page }) => {
   const indexPage = await new IndexPage().loadAndWait(page, basicEdgeFn, {

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-fetch.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-fetch.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { commonSignalData } from '../../helpers/fixtures'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test.describe('network signals - fetch', () => {
   let indexPage: IndexPage

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-xhr.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/network-signals-xhr.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test.describe('network signals - XHR', () => {
   let indexPage: IndexPage

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/reset.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/reset.test.ts
@@ -7,7 +7,7 @@ import { pTimeout } from '@segment/analytics-core'
  * If a signal is generated, the signal buffer should be reset
  * when the user clicks on the complex button.
  */
-const edgeFn = `const processSignal = (signal) => {
+const edgeFn = `globalThis.processSignal = (signal) => {
   // create a custom signal to echo out the current signal buffer
   if (signal.type === 'userDefined') {
     analytics.track('current signal buffer', { signalBuffer: signals.signalBuffer })

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/runtime-constants.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/runtime-constants.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { IndexPage } from './index-page'
 
 const basicEdgeFn = `
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
       // test that constants are properly injected
       if (typeof EventType !== 'object') {
         throw new Error('EventType is missing?')

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-find.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-find.test.ts
@@ -4,7 +4,7 @@ import { IndexPage } from './index-page'
 const indexPage = new IndexPage()
 
 test('should find the most recent signal', async ({ page }) => {
-  const basicEdgeFn = `const processSignal = (signal) => {
+  const basicEdgeFn = `globalThis.processSignal = (signal) => {
   if (signal.type === 'interaction' && signal.data.target.id === 'complex-button') {
     const mostRecentSignal = signals.find(signal, 'userDefined')
     if (mostRecentSignal.data.num === 2) {

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-ingestion.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-ingestion.test.ts
@@ -4,7 +4,7 @@ import { waitForCondition } from '../../helpers/playwright-utils'
 
 const indexPage = new IndexPage()
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('debug ingestion disabled and sample rate 0 -> will not send the signal', async ({
   page,

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-redaction.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/signals-redaction.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { waitForCondition } from '../../helpers/playwright-utils'
 import { IndexPage } from './index-page'
 
-const basicEdgeFn = `const processSignal = (signal) => {}`
+const basicEdgeFn = `globalThis.processSignal = (signal) => {}`
 
 test('redaction enabled -> will XXX the value of text input', async ({
   page,

--- a/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
+++ b/packages/signals/signals-integration-tests/src/tests/signals-vanilla/top-level-metadata.test.ts
@@ -4,7 +4,7 @@ import { IndexPage } from './index-page'
 
 const basicEdgeFn = `
     // this is a process signal function
-    const processSignal = (signal) => {
+    globalThis.processSignal = (signal) => {
       if (signal.type === 'interaction') {
         analytics.track('hello', { myAnonId: signal.anonymousId, myTimestamp: signal.timestamp })
       } 

--- a/packages/signals/signals/README.md
+++ b/packages/signals/signals/README.md
@@ -86,6 +86,14 @@ signalsPlugin.addSignal({ someData: 'foo' })
 }
 ```
 
+### Sandbox Strategies
+If getting CSP errors, you can use the experimental 'global' sandbox strategy.
+
+```ts
+new SignalsPlugin({ sandboxStrategy: 'global' })
+```
+
+
 ### Debugging  
 Debug mode **MUST** be enabled on the client to VIEW signals on segment.com.
 

--- a/packages/signals/signals/src/core/buffer/index.ts
+++ b/packages/signals/signals/src/core/buffer/index.ts
@@ -25,7 +25,7 @@ interface IDBPObjectStoreSignals
     'readonly' | 'readwrite' | 'versionchange'
   > {}
 
-const MAX_BUFFER_SIZE_DEFAULT = 50
+const MAX_BUFFER_SIZE_DEFAULT = 100
 
 interface StoreSettings {
   maxBufferSize?: number

--- a/packages/signals/signals/src/core/middleware/event-processor/index.ts
+++ b/packages/signals/signals/src/core/middleware/event-processor/index.ts
@@ -2,17 +2,48 @@ import { Signal } from '@segment/analytics-signals-runtime'
 import { SignalBuffer } from '../../buffer'
 import { SignalsSubscriber, SignalsMiddlewareContext } from '../../emitter'
 import { SignalEventProcessor } from '../../processor/processor'
-import { Sandbox, SandboxSettings } from '../../processor/sandbox'
+import {
+  normalizeEdgeFunctionURL,
+  GlobalScopeSandbox,
+  WorkerSandbox,
+  WorkerSandboxSettings,
+  SignalSandbox,
+  NoopSandbox,
+} from '../../processor/sandbox'
+
+const GLOBAL_SCOPE_SANDBOX = true
 
 export class SignalsEventProcessorSubscriber implements SignalsSubscriber {
   processor!: SignalEventProcessor
   buffer!: SignalBuffer
   load(ctx: SignalsMiddlewareContext) {
     this.buffer = ctx.buffer
-    this.processor = new SignalEventProcessor(
-      ctx.analyticsInstance,
-      new Sandbox(new SandboxSettings(ctx.unstableGlobalSettings.sandbox))
+    const sandboxSettings = ctx.unstableGlobalSettings.sandbox
+    const normalizedEdgeFunctionURL = normalizeEdgeFunctionURL(
+      sandboxSettings.functionHost,
+      sandboxSettings.edgeFnDownloadURL
     )
+
+    let sandbox: SignalSandbox
+    if (!normalizedEdgeFunctionURL) {
+      console.warn(
+        `No processSignal function found. Have you written a processSignal function on app.segment.com?`
+      )
+      sandbox = new NoopSandbox()
+    } else if (!GLOBAL_SCOPE_SANDBOX) {
+      sandbox = new WorkerSandbox(
+        new WorkerSandboxSettings({
+          processSignal: sandboxSettings.processSignal,
+          edgeFnDownloadURL: normalizedEdgeFunctionURL,
+        })
+      )
+    } else {
+      sandbox = new GlobalScopeSandbox({
+        edgeFnDownloadURL: normalizedEdgeFunctionURL,
+      })
+    }
+
+    this.processor = new SignalEventProcessor(ctx.analyticsInstance, sandbox)
   }
   async process(signal: Signal) {
     return this.processor.process(signal, await this.buffer.getAll())

--- a/packages/signals/signals/src/core/middleware/event-processor/index.ts
+++ b/packages/signals/signals/src/core/middleware/event-processor/index.ts
@@ -30,7 +30,7 @@ export class SignalsEventProcessorSubscriber implements SignalsSubscriber {
         `No processSignal function found. Have you written a processSignal function on app.segment.com?`
       )
       sandbox = new NoopSandbox()
-    } else if (!GLOBAL_SCOPE_SANDBOX) {
+    } else if (!GLOBAL_SCOPE_SANDBOX || sandboxSettings.processSignal) {
       sandbox = new WorkerSandbox(
         new WorkerSandboxSettings({
           processSignal: sandboxSettings.processSignal,

--- a/packages/signals/signals/src/core/middleware/event-processor/index.ts
+++ b/packages/signals/signals/src/core/middleware/event-processor/index.ts
@@ -24,7 +24,7 @@ export class SignalsEventProcessorSubscriber implements SignalsSubscriber {
     )
 
     let sandbox: SignalSandbox
-    console.log('sup')
+
     if (!normalizedEdgeFunctionURL) {
       console.warn(
         `No processSignal function found. Have you written a processSignal function on app.segment.com?`

--- a/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
+++ b/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
@@ -1,9 +1,8 @@
-import { WorkerSandboxSettings, SandboxSettingsConfig } from '../sandbox'
+import { IframeSandboxSettings, IframeSandboxSettingsConfig } from '../sandbox'
 
-describe(WorkerSandboxSettings, () => {
+describe(IframeSandboxSettings, () => {
   const edgeFnResponseBody = `function processSignal() { console.log('hello world') }`
-  const baseSettings: SandboxSettingsConfig = {
-    functionHost: undefined,
+  const baseSettings: IframeSandboxSettingsConfig = {
     processSignal: undefined,
     edgeFnDownloadURL: 'http://example.com/download',
     edgeFnFetchClient: jest.fn().mockReturnValue(
@@ -13,7 +12,7 @@ describe(WorkerSandboxSettings, () => {
     ),
   }
   test('initializes with provided settings', async () => {
-    const sandboxSettings = new WorkerSandboxSettings({ ...baseSettings })
+    const sandboxSettings = new IframeSandboxSettings({ ...baseSettings })
     expect(baseSettings.edgeFnFetchClient).toHaveBeenCalledWith(
       baseSettings.edgeFnDownloadURL
     )
@@ -21,13 +20,13 @@ describe(WorkerSandboxSettings, () => {
   })
 
   test('normalizes edgeFnDownloadURL when functionHost is provided', async () => {
-    const settings: SandboxSettingsConfig = {
+    const settings = {
       ...baseSettings,
       processSignal: undefined,
       functionHost: 'newHost.com',
       edgeFnDownloadURL: 'https://original.com/download',
     }
-    new WorkerSandboxSettings(settings)
+    new IframeSandboxSettings(settings)
     expect(baseSettings.edgeFnFetchClient).toHaveBeenCalledWith(
       'https://newHost.com/download'
     )
@@ -37,12 +36,12 @@ describe(WorkerSandboxSettings, () => {
     const consoleWarnSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => {})
-    const settings: SandboxSettingsConfig = {
+    const settings = {
       ...baseSettings,
       processSignal: undefined,
       edgeFnDownloadURL: undefined,
     }
-    const sandboxSettings = new WorkerSandboxSettings(settings)
+    const sandboxSettings = new IframeSandboxSettings(settings)
     expect(await sandboxSettings.processSignal).toEqual(
       'globalThis.processSignal = function processSignal() {}'
     )

--- a/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
+++ b/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
@@ -1,6 +1,6 @@
-import { SandboxSettings, SandboxSettingsConfig } from '../sandbox'
+import { WorkerSandboxSettings, SandboxSettingsConfig } from '../sandbox'
 
-describe(SandboxSettings, () => {
+describe(WorkerSandboxSettings, () => {
   const edgeFnResponseBody = `function processSignal() { console.log('hello world') }`
   const baseSettings: SandboxSettingsConfig = {
     functionHost: undefined,
@@ -13,7 +13,7 @@ describe(SandboxSettings, () => {
     ),
   }
   test('initializes with provided settings', async () => {
-    const sandboxSettings = new SandboxSettings({ ...baseSettings })
+    const sandboxSettings = new WorkerSandboxSettings({ ...baseSettings })
     expect(baseSettings.edgeFnFetchClient).toHaveBeenCalledWith(
       baseSettings.edgeFnDownloadURL
     )
@@ -27,7 +27,7 @@ describe(SandboxSettings, () => {
       functionHost: 'newHost.com',
       edgeFnDownloadURL: 'https://original.com/download',
     }
-    new SandboxSettings(settings)
+    new WorkerSandboxSettings(settings)
     expect(baseSettings.edgeFnFetchClient).toHaveBeenCalledWith(
       'https://newHost.com/download'
     )
@@ -42,7 +42,7 @@ describe(SandboxSettings, () => {
       processSignal: undefined,
       edgeFnDownloadURL: undefined,
     }
-    const sandboxSettings = new SandboxSettings(settings)
+    const sandboxSettings = new WorkerSandboxSettings(settings)
     expect(await sandboxSettings.processSignal).toEqual(
       'globalThis.processSignal = function processSignal() {}'
     )

--- a/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
+++ b/packages/signals/signals/src/core/processor/__tests__/sandbox-settings.test.ts
@@ -19,16 +19,15 @@ describe(IframeSandboxSettings, () => {
     expect(await sandboxSettings.processSignal).toEqual(edgeFnResponseBody)
   })
 
-  test('normalizes edgeFnDownloadURL when functionHost is provided', async () => {
-    const settings = {
+  test('should call edgeFnDownloadURL', async () => {
+    const settings: IframeSandboxSettingsConfig = {
       ...baseSettings,
       processSignal: undefined,
-      functionHost: 'newHost.com',
-      edgeFnDownloadURL: 'https://original.com/download',
+      edgeFnDownloadURL: 'https://foo.com/download',
     }
     new IframeSandboxSettings(settings)
     expect(baseSettings.edgeFnFetchClient).toHaveBeenCalledWith(
-      'https://newHost.com/download'
+      'https://foo.com/download'
     )
   })
 
@@ -36,14 +35,14 @@ describe(IframeSandboxSettings, () => {
     const consoleWarnSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => {})
-    const settings = {
+    const settings: IframeSandboxSettingsConfig = {
       ...baseSettings,
       processSignal: undefined,
       edgeFnDownloadURL: undefined,
     }
     const sandboxSettings = new IframeSandboxSettings(settings)
-    expect(await sandboxSettings.processSignal).toEqual(
-      'globalThis.processSignal = function processSignal() {}'
+    expect(await sandboxSettings.processSignal).toMatchInlineSnapshot(
+      `"globalThis.processSignal = function() {}"`
     )
     expect(baseSettings.edgeFnFetchClient).not.toHaveBeenCalled()
     expect(consoleWarnSpy).toHaveBeenCalledWith(

--- a/packages/signals/signals/src/core/processor/processor.ts
+++ b/packages/signals/signals/src/core/processor/processor.ts
@@ -12,7 +12,6 @@ export class SignalEventProcessor {
   }
 
   async process(signal: Signal, signals: Signal[]) {
-    await this.sandbox.isLoaded()
     let analyticsMethodCalls: AnalyticsMethodCalls | undefined
     try {
       analyticsMethodCalls = await this.sandbox.execute(signal, signals)

--- a/packages/signals/signals/src/core/processor/sandbox.ts
+++ b/packages/signals/signals/src/core/processor/sandbox.ts
@@ -292,6 +292,7 @@ const processWithGlobalScopeExecutionEnv = (
       'Invariant: analytics variable was not properly restored on the previous execution. This indicates a concurrency bug'
     )
   }
+  const originalSignals = g.signals
 
   try {
     g['analytics'] = analytics
@@ -309,10 +310,9 @@ const processWithGlobalScopeExecutionEnv = (
   } finally {
     // restore globals
     g['analytics'] = originalAnalytics
+    g['signals'] = originalSignals
   }
 
-  // this seems like it could potentially cause bugs in async environment
-  g.analytics = originalAnalytics
   return analytics.getCalls()
 }
 

--- a/packages/signals/signals/src/core/processor/sandbox.ts
+++ b/packages/signals/signals/src/core/processor/sandbox.ts
@@ -341,7 +341,5 @@ export class NoopSandbox implements SignalSandbox {
   execute(_signal: Signal, _signals: Signal[]) {
     return Promise.resolve(undefined)
   }
-  destroy(): void | Promise<void> {
-    return
-  }
+  destroy(): void {}
 }

--- a/packages/signals/signals/src/core/processor/sandbox.ts
+++ b/packages/signals/signals/src/core/processor/sandbox.ts
@@ -287,18 +287,18 @@ const processWithGlobalScopeExecutionEnv = (
   const signals = new WebSignalsRuntime(signalBuffer)
 
   const originalAnalytics = g.analytics
+  if (originalAnalytics instanceof AnalyticsRuntime) {
+    throw new Error(
+      'Invariant: analytics variable was not properly restored on the previous execution. This indicates a concurrency bug'
+    )
+  }
+
   try {
-    if (g['analytics'] instanceof AnalyticsRuntime) {
-      throw new Error(
-        'Invariant: analytics variable was not properly restored on the previous execution. This indicates a concurrency bug'
-      )
-    }
-
     g['analytics'] = analytics
-
     g['signals'] = signals
     processSignal(signal, {
       // we eventually want to get rid of globals and processSignal just uses local variables.
+      // TODO: update processSignal generator to accept params like these for web (mobile currently uses globals for their architecture -- can be changed but hard).
       analytics: analytics,
       signals: signals,
       // constants

--- a/packages/signals/signals/src/core/signals/settings.ts
+++ b/packages/signals/signals/src/core/signals/settings.ts
@@ -28,6 +28,7 @@ export type SignalsSettingsConfig = Pick<
   | 'mutationGenPollInterval'
   | 'mutationGenObservedAttributes'
   | 'debug'
+  | 'sandboxStrategy'
 > & {
   signalStorage?: SignalPersistentStorage
   processSignal?: string
@@ -89,6 +90,7 @@ export class SignalGlobalSettings {
       },
     }
     this.sandbox = {
+      sandboxStrategy: settings.sandboxStrategy ?? 'iframe',
       functionHost: settings.functionHost,
       processSignal: settings.processSignal,
       edgeFnDownloadURL: undefined,

--- a/packages/signals/signals/src/lib/load-script/index.ts
+++ b/packages/signals/signals/src/lib/load-script/index.ts
@@ -1,0 +1,66 @@
+function findScript(src: string): HTMLScriptElement | undefined {
+  const scripts = Array.prototype.slice.call(
+    window.document.querySelectorAll('script')
+  )
+  return scripts.find((s) => s.src === src)
+}
+
+/**
+ * Load a script from a URL and append it to the document head
+ */
+export function loadScript(
+  src: string,
+  attributes?: Record<string, string>
+): Promise<HTMLScriptElement> {
+  const found = findScript(src)
+
+  if (found !== undefined) {
+    const status = found?.getAttribute('status')
+
+    if (status === 'loaded') {
+      return Promise.resolve(found)
+    }
+
+    if (status === 'loading') {
+      return new Promise((resolve, reject) => {
+        found.addEventListener('load', () => resolve(found))
+        found.addEventListener('error', (err) => reject(err))
+      })
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = window.document.createElement('script')
+
+    script.type = 'text/javascript'
+    script.src = src
+    script.async = true
+
+    script.setAttribute('status', 'loading')
+    for (const [k, v] of Object.entries(attributes ?? {})) {
+      script.setAttribute(k, v)
+    }
+
+    script.onload = (): void => {
+      script.onerror = script.onload = null
+      script.setAttribute('status', 'loaded')
+      resolve(script)
+    }
+
+    script.onerror = (): void => {
+      script.onerror = script.onload = null
+      script.setAttribute('status', 'error')
+      reject(new Error(`Failed to load ${src}`))
+    }
+
+    const firstExistingScript = window.document.querySelector('script')
+    if (!firstExistingScript) {
+      window.document.head.appendChild(script)
+    } else {
+      firstExistingScript.parentElement?.insertBefore(
+        script,
+        firstExistingScript
+      )
+    }
+  })
+}

--- a/packages/signals/signals/src/plugin/signals-plugin.ts
+++ b/packages/signals/signals/src/plugin/signals-plugin.ts
@@ -34,24 +34,11 @@ export class SignalsPlugin implements Plugin, SignalsAugmentedFunctionality {
     Object.assign(window, { SegmentSignalsPlugin: this })
 
     this.signals = new Signals({
-      debug: settings.debug,
-      disableSignalsRedaction: settings.disableSignalsRedaction,
-      enableSignalsIngestion: settings.enableSignalsIngestion,
-      flushAt: settings.flushAt,
-      flushInterval: settings.flushInterval,
-      functionHost: settings.functionHost,
-      apiHost: settings.apiHost,
-      maxBufferSize: settings.maxBufferSize,
+      ...settings,
       processSignal:
         typeof settings.processSignal === 'function'
           ? settings.processSignal.toString()
           : settings.processSignal,
-      networkSignalsAllowSameDomain: settings.networkSignalsAllowSameDomain,
-      networkSignalsAllowList: settings.networkSignalsAllowList,
-      networkSignalsDisallowList: settings.networkSignalsDisallowList,
-      signalStorage: settings.signalStorage,
-      signalStorageType: settings.signalStorageType,
-      middleware: settings.middleware,
     })
 
     logger.debug(`SignalsPlugin v${version} initializing`, {

--- a/packages/signals/signals/src/types/settings.ts
+++ b/packages/signals/signals/src/types/settings.ts
@@ -144,6 +144,14 @@ export interface SignalsPluginSettingsConfig {
    * (defaultAttributes) => defaultAttributes.filter(attr => attr.toLowerCase() !== 'aria-selected')
    */
   mutationGenObservedAttributes?: (defaultAttributes: string[]) => string[]
+
+  /**
+   * What sandbox strategy to use
+   * - global - [EXPERIMENTAL] evaluate everything in the global scope -- use this if you want to avoid CSP errors.
+   * - iframe - use a web worker and regular evaluation
+   * @default 'iframe'
+   */
+  sandboxStrategy?: 'iframe' | 'global'
 }
 
 export type RegexLike = RegExp | string


### PR DESCRIPTION
- Raises the max signal buffer to 100.
- Add new  setting:
```ts
const plugin = new SignalsPlugin({ sandboxStrategy: 'global' })
 ```
 
 
 
### Background


This fixes CSP errors: `unsafe-inline` and `unsafe-eval` without requiring customers to add these to their CSP directive. These occur because, ironically, the default safe strategy of injecting js as a string into an iframe-web-worker and evaluating is not allowed because it's dynamic, so this setting essentially removes the sandbox. 




The iframe sandbox is mainly needed for "vanilla" function scenarios where people can introduce infinite loops, etc -- not UI-driven auto-instrumentation scenarios, so global is probably going to become the default.


There is a feature called `Shadow Realms` that is coming to JS, that one day we will be able to use without upsetting CSPs.

## TLDR
The following CSP:
```
<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.segment.com https://*.googletagmanager.com blob:">
```
Produces the following error:
<img width="1841" alt="image" src="https://github.com/user-attachments/assets/7126bf90-1aba-4218-a665-f131aae267f8" />