### PR TITLE
Version Packages

### DIFF
--- a/.changeset/bump-js-cookie-security.md
+++ b/.changeset/bump-js-cookie-security.md
@@ -1,6 +1,0 @@
----
-"@segment/analytics-next": patch
----
-
-Bump js-cookie from 3.0.1 to 3.0.7 to fix CVE-2026-46625 (cookie-attribute injection via prototype hijack)
-

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @segment/analytics-next
 
+## 1.84.1
+
+### Patch Changes
+
+- [#1368](https://github.com/segmentio/analytics-next/pull/1368) [`3c92e372`](https://github.com/segmentio/analytics-next/commit/3c92e3725ece3bcd747d5ee07d403aa189c0532e) Thanks [@samjoffe](https://github.com/samjoffe)! - Bump js-cookie from 3.0.1 to 3.0.7 to fix CVE-2026-46625 (cookie-attribute injection via prototype hijack)
+
 ## 1.84.0
 
 ### Minor Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-next",
-  "version": "1.84.0",
+  "version": "1.84.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/analytics-next",

--- a/packages/browser/src/generated/version.ts
+++ b/packages/browser/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.84.0'
+export const version = '1.84.1'


### PR DESCRIPTION
This PR was opened by hand (not by the usual bot) because `release-creator.yml` has been failing since 2026-07-15 - `changesets/action` is a third-party GitHub Action blocked by this org's Actions allowlist (only GitHub-owned actions are permitted). That's being tracked as a separate follow-up to rebuild the automation without a third-party action.

Content is exactly what the bot would have produced: ran `yarn update-versions-and-changelogs` (the same command `release-creator.yml` already calls) against the one pending changeset.

# Releases
## @segment/analytics-next@1.84.1

### Patch Changes

- [#1368](https://github.com/segmentio/analytics-next/pull/1368) Bump js-cookie from 3.0.1 to 3.0.7 to fix CVE-2026-46625 (cookie-attribute injection via prototype hijack)

Merging this will trigger `release.yml`'s publish job (gated on a commit message starting with "Version Packages", same as the automated flow).