### PR TITLE
fix(analytics): use more unique chunk name for middleware (#1339)

### DIFF
--- a/.changeset/fix-middleware-chunk-name.md
+++ b/.changeset/fix-middleware-chunk-name.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-next': patch
+---
+
+Rename middleware chunk name to avoid collision with Next.js middleware entrypoint

--- a/packages/browser/src/core/analytics/index.ts
+++ b/packages/browser/src/core/analytics/index.ts
@@ -467,7 +467,7 @@ export class Analytics
   async addSourceMiddleware(fn: MiddlewareFunction): Promise<Analytics> {
     await this.queue.criticalTasks.run(async () => {
       const { sourceMiddlewarePlugin } = await import(
-        /* webpackChunkName: "middleware" */ '../../plugins/middleware'
+        /* webpackChunkName: "analytics-middleware" */ '../../plugins/middleware'
       )
 
       const integrations: Record<string, boolean> = {}


### PR DESCRIPTION
Fixes issue with Next.js where the "middleware" webpack chunk name collides with Next.js's middleware.js entrypoint when using the Node.js runtime.

Based on #1355 by @blurrah.

<!---

Hello! And thanks for contributing to the Analytics-Next 🎉
- Please add:
  - a description of your PR, including the what and why
  - a changeset (if applicable)

Also make sure to describe how you tested this change, include any gifs or screenshots you find necessary.
--->

- [x] I've included a changeset (psst. run `yarn changeset`. Read about changesets [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)).
