### PR TITLE
fix: bump js-cookie from 3.0.1 to 3.0.7 (CVE-2026-46625)

### DIFF
--- a/.changeset/bump-js-cookie-security.md
+++ b/.changeset/bump-js-cookie-security.md
@@ -1,0 +1,6 @@
+---
+"@segment/analytics-next": patch
+---
+
+Bump js-cookie from 3.0.1 to 3.0.7 to fix CVE-2026-46625 (cookie-attribute injection via prototype hijack)
+

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -56,7 +56,7 @@
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
     "dset": "^3.1.4",
-    "js-cookie": "3.0.1",
+    "js-cookie": "3.0.7",
     "node-fetch": "^2.6.7",
     "tslib": "^2.4.1",
     "unfetch": "^4.1.0"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -56,7 +56,7 @@
     "@segment/analytics.js-video-plugins": "^0.2.1",
     "@segment/facade": "^3.4.9",
     "dset": "^3.1.4",
-    "js-cookie": "3.0.7",
+    "js-cookie": "^3.0.7",
     "node-fetch": "^2.6.7",
     "tslib": "^2.4.1",
     "unfetch": "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,7 +5056,7 @@ __metadata:
     jest-dev-server: ^6.0.3
     jest-environment-jsdom: ^28.1.1
     jquery: ^3.5.1
-    js-cookie: 3.0.7
+    js-cookie: ^3.0.7
     jsdom: ^19.0.0
     lighthouse: ^9.6.3
     log-update: ^4.0.0
@@ -16122,7 +16122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.7":
+"js-cookie@npm:^3.0.7":
   version: 3.0.7
   resolution: "js-cookie@npm:3.0.7"
   checksum: 2ce197fa171981af9b2686b49d4f4ed1ebfcec915db9d3ce42933415557726ca87135f6522ed5f5936b0d016e0f7e969344683dcd7f4e67a6fe2af9a976038d9

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,7 +5056,7 @@ __metadata:
     jest-dev-server: ^6.0.3
     jest-environment-jsdom: ^28.1.1
     jquery: ^3.5.1
-    js-cookie: 3.0.1
+    js-cookie: 3.0.7
     jsdom: ^19.0.0
     lighthouse: ^9.6.3
     log-update: ^4.0.0
@@ -16122,10 +16122,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.1":
-  version: 3.0.1
-  resolution: "js-cookie@npm:3.0.1"
-  checksum: bb48de67e2a6bd1ae3dfd6b2d5a167c33dd0c5a37e909206161eb0358c98f17cb55acd55827a58e9eea3630d89444e7479f7938ef4420dda443218b8c434a4c3
+"js-cookie@npm:3.0.7":
+  version: 3.0.7
+  resolution: "js-cookie@npm:3.0.7"
+  checksum: 2ce197fa171981af9b2686b49d4f4ed1ebfcec915db9d3ce42933415557726ca87135f6522ed5f5936b0d016e0f7e969344683dcd7f4e67a6fe2af9a976038d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `js-cookie` dependency from `3.0.1` to `3.0.7` in `packages/browser` to address [CVE-2026-46625](https://github.com/advisories/CVE-2026-46625) / [GHSA-qjx8-664m-686j](https://github.com/js-cookie/js-cookie/security/advisories/GHSA-qjx8-664m-686j).

## Vulnerability Details

The internal `assign()` helper in js-cookie copies properties with `for...in` + plain assignment. When the source object is produced by `JSON.parse`, a `"__proto__"` member is enumerable and triggers the `Object.prototype.__proto__` setter, resulting in a per-instance prototype hijack. An attacker can inject cookie attributes like `domain`, `secure`, `samesite`, `expires`, and `path` into cookies whose attributes the developer thought were locked down.

- **Severity**: High (CVSS 7.5)
- **CWE**: CWE-1321 (Improperly Controlled Modification of Object Prototype Attributes)
- **Patched in**: js-cookie 3.0.7

## Changes

- `packages/browser/package.json`: `js-cookie` `3.0.1` → `3.0.7`
- `yarn.lock`: updated accordingly

## References

- [js-cookie v3.0.7 release notes](https://github.com/js-cookie/js-cookie/releases/tag/v3.0.7)
- [GHSA-qjx8-664m-686j](https://github.com/js-cookie/js-cookie/security/advisories/GHSA-qjx8-664m-686j)
- Fixes #1367