### PR TITLE
feat(browser): support for nonce in some loadScript calls

### DIFF
--- a/.changeset/old-cameras-unite.md
+++ b/.changeset/old-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Added support for nonce attribute in injected load script

--- a/packages/browser/src/browser/index.ts
+++ b/packages/browser/src/browser/index.ts
@@ -214,11 +214,7 @@ async function registerPlugins(
     await import(
       /* webpackChunkName: "remoteMiddleware" */ '../plugins/remote-middleware'
     ).then(async ({ remoteMiddlewares }) => {
-      const middleware = await remoteMiddlewares(
-        ctx,
-        cdnSettings,
-        options.obfuscate
-      )
+      const middleware = await remoteMiddlewares(ctx, cdnSettings, options)
       const promises = middleware.map((mdw) =>
         analytics.addSourceMiddleware(mdw)
       )

--- a/packages/browser/src/browser/settings.ts
+++ b/packages/browser/src/browser/settings.ts
@@ -225,6 +225,10 @@ export interface InitOptions {
   retryQueue?: boolean
   obfuscate?: boolean
   /**
+   * Nonce to be used by the injected segment script
+   */
+  nonce?: string
+  /**
    * This callback allows you to update/mutate CDN Settings.
    * This is called directly after settings are fetched from the CDN.
    * @internal

--- a/packages/browser/src/browser/standalone.ts
+++ b/packages/browser/src/browser/standalone.ts
@@ -33,7 +33,7 @@ import { setGlobalAnalyticsKey } from '../lib/global-analytics-helper'
 let ajsIdentifiedCSP = false
 
 const sendErrorMetrics = (tags: string[]) => {
-  // this should not be instantied at the root, or it will break ie11.
+  // this should not be instantiated at the root, or it will break ie11.
   const metrics = new RemoteMetrics()
   metrics.increment('analytics_js.invoke.error', [
     ...tags,

--- a/packages/browser/src/plugins/ajs-destination/index.ts
+++ b/packages/browser/src/plugins/ajs-destination/index.ts
@@ -136,12 +136,7 @@ export class LegacyDestination implements InternalPluginWithAddMiddleware {
 
     const integrationSource =
       this.integrationSource ??
-      (await loadIntegration(
-        ctx,
-        this.name,
-        this.version,
-        this.options.obfuscate
-      ))
+      (await loadIntegration(ctx, this.name, this.version, this.options))
 
     this.integration = buildIntegration(
       integrationSource,

--- a/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/remote-loader/__tests__/index.test.ts
@@ -42,7 +42,10 @@ describe('Remote Loader', () => {
       {}
     )
 
-    expect(loader.loadScript).toHaveBeenCalledWith('cdn/path/to/file.js')
+    expect(loader.loadScript).toHaveBeenCalledWith(
+      'cdn/path/to/file.js',
+      undefined
+    )
   })
 
   it('should attempt to load a script from the obfuscated url of each remotePlugin', async () => {
@@ -69,6 +72,30 @@ describe('Remote Loader', () => {
     )
   })
 
+  it('should pass the nonce attribute to for each remotePlugin load', async () => {
+    await remoteLoader(
+      {
+        ...cdnSettingsMinimal,
+        remotePlugins: [
+          {
+            name: 'remote plugin',
+            creationName: 'remote plugin',
+            url: 'cdn/path/to/file.js',
+            libraryName: 'testPlugin',
+            settings: {},
+          },
+        ],
+      },
+      {},
+      {},
+      { nonce: 'my-foo-nonce' }
+    )
+
+    expect(loader.loadScript).toHaveBeenCalledWith('cdn/path/to/file.js', {
+      nonce: 'my-foo-nonce',
+    })
+  })
+
   it('should attempt to load a script from a custom CDN', async () => {
     window.analytics = {}
     window.analytics._cdn = 'foo.com'
@@ -89,7 +116,10 @@ describe('Remote Loader', () => {
       {}
     )
 
-    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/file.js')
+    expect(loader.loadScript).toHaveBeenCalledWith(
+      'foo.com/actions/file.js',
+      undefined
+    )
   })
 
   it('should work if the cdn is staging', async () => {
@@ -114,7 +144,10 @@ describe('Remote Loader', () => {
       {}
     )
 
-    expect(loader.loadScript).toHaveBeenCalledWith('foo.com/actions/foo.js')
+    expect(loader.loadScript).toHaveBeenCalledWith(
+      'foo.com/actions/foo.js',
+      undefined
+    )
   })
 
   it('should attempt calling the library', async () => {

--- a/packages/browser/src/plugins/remote-middleware/index.ts
+++ b/packages/browser/src/plugins/remote-middleware/index.ts
@@ -8,7 +8,7 @@ import { MiddlewareFunction } from '../middleware'
 export async function remoteMiddlewares(
   ctx: Context,
   settings: CDNSettings,
-  obfuscate?: boolean
+  options?: { obfuscate?: boolean; nonce?: string }
 ): Promise<MiddlewareFunction[]> {
   if (isServer()) {
     return []
@@ -22,13 +22,14 @@ export async function remoteMiddlewares(
   const scripts = names.map(async (name) => {
     const nonNamespaced = name.replace('@segment/', '')
     let bundleName = nonNamespaced
-    if (obfuscate) {
+    if (options?.obfuscate) {
       bundleName = btoa(nonNamespaced).replace(/=/g, '')
     }
     const fullPath = `${path}/middleware/${bundleName}/latest/${bundleName}.js.gz`
 
     try {
-      await loadScript(fullPath)
+      const nonceAttr = options?.nonce ? { nonce: options.nonce } : undefined
+      await loadScript(fullPath, nonceAttr)
       // @ts-ignore
       return window[`${nonNamespaced}Middleware`] as MiddlewareFunction
     } catch (error: any) {


### PR DESCRIPTION
Related to https://github.com/segmentio/analytics-next/issues/377

I'm adding the support for calling `analytics.load(settings, { nonce })` and carrying that nonce to most places where segment injects scripts.  I've also fixed a lil typo.

Note: this does not cover all places AFAIK, there's some polyfills somewhere which might need attention. I'm not focusing this PR on them.

Note 2: I've tested this here locally in a nextjs project

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
