### PR TITLE
fix shell command built from environment values

### DIFF
--- a/packages/browser/scripts/vendor/run.js
+++ b/packages/browser/scripts/vendor/run.js
@@ -3,13 +3,13 @@
  * - uses webpack to build tsub.js
  * - converts tsub.js to tsub.ts, appends comments, and moves it into the source directory
  */
-const { execSync } = require('node:child_process')
+const { execFileSync } = require('node:child_process')
 const path = require('node:path')
 const { createTSFromJSLib } = require('./helpers')
 
 // build tsub.js with webpack
 const configPath = path.join(__dirname, 'webpack.config.vendor.js')
-execSync(`yarn webpack --config ${configPath}`, { stdio: 'inherit' })
+execFileSync('yarn', ['webpack', '--config', configPath], { stdio: 'inherit' })
 
 // create tsub.ts artifact and move to source directory
 const tsubInputBundlePath = path.join(__dirname, 'dist.vendor', 'tsub.js')


### PR DESCRIPTION
https://github.com/segmentio/analytics-next/blob/80ef0bee716ee616ce9369da946be2999f3fe3a4/packages/browser/scripts/vendor/run.js#L6-L12

Fix the issue will replace the use of `execSync` with `execFileSync` and pass the command arguments separately. This approach avoids shell interpretation of the dynamically constructed command string. Specifically:
1. Replace the dynamic command string `` `yarn webpack --config ${configPath}` `` with the command `yarn` and arguments `['webpack', '--config', configPath]`.
2. Update the `execSync` call to use `execFileSync` with the new command and arguments.

This change ensures that the `configPath` value is treated as a literal argument and not subject to shell interpretation.

---

### References
- [Command Injection](https://www.owasp.org/index.php/Command_Injection)
- [CWE-78](https://cwe.mitre.org/data/definitions/78.html)
- [CWE-88](https://cwe.mitre.org/data/definitions/88.html)
