### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-next
+  description: Analytics.js 2.0 — Segment's browser & Node analytics SDK monorepo (@segment/analytics-next, analytics-core, analytics-node, consent).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+    - javascript
+    - sdk
+  links:
+    - title: npm — @segment/analytics-next
+      url: https://www.npmjs.com/package/@segment/analytics-next
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: analytics-next
-  description: Analytics.js 2.0 — Segment's browser & Node analytics SDK monorepo (@segment/analytics-next, analytics-core, analytics-node, consent).
+  description: Analytics.js 2.0 — Segment's browser analytics SDK (@segment/analytics-next).
   annotations:
     github.com/project-slug: segmentio/analytics-next
     github.com/team-slug: segmentio/data-collection
@@ -16,6 +16,136 @@ metadata:
   links:
     - title: npm — @segment/analytics-next
       url: https://www.npmjs.com/package/@segment/analytics-next
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-core
+  description: Shared core used by Segment's analytics SDKs (@segment/analytics-core).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+    - sdk
+  links:
+    - title: npm — @segment/analytics-core
+      url: https://www.npmjs.com/package/@segment/analytics-core
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-node
+  description: Server-side Node analytics SDK (@segment/analytics-node).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+    - sdk
+  links:
+    - title: npm — @segment/analytics-node
+      url: https://www.npmjs.com/package/@segment/analytics-node
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-consent-tools
+  description: Consent-management tooling for Analytics.js (@segment/analytics-consent-tools).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+    - sdk
+  links:
+    - title: npm — @segment/analytics-consent-tools
+      url: https://www.npmjs.com/package/@segment/analytics-consent-tools
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-consent-wrapper-onetrust
+  description: OneTrust consent wrapper for Analytics.js (@segment/analytics-consent-wrapper-onetrust).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+    - sdk
+  links:
+    - title: npm — @segment/analytics-consent-wrapper-onetrust
+      url: https://www.npmjs.com/package/@segment/analytics-consent-wrapper-onetrust
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-generic-utils
+  description: Shared generic utilities for Segment analytics SDKs (@segment/analytics-generic-utils).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+  links:
+    - title: npm — @segment/analytics-generic-utils
+      url: https://www.npmjs.com/package/@segment/analytics-generic-utils
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sup-org-1996
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: analytics-page-tools
+  description: Page/URL helper utilities for Analytics.js (@segment/analytics-page-tools).
+  annotations:
+    github.com/project-slug: segmentio/analytics-next
+    github.com/team-slug: segmentio/data-collection
+    jira/project-key: LIBRARIES
+    pagerduty.com/service-id: POJL6ZQ
+    twilio.com/slack-id: integrations-libs
+  tags:
+    - typescript
+  links:
+    - title: npm — @segment/analytics-page-tools
+      url: https://www.npmjs.com/package/@segment/analytics-page-tools
 spec:
   type: library
   lifecycle: production


### PR DESCRIPTION
Registers the monorepo's 7 published packages as separate Backstage `type: library` Components (so each is individually discoverable), all owned by Data Collections (`group:default/sup-org-1996`):

`analytics-next`, `analytics-core`, `analytics-node`, `analytics-consent-tools`, `analytics-consent-wrapper-onetrust`, `analytics-generic-utils`, `analytics-page-tools`.

Private `@internal/*` workspaces (tests/config) are excluded. Each shares `github.com/project-slug: segmentio/analytics-next` and the team's jira/pagerduty/slack annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)