### PR TITLE
Export NullAnalytics from main package

### DIFF
--- a/.changeset/beige-timers-clean.md
+++ b/.changeset/beige-timers-clean.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': minor
+---
+
+Fixes #1336 NullAnalytics was accidentally removed from the public exports in commit b611746 (PR #1090) when exports were changed from wildcard to explicit. This restores the export for users who need NullAnalytics in their test code.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,4 +1,4 @@
-export { Analytics } from './core/analytics'
+export { Analytics, NullAnalytics } from './core/analytics'
 export { AnalyticsBrowser } from './browser'
 export type {
   AnalyticsBrowserSettings,


### PR DESCRIPTION
  Fixes #1336

  NullAnalytics was accidentally removed from the public exports in
  commit b611746e (PR #1090) when exports were changed from wildcard
  to explicit. This restores the export for users who need NullAnalytics
  in their test code.

<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [X] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
