### PR TITLE
ci: allow release.yml to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -13,6 +14,10 @@ jobs:
   # Only proceeds past this gate when master's HEAD is a "Version Packages"
   # merge. Any other push to master (a regular PR merge) just no-ops here;
   # release-creator.yml is what opens/updates the Version Packages PR itself.
+  # A manual workflow_dispatch run always passes this gate - there's no
+  # head_commit on that event, and choosing to run it by hand is itself the
+  # signal; the production environment's approval gate downstream still
+  # applies before anything actually publishes.
   should-release:
     name: Check for Version Packages merge
     runs-on: ubuntu-latest-large
@@ -28,7 +33,8 @@ jobs:
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          if [[ "$COMMIT_MESSAGE" == "Version Packages"* ]] && [[ "$COMMIT_MESSAGE" != *"[skip]"* ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "$COMMIT_MESSAGE" == "Version Packages"* && "$COMMIT_MESSAGE" != *"[skip]"* ]]; then
             echo "release=true" >> "$GITHUB_OUTPUT"
           else
             echo "release=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`@segment/analytics-next` was bumped to `1.84.1` by the "Version Packages" merge (#1378), but the publish job never actually ran to completion - the Artifactory OIDC step failed with `Invalid organization` (fixed in #1380). So `1.84.1` is committed, changelogged, and tagged-in-intent, but was never actually published to npm.

`release.yml` only triggers on a push to `master` whose commit message starts with `Version Packages` - there was no way to retry the publish once the underlying bug was fixed, short of a fresh version bump.

## Change

Adds `workflow_dispatch` so the workflow can be run by hand against master's current state. `should-release` now treats a manual run as always passing the gate (there's no `head_commit` on a `workflow_dispatch` event to check) - the `production` environment's manual-approval gate still applies before anything actually publishes.

## Test plan

- [ ] After merge, manually run this workflow (`gh workflow run release.yml` or via the Actions tab)
- [ ] Confirm the `test` job's Artifactory OIDC step succeeds this time
- [ ] Approve the `production` environment gate
- [ ] Confirm `@segment/analytics-next@1.84.1` appears on npm and a matching GitHub release is created