### PR TITLE
fix: set YARN_NPM_ALWAYS_AUTH so Artifactory auth actually applies

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -57,9 +57,19 @@ runs:
         # config keys: npmRegistryServer -> YARN_NPM_REGISTRY_SERVER,
         # npmAuthToken -> YARN_NPM_AUTH_TOKEN). Exported to GITHUB_ENV so every
         # later step in the job (not just this one) picks them up.
+        #
+        # npmAlwaysAuth (YARN_NPM_ALWAYS_AUTH) is required too: without it,
+        # Yarn only attaches the token to packages it already suspects need
+        # auth (scoped/private), so ordinary public-looking dependencies get
+        # fetched with no auth header at all and Artifactory 401s them as
+        # anonymous. npm's classic ~/.npmrc `_authToken` line (what the
+        # reference action in the npm-publishing guide uses) doesn't have
+        # this ambiguity - this is the one place the Yarn Berry adaptation
+        # diverges from that reference and needs its own explicit setting.
         REGISTRY="${BASE_URL}/artifactory/api/npm/virtual-npm-thirdparty/"
         {
           echo "YARN_NPM_REGISTRY_SERVER=${REGISTRY}"
           echo "YARN_NPM_AUTH_TOKEN=${ART_TOKEN}"
+          echo "YARN_NPM_ALWAYS_AUTH=true"
         } >> "$GITHUB_ENV"
         echo "::notice::Yarn configured to use Artifactory registry"


### PR DESCRIPTION
## Summary

The last release attempt got past the OIDC token exchange (fixed in #1380) but then failed at `yarn install --immutable` in the `publish` job with `Invalid authentication (as an anonymous user)` on every single real dependency fetch. The `test` job in the same run didn't hit this - it had a full yarn cache hit and never made a real authenticated request, which is why this wasn't caught earlier.

## Root cause

Per the [npm publishing guide's](https://internal-product-docs.twilio.com/docs/publishing-oss-packages/setup-npm-publishing) reference Artifactory OIDC action, npm's classic `~/.npmrc` `_authToken` line attaches the token to every request against that registry path unconditionally. Our composite action adapts this to Yarn Berry's own config instead (`YARN_NPM_REGISTRY_SERVER` / `YARN_NPM_AUTH_TOKEN`, since Yarn Berry doesn't read `.npmrc`) - but without also setting `npmAlwaysAuth` (env: `YARN_NPM_ALWAYS_AUTH`), Yarn only attaches the token to packages it already suspects need auth (scoped/private ones). Ordinary public-looking dependencies get fetched with no auth header at all, so Artifactory rejects them as anonymous.

## Fix

Adds `YARN_NPM_ALWAYS_AUTH=true` alongside the existing registry/token env vars.

## Test plan

- [ ] Re-run `release.yml`'s `publish` job (or trigger a fresh, uncached install) and confirm dependency resolution succeeds instead of failing with `Invalid authentication`