### PR TITLE
add ability to get user from initialize

### DIFF
--- a/.changeset/sixty-chicken-wave.md
+++ b/.changeset/sixty-chicken-wave.md
@@ -1,0 +1,10 @@
+---
+'@segment/analytics-next': minor
+---
+
+Initialize should actually support getting the initialized analytics instance.
+
+```ts
+analytics.on('initialize',function ({ analytics }) {
+  console.log('initialize', analytics.user()) // this works now.
+})

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -308,7 +308,16 @@ async function loadAnalytics(
   )
 
   analytics.initialized = true
-  analytics.emit('initialize', settings, options)
+  analytics.emit(
+    'initialize',
+    {
+      writeKey: settings.writeKey,
+      cdnSettings: settings.cdnSettings,
+      analytics: analytics,
+    },
+    /* @deprecated -- can just use analytics.options */
+    options
+  )
   await flushFinalBuffer(analytics, queryString, preInitBuffer)
 
   return [analytics, ctx]


### PR DESCRIPTION
This doesn't work:
```ts
      analytics.on('initialize', () =>  {
         user = analytics.user();
         console.log(user)
});
```

![image](https://github.com/user-attachments/assets/0d7b1696-f4b8-4ffa-93ca-9918632a3fbb)


Currently, this works, but the semantics of .ready() means that it is not resilient to failed plugins. analytics.initialize should get the analytics instance as soon as its available, and all critical plugins are registered.

```ts
      analytics.ready(() => {
         console.log(analytics.user())
  });
```


If you just need access to the user in a way that is resillient to failed plugins, you can still do:
```ts
  analytics.register({
      type: 'utility',
      load(_ctx, analytics) {
             console.log(analytics.user()) 
       }
  })
  ```