### PR TITLE
Chore adjusts to receive the conversion

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -20,6 +20,14 @@ export { getGlobalAnalytics } from './lib/global-analytics-helper'
 export { UniversalStorage, Store, StorageObject } from './core/storage'
 export { segmentio } from './plugins/segmentio'
 export {
+  conversionCollectorPlugin,
+  conversionCdnSettingsMinimal,
+} from './plugins/conversion-collector'
+export type {
+  ConversionCollectorSettings,
+  AnalyticsEventEnvelope,
+} from './plugins/conversion-collector'
+export {
   resolveAliasArguments,
   resolveArguments,
   resolvePageArguments,

--- a/packages/browser/src/plugins/conversion-collector/__tests__/index.test.ts
+++ b/packages/browser/src/plugins/conversion-collector/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import { AnalyticsBrowser } from '../../../browser'
+import { conversionCdnSettingsMinimal, conversionCollectorPlugin } from '..'
+
+const COLLECTOR_ENDPOINT = 'https://collector.test/events'
+
+describe('Conversion Collector plugin', () => {
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 })
+    global.fetch = fetchMock
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('posts batched track and identify to the collector without calling Segment.io', async () => {
+    const collector = conversionCollectorPlugin({
+      endpoint: COLLECTOR_ENDPOINT,
+      retryAttempts: 0,
+      flushIntervalMs: 60_000,
+      batchSize: 10,
+    })
+
+    const [analytics] = await AnalyticsBrowser.load(
+      {
+        writeKey: 'conversion-pipeline',
+        cdnSettings: conversionCdnSettingsMinimal,
+        plugins: [collector],
+      },
+      {
+        integrations: { 'Segment.io': false },
+      }
+    )
+
+    await analytics.track('quiz_started', { quizId: 'q1' })
+    await analytics.identify('user-1', { email: 'a@test.com' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(COLLECTOR_ENDPOINT)
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' })
+
+    const body = JSON.parse(String(init.body)) as {
+      events: Array<{
+        type: string
+        event_name?: string
+        anonymous_id: string
+        user_id?: string
+        version: number
+        sent_at?: string
+      }>
+    }
+
+    expect(body.events).toHaveLength(2)
+    expect(body.events[0]?.type).toBe('track')
+    expect(body.events[0]?.event_name).toBe('quiz_started')
+    expect(body.events[1]?.type).toBe('identify')
+    expect(body.events[1]?.user_id).toBe('user-1')
+    expect(body.events[0]?.version).toBe(2)
+    expect(typeof body.events[0]?.anonymous_id).toBe('string')
+    expect(typeof body.events[0]?.sent_at).toBe('string')
+
+    const segmentCalls = fetchMock.mock.calls.filter(([callUrl]) =>
+      String(callUrl).includes('api.segment.io')
+    )
+    expect(segmentCalls).toHaveLength(0)
+  })
+})

--- a/packages/browser/src/plugins/conversion-collector/__tests__/send-events.test.ts
+++ b/packages/browser/src/plugins/conversion-collector/__tests__/send-events.test.ts
@@ -1,0 +1,32 @@
+import { sendEventsToCollect } from '../send-events'
+import type { AnalyticsEventEnvelope } from '../types'
+
+const sampleEvent = (): AnalyticsEventEnvelope => ({
+  type: 'track',
+  event_name: 'test',
+  anonymous_id: '550e8400-e29b-41d4-a716-446655440001',
+  context: {},
+  message_id: '550e8400-e29b-41d4-a716-446655440002',
+  original_timestamp: '2026-03-23T12:00:00.000Z',
+  timestamp: '2026-03-23T12:00:00.000Z',
+  version: 2,
+})
+
+describe('sendEventsToCollect', () => {
+  it('retries failed requests with backoff', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+    global.fetch = fetchMock
+
+    await sendEventsToCollect([sampleEvent()], {
+      endpoint: '/collector',
+      retryAttempts: 1,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))
+    expect(body.events[0].sent_at).toBeDefined()
+  })
+})

--- a/packages/browser/src/plugins/conversion-collector/batch-buffer.ts
+++ b/packages/browser/src/plugins/conversion-collector/batch-buffer.ts
@@ -1,0 +1,60 @@
+import type { AnalyticsEventEnvelope } from './types'
+import { sendEventsToCollect, CollectSendConfig } from './send-events'
+
+export interface BatchBufferConfig extends CollectSendConfig {
+  flushIntervalMs: number
+  batchSize: number
+}
+
+export class BatchBuffer {
+  private queue: AnalyticsEventEnvelope[] = []
+  private timer: ReturnType<typeof setInterval> | null = null
+  private flushing = false
+
+  constructor(private readonly config: BatchBufferConfig) {}
+
+  start(): void {
+    if (this.timer) {
+      return
+    }
+    this.timer = setInterval(() => {
+      void this.flush()
+    }, this.config.flushIntervalMs)
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  enqueue(event: AnalyticsEventEnvelope): void {
+    this.queue.push(event)
+    if (this.queue.length >= this.config.batchSize) {
+      void this.flush()
+    }
+  }
+
+  getSize(): number {
+    return this.queue.length
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushing || this.queue.length === 0) {
+      return
+    }
+
+    this.flushing = true
+    const batch = this.queue.splice(0, this.config.batchSize)
+
+    try {
+      await sendEventsToCollect(batch, this.config)
+    } catch (error) {
+      this.queue.unshift(...batch)
+      throw error
+    } finally {
+      this.flushing = false
+    }
+  }
+}

--- a/packages/browser/src/plugins/conversion-collector/cdn-settings.ts
+++ b/packages/browser/src/plugins/conversion-collector/cdn-settings.ts
@@ -1,0 +1,13 @@
+import { CDNSettings } from '../../browser/settings'
+
+/**
+ * Minimal CDN settings for npm-only loads without calling the Segment CDN.
+ * Pair with `integrations: { 'Segment.io': false }` and a custom collector plugin.
+ */
+export const conversionCdnSettingsMinimal: CDNSettings = {
+  integrations: {
+    'Segment.io': {
+      apiKey: 'conversion-pipeline',
+    },
+  },
+}

--- a/packages/browser/src/plugins/conversion-collector/context-to-envelope.ts
+++ b/packages/browser/src/plugins/conversion-collector/context-to-envelope.ts
@@ -1,0 +1,86 @@
+import { Analytics } from '../../core/analytics'
+import { Context } from '../../core/context'
+import { toFacade } from '../../lib/to-facade'
+import type { AnalyticsEventEnvelope, ConversionEventType } from './types'
+
+type FacadeJson = ReturnType<ReturnType<typeof toFacade>['json']>
+
+function toIsoString(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  return new Date().toISOString()
+}
+
+function resolveEventName(json: FacadeJson): string | undefined {
+  if (typeof json.event === 'string' && json.event.length > 0) {
+    return json.event
+  }
+  if (typeof json.name === 'string' && json.name.length > 0) {
+    return json.name
+  }
+  return 'page'
+}
+
+function resolveEnvelopeType(json: FacadeJson): ConversionEventType | null {
+  if (json.type === 'identify') {
+    return 'identify'
+  }
+  if (json.type === 'track' || json.type === 'page' || json.type === 'screen') {
+    return 'track'
+  }
+  return null
+}
+
+/**
+ * Maps an analytics-next context to the UTUA collector envelope (`version: 2`).
+ */
+export function contextToEnvelope(
+  ctx: Context,
+  analytics: Analytics
+): AnalyticsEventEnvelope | null {
+  const json = toFacade(ctx.event).json()
+  const type = resolveEnvelopeType(json)
+  if (!type) {
+    return null
+  }
+
+  const user = analytics.user()
+  const timestamp = toIsoString(json.timestamp)
+  const anonymousId = json.anonymousId ?? user.anonymousId()
+  const userId = json.userId ?? user.id() ?? undefined
+
+  const envelope: AnalyticsEventEnvelope = {
+    type,
+    anonymous_id: anonymousId,
+    user_id: userId || undefined,
+    context: (json.context ?? {}) as Record<string, unknown>,
+    integrations: json.integrations as Record<string, boolean> | undefined,
+    message_id: json.messageId ?? ctx.id,
+    original_timestamp: timestamp,
+    timestamp,
+    version: 2,
+  }
+
+  if (type === 'track') {
+    envelope.event_name = resolveEventName(json)
+    const properties = { ...(json.properties ?? {}) } as Record<string, unknown>
+    delete properties.event_name
+    delete properties.eventName
+    envelope.properties =
+      Object.keys(properties).length > 0 ? properties : undefined
+  }
+
+  if (type === 'identify') {
+    const traits = { ...(json.traits ?? {}) } as Record<string, unknown>
+    envelope.traits = Object.keys(traits).length > 0 ? traits : undefined
+    const properties = { ...(json.properties ?? {}) } as Record<string, unknown>
+    envelope.properties =
+      Object.keys(properties).length > 0 ? properties : undefined
+  }
+
+  return envelope
+}

--- a/packages/browser/src/plugins/conversion-collector/index.ts
+++ b/packages/browser/src/plugins/conversion-collector/index.ts
@@ -55,10 +55,9 @@ export function conversionCollectorPlugin(
       try {
         await buffer.flush()
       } catch (error) {
-        ctx.log('error', 'Conversion collector delivery failed', error)
-        ctx.setFailedDelivery({
-          reason: error instanceof Error ? error : new Error(String(error)),
-        })
+        const reason = error instanceof Error ? error : new Error(String(error))
+        ctx.log('error', 'Conversion collector delivery failed', { reason })
+        ctx.setFailedDelivery({ reason })
         analytics.emit('error', {
           code: 'delivery_failure',
           reason: error,

--- a/packages/browser/src/plugins/conversion-collector/index.ts
+++ b/packages/browser/src/plugins/conversion-collector/index.ts
@@ -1,0 +1,94 @@
+import { Analytics } from '../../core/analytics'
+import { Context } from '../../core/context'
+import { Plugin } from '../../core/plugin'
+import { BatchBuffer } from './batch-buffer'
+import { contextToEnvelope } from './context-to-envelope'
+import type { ConversionCollectorSettings } from './types'
+
+export type {
+  ConversionCollectorSettings,
+  AnalyticsEventEnvelope,
+} from './types'
+export { conversionCdnSettingsMinimal } from './cdn-settings'
+export { sendEventsToCollect } from './send-events'
+export { contextToEnvelope } from './context-to-envelope'
+
+const DEFAULT_FLUSH_INTERVAL_MS = 2000
+const DEFAULT_BATCH_SIZE = 10
+const DEFAULT_RETRY_ATTEMPTS = 2
+
+export function conversionCollectorPlugin(
+  settings: ConversionCollectorSettings
+): Plugin {
+  const buffer = new BatchBuffer({
+    endpoint: settings.endpoint,
+    headers: settings.headers,
+    retryAttempts: settings.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS,
+    flushIntervalMs: settings.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
+    batchSize: settings.batchSize ?? DEFAULT_BATCH_SIZE,
+  })
+
+  let analytics: Analytics | undefined
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('pagehide', () => {
+      void buffer.flush()
+    })
+  }
+
+  async function deliver(
+    ctx: Context,
+    flushImmediately: boolean
+  ): Promise<Context> {
+    if (!analytics) {
+      return ctx
+    }
+
+    const envelope = contextToEnvelope(ctx, analytics)
+    if (!envelope) {
+      return ctx
+    }
+
+    buffer.enqueue(envelope)
+
+    if (flushImmediately) {
+      try {
+        await buffer.flush()
+      } catch (error) {
+        ctx.log('error', 'Conversion collector delivery failed', error)
+        ctx.setFailedDelivery({
+          reason: error instanceof Error ? error : new Error(String(error)),
+        })
+        analytics.emit('error', {
+          code: 'delivery_failure',
+          reason: error,
+          ctx,
+        })
+      }
+    }
+
+    return ctx
+  }
+
+  return {
+    name: 'Conversion Collector',
+    type: 'destination',
+    version: '0.1.0',
+    isLoaded: (): boolean => true,
+    load: (_ctx, instance) => {
+      analytics = instance as Analytics
+      buffer.start()
+      return Promise.resolve()
+    },
+    unload: () => {
+      buffer.stop()
+      return buffer.flush().then(() => undefined)
+    },
+    track: (ctx) => deliver(ctx, false),
+    page: (ctx) => deliver(ctx, false),
+    screen: (ctx) => deliver(ctx, false),
+    identify: (ctx) => deliver(ctx, true),
+    alias: (ctx) => Promise.resolve(ctx),
+    group: (ctx) => Promise.resolve(ctx),
+  }
+}

--- a/packages/browser/src/plugins/conversion-collector/send-events.ts
+++ b/packages/browser/src/plugins/conversion-collector/send-events.ts
@@ -1,0 +1,63 @@
+import type {
+  AnalyticsEventEnvelope,
+  ConversionCollectorSettings,
+} from './types'
+
+export type CollectSendConfig = Pick<
+  ConversionCollectorSettings,
+  'endpoint' | 'headers' | 'retryAttempts'
+>
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function sendEventsToCollect(
+  events: AnalyticsEventEnvelope[],
+  config: CollectSendConfig
+): Promise<void> {
+  const sentAt = new Date().toISOString()
+  const body = JSON.stringify({
+    events: events.map((event) => ({
+      ...event,
+      sent_at: sentAt,
+    })),
+  })
+
+  const retryAttempts = config.retryAttempts ?? 2
+  let attempt = 0
+  let lastError: unknown
+
+  while (attempt <= retryAttempts) {
+    try {
+      const response = await fetch(config.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...config.headers,
+        },
+        body,
+      })
+
+      if (!response.ok) {
+        throw new Error(`Collect failed with status ${response.status}`)
+      }
+
+      return
+    } catch (error) {
+      lastError = error
+      const shouldRetry = attempt < retryAttempts
+      if (!shouldRetry) {
+        break
+      }
+      const backoffMs = Math.min(1500, 200 * 2 ** attempt)
+      await wait(backoffMs)
+    } finally {
+      attempt += 1
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Collect request failed')
+}

--- a/packages/browser/src/plugins/conversion-collector/types.ts
+++ b/packages/browser/src/plugins/conversion-collector/types.ts
@@ -1,0 +1,29 @@
+export type ConversionEventType = 'track' | 'identify'
+
+export interface AnalyticsEventEnvelope {
+  type: ConversionEventType
+  event_name?: string
+  anonymous_id: string
+  user_id?: string
+  traits?: Record<string, unknown>
+  properties?: Record<string, unknown>
+  context: Record<string, unknown>
+  integrations?: Record<string, boolean>
+  message_id: string
+  original_timestamp: string
+  sent_at?: string
+  timestamp: string
+  version: 2
+}
+
+export interface CollectRequestBody {
+  events: AnalyticsEventEnvelope[]
+}
+
+export interface ConversionCollectorSettings {
+  endpoint: string
+  headers?: Record<string, string>
+  retryAttempts?: number
+  flushIntervalMs?: number
+  batchSize?: number
+}


### PR DESCRIPTION
**Summary**

Primeira entrega da Fase 1 (npm-only) para integrar o collector UTUA no fork do analytics-next, sem depender da CDN Segment nem do destino Segment.io.

Adiciona o plugin destination Conversion Collector, que:

- Envia eventos em lote via POST com corpo { events: [...] } (contrato do conversion pipeline)
- Mapeia contextos do analytics-next para envelopes version: 2 em snake_case (anonymous_id, event_name, etc.)
- Faz flush imediato em identify e batch por intervalo/tamanho em track/page/screen
- Inclui retry com backoff no transporte HTTP
- Expõe conversionCdnSettingsMinimal para AnalyticsBrowser.load com cdnSettings inline (sem fetch na CDN)

**Uso esperado**

```
import {
  AnalyticsBrowser,
  conversionCollectorPlugin,
  conversionCdnSettingsMinimal,
} from '@segment/analytics-next'

const [analytics] = await AnalyticsBrowser.load(
  {
    writeKey: 'conversion-pipeline',
    cdnSettings: conversionCdnSettingsMinimal,
    plugins: [
      conversionCollectorPlugin({
        endpoint: 'https://collector.example/collect',
      }),
    ],
  },
  { integrations: { 'Segment.io': false } }
)
```