### PR TITLE
ci: fix Artifactory OIDC provider_name for segmentio org

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -37,7 +37,7 @@ runs:
           -d "{\"grant_type\":\"urn:ietf:params:oauth:grant-type:token-exchange\",
                \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\",
                \"subject_token\":\"${GITHUB_JWT}\",
-               \"provider_name\":\"github-actions\"}")
+               \"provider_name\":\"github-actions-segmentio\"}")
         ART_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
 
         if [ -z "$ART_TOKEN" ]; then


### PR DESCRIPTION
## Summary

`release.yml`'s Artifactory OIDC step has been failing with `Invalid organization` since the workflow was added. The composite action hardcodes `provider_name: "github-actions"` for every repo, but this org's OIDC trust is registered under a distinct provider name — sending the wrong one causes JFrog to validate the token's org claim against the wrong provider config and reject it, independent of whether the repo itself is already allow-listed.

## Fix

`.github/actions/artifactory-oidc/action.yml` now sends this org's actual provider name in the token-exchange request instead of the generic default.

## Test plan

- [ ] `release.yml`'s `test` job reaches the Artifactory OIDC step successfully on the next run
- [ ] Yarn install resolves dependencies through Artifactory without falling back/erroring