### PR TITLE
fix(browser): re-read document.referrer when buffered value is empty

### DIFF
--- a/packages/browser/src/core/buffer/__tests__/index.test.ts
+++ b/packages/browser/src/core/buffer/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import {
   flushAnalyticsCallsInNewTask,
   PreInitMethodCallBuffer,
   PreInitMethodName,
+  popPageContext,
 } from '..'
 import { Analytics } from '../../analytics'
 import { Context } from '../../context'
@@ -13,6 +14,7 @@ import { User } from '../../user'
 import { getBufferedPageCtxFixture } from '../../../test-helpers/fixtures'
 import * as GlobalAnalytics from '../../../lib/global-analytics-helper'
 import { setVersionType } from '../../../lib/version-type'
+import { BufferedPageContextDiscriminant } from '../../page'
 
 describe(PreInitMethodCallBuffer, () => {
   beforeEach(() => {
@@ -355,6 +357,47 @@ describe(AnalyticsBuffered, () => {
       expect(thenCb).not.toBeCalled()
       expect.assertions(2)
       return p
+    })
+  })
+})
+
+describe(popPageContext, () => {
+  const makeBPC = (referrer: string) => ({
+    __t: BufferedPageContextDiscriminant,
+    c: undefined,
+    p: '/',
+    u: 'https://example.com/',
+    s: '',
+    t: 'Test',
+    r: referrer,
+  })
+
+  function withDocumentReferrer(value: string, fn: () => void) {
+    const original = document.referrer
+    Object.defineProperty(document, 'referrer', { value, configurable: true })
+    try {
+      fn()
+    } finally {
+      Object.defineProperty(document, 'referrer', {
+        value: original,
+        configurable: true,
+      })
+    }
+  }
+
+  it('should use fresh document.referrer when buffered referrer is empty', () => {
+    withDocumentReferrer('https://www.google.com/', () => {
+      const args: unknown[] = [makeBPC('')]
+      const result = popPageContext(args)
+      expect(result!.referrer).toBe('https://www.google.com/')
+    })
+  })
+
+  it('should not override when both buffered and document.referrer are empty', () => {
+    withDocumentReferrer('', () => {
+      const args: unknown[] = [makeBPC('')]
+      const result = popPageContext(args)
+      expect(result!.referrer).toBe('')
     })
   })
 })

--- a/packages/browser/src/core/buffer/index.ts
+++ b/packages/browser/src/core/buffer/index.ts
@@ -107,7 +107,16 @@ export const flushAnalyticsCallsInNewTask = (
 export const popPageContext = (args: unknown[]): PageContext | undefined => {
   if (hasBufferedPageContextAsLastArg(args)) {
     const ctx = args.pop() as BufferedPageContext
-    return createPageContext(ctx)
+    const pageCtx = createPageContext(ctx)
+    // Re-read referrer if the buffered value is empty (iOS Safari timing issue)
+    if (
+      !pageCtx.referrer &&
+      typeof document !== 'undefined' &&
+      document.referrer
+    ) {
+      return { ...pageCtx, referrer: document.referrer }
+    }
+    return pageCtx
   }
 }
 


### PR DESCRIPTION
## Summary

On iOS Safari, `document.referrer` is not yet populated when the snippet captures `BufferedPageContext` during early script execution. This causes `context.page.referrer` to be empty in all Segment calls for the session.

Fix: re-read `document.referrer` in `popPageContext()` when the buffered value is empty.

Chrome is unaffected — it populates `document.referrer` before scripts execute.

## Test plan

- [x] Unit tests for `popPageContext()` referrer re-read (fail without fix, pass with)

🤖 Generated with [Claude Code](https://claude.com/claude-code)