### PR TITLE
Add segmentio/libraries-web-team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
+@segmentio/libraries-web-team
 @danieljackins
 @pooyaj


### PR DESCRIPTION
Adding a segmentio team as a codeowner.

- [ ] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
