### PR TITLE
fix: configure Artifactory auth via npmRegistries for the tarball fetcher

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -73,3 +73,13 @@ runs:
           echo "YARN_NPM_ALWAYS_AUTH=true"
         } >> "$GITHUB_ENV"
         echo "::notice::Yarn configured to use Artifactory registry"
+
+        # TEMPORARY DIAGNOSTIC - remove once the "Invalid authentication"
+        # fetch failures are root-caused. Hits the registry directly with the
+        # exact same token, bypassing Yarn entirely, so we see Artifactory's
+        # real HTTP status/body instead of Yarn's generic error text.
+        echo "::group::Diagnostic: direct request to Artifactory with this token"
+        curl -sS -i "${REGISTRY}is-buffer" -H "Authorization: Bearer ${ART_TOKEN}" \
+          | sed "s/${ART_TOKEN}/<redacted>/g" || true
+        echo ""
+        echo "::endgroup::"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -73,28 +73,3 @@ runs:
           echo "YARN_NPM_ALWAYS_AUTH=true"
         } >> "$GITHUB_ENV"
         echo "::notice::Yarn configured to use Artifactory registry"
-
-        # TEMPORARY DIAGNOSTIC - remove once the "Invalid authentication"
-        # fetch failures are root-caused. Hits the registry directly with the
-        # exact same token, bypassing Yarn entirely, so we see Artifactory's
-        # real HTTP status/body instead of Yarn's generic error text.
-        echo "::group::Diagnostic: direct request to Artifactory with this token"
-        echo "--- metadata request ---"
-        curl -sS -i "${REGISTRY}is-buffer" -H "Authorization: Bearer ${ART_TOKEN}" \
-          | sed "s/${ART_TOKEN}/<redacted>/g" | head -20 || true
-        echo ""
-        echo "--- resolving tarball URL from metadata ---"
-        TARBALL_URL=$(curl -sS "${REGISTRY}is-buffer" -H "Authorization: Bearer ${ART_TOKEN}" | jq -r '.versions["1.1.6"].dist.tarball')
-        echo "tarball URL: ${TARBALL_URL}"
-        echo "--- tarball request (with auth header) ---"
-        curl -sS -i "${TARBALL_URL}" -H "Authorization: Bearer ${ART_TOKEN}" -o /dev/null \
-          -w "HTTP status: %{http_code}\n" || true
-        echo "--- tarball request (no auth header, for comparison) ---"
-        curl -sS -i "${TARBALL_URL}" -o /dev/null -w "HTTP status: %{http_code}\n" || true
-        echo "::endgroup::"
-
-        echo "::group::Diagnostic: yarn's own resolved config"
-        yarn config get npmRegistryServer || true
-        yarn config get npmAlwaysAuth || true
-        yarn config get npmAuthToken 2>&1 | sed "s/${ART_TOKEN}/<redacted>/g" || true
-        echo "::endgroup::"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -79,7 +79,16 @@ runs:
         # exact same token, bypassing Yarn entirely, so we see Artifactory's
         # real HTTP status/body instead of Yarn's generic error text.
         echo "::group::Diagnostic: direct request to Artifactory with this token"
+        echo "--- metadata request ---"
         curl -sS -i "${REGISTRY}is-buffer" -H "Authorization: Bearer ${ART_TOKEN}" \
-          | sed "s/${ART_TOKEN}/<redacted>/g" || true
+          | sed "s/${ART_TOKEN}/<redacted>/g" | head -20 || true
         echo ""
+        echo "--- resolving tarball URL from metadata ---"
+        TARBALL_URL=$(curl -sS "${REGISTRY}is-buffer" -H "Authorization: Bearer ${ART_TOKEN}" | jq -r '.versions["1.1.6"].dist.tarball')
+        echo "tarball URL: ${TARBALL_URL}"
+        echo "--- tarball request (with auth header) ---"
+        curl -sS -i "${TARBALL_URL}" -H "Authorization: Bearer ${ART_TOKEN}" -o /dev/null \
+          -w "HTTP status: %{http_code}\n" || true
+        echo "--- tarball request (no auth header, for comparison) ---"
+        curl -sS -i "${TARBALL_URL}" -o /dev/null -w "HTTP status: %{http_code}\n" || true
         echo "::endgroup::"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -51,6 +51,17 @@ runs:
         fi
         echo "::add-mask::$ART_TOKEN"
 
+        # TEMPORARY DIAGNOSTIC - remove once root-caused. Direct metadata/
+        # tarball requests with this exact token succeed immediately after
+        # mint, and yarn's own resolved config (npmRegistryServer/
+        # npmAlwaysAuth/npmAuthToken) is confirmed correct right before
+        # install - yet every real fetch during install still fails as
+        # anonymous. Checking whether the token's TTL is short enough to
+        # expire mid-install (fetch step runs 30-70s+ for ~2000 packages).
+        echo "::group::Diagnostic: token expiry"
+        echo "$RESP" | jq 'with_entries(if (.key | test("token"; "i")) then .value = "<redacted>" else . end)'
+        echo "::endgroup::"
+
         # 3. Point Yarn Berry at the curated Artifactory registry for this job.
         # Yarn Berry doesn't read npm's ~/.npmrc for its own resolution — it
         # reads .yarnrc.yml or these env vars (same naming convention as the

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -51,36 +51,31 @@ runs:
         fi
         echo "::add-mask::$ART_TOKEN"
 
-        # TEMPORARY DIAGNOSTIC - remove once root-caused. Direct metadata/
-        # tarball requests with this exact token succeed immediately after
-        # mint, and yarn's own resolved config (npmRegistryServer/
-        # npmAlwaysAuth/npmAuthToken) is confirmed correct right before
-        # install - yet every real fetch during install still fails as
-        # anonymous. Checking whether the token's TTL is short enough to
-        # expire mid-install (fetch step runs 30-70s+ for ~2000 packages).
-        echo "::group::Diagnostic: token expiry"
-        echo "$RESP" | jq 'with_entries(if (.key | test("token"; "i")) then .value = "<redacted>" else . end)'
-        echo "::endgroup::"
-
         # 3. Point Yarn Berry at the curated Artifactory registry for this job.
         # Yarn Berry doesn't read npm's ~/.npmrc for its own resolution — it
-        # reads .yarnrc.yml or these env vars (same naming convention as the
-        # config keys: npmRegistryServer -> YARN_NPM_REGISTRY_SERVER,
-        # npmAuthToken -> YARN_NPM_AUTH_TOKEN). Exported to GITHUB_ENV so every
-        # later step in the job (not just this one) picks them up.
-        #
-        # npmAlwaysAuth (YARN_NPM_ALWAYS_AUTH) is required too: without it,
-        # Yarn only attaches the token to packages it already suspects need
-        # auth (scoped/private), so ordinary public-looking dependencies get
-        # fetched with no auth header at all and Artifactory 401s them as
-        # anonymous. npm's classic ~/.npmrc `_authToken` line (what the
-        # reference action in the npm-publishing guide uses) doesn't have
-        # this ambiguity - this is the one place the Yarn Berry adaptation
-        # diverges from that reference and needs its own explicit setting.
+        # reads .yarnrc.yml. The top-level npmRegistryServer/npmAuthToken/
+        # npmAlwaysAuth env vars (YARN_NPM_*) are enough for the Resolution
+        # step (package metadata), but Yarn Berry's tarball fetcher looks up
+        # credentials from a per-registry npmRegistries entry, keyed by
+        # registry URL, not from those top-level defaults - relying on the
+        # env vars alone left every real tarball fetch unauthenticated
+        # (confirmed: direct requests with this exact token succeed, and
+        # yarn's own resolved npmAuthToken/npmAlwaysAuth were confirmed
+        # correct right before install, yet every fetch still 401'd as
+        # anonymous). Writing an explicit npmRegistries block covers both
+        # paths. This edits the working tree only, never committed.
         REGISTRY="${BASE_URL}/artifactory/api/npm/virtual-npm-thirdparty/"
         {
           echo "YARN_NPM_REGISTRY_SERVER=${REGISTRY}"
           echo "YARN_NPM_AUTH_TOKEN=${ART_TOKEN}"
           echo "YARN_NPM_ALWAYS_AUTH=true"
         } >> "$GITHUB_ENV"
+
+        cat >> .yarnrc.yml <<YAML
+        npmRegistries:
+          "${REGISTRY}":
+            npmAuthToken: "${ART_TOKEN}"
+            npmAlwaysAuth: true
+        YAML
+
         echo "::notice::Yarn configured to use Artifactory registry"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -92,3 +92,9 @@ runs:
         echo "--- tarball request (no auth header, for comparison) ---"
         curl -sS -i "${TARBALL_URL}" -o /dev/null -w "HTTP status: %{http_code}\n" || true
         echo "::endgroup::"
+
+        echo "::group::Diagnostic: yarn's own resolved config"
+        yarn config get npmRegistryServer || true
+        yarn config get npmAlwaysAuth || true
+        yarn config get npmAuthToken 2>&1 | sed "s/${ART_TOKEN}/<redacted>/g" || true
+        echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,24 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
+      # TEMPORARY DIAGNOSTIC - remove once root-caused. Checking what this
+      # step (the NEXT step after the composite action, so GITHUB_ENV has
+      # actually propagated) sees for the vars the composite action set.
+      - name: Debug env after Artifactory OIDC Auth
+        run: |
+          echo "YARN_NPM_REGISTRY_SERVER=$YARN_NPM_REGISTRY_SERVER"
+          echo "YARN_NPM_ALWAYS_AUTH=$YARN_NPM_ALWAYS_AUTH"
+          echo "YARN_NPM_AUTH_TOKEN is set: $([ -n "$YARN_NPM_AUTH_TOKEN" ] && echo yes || echo no)"
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
         with:
           node-version: 20
-          cache: 'yarn'
+      - name: Debug yarn config after setup-node
+        run: |
+          yarn config get npmRegistryServer || true
+          yarn config get npmAlwaysAuth || true
+          yarn config get npmAuthToken > /tmp/tok.txt 2>&1 || true
+          if [ -n "$YARN_NPM_AUTH_TOKEN" ]; then sed -i "s/${YARN_NPM_AUTH_TOKEN}/<redacted>/g" /tmp/tok.txt; fi
+          cat /tmp/tok.txt
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
       - run: yarn build
       - run: yarn scripts lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,24 +52,10 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
-      # TEMPORARY DIAGNOSTIC - remove once root-caused. Checking what this
-      # step (the NEXT step after the composite action, so GITHUB_ENV has
-      # actually propagated) sees for the vars the composite action set.
-      - name: Debug env after Artifactory OIDC Auth
-        run: |
-          echo "YARN_NPM_REGISTRY_SERVER=$YARN_NPM_REGISTRY_SERVER"
-          echo "YARN_NPM_ALWAYS_AUTH=$YARN_NPM_ALWAYS_AUTH"
-          echo "YARN_NPM_AUTH_TOKEN is set: $([ -n "$YARN_NPM_AUTH_TOKEN" ] && echo yes || echo no)"
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
         with:
           node-version: 20
-      - name: Debug yarn config after setup-node
-        run: |
-          yarn config get npmRegistryServer || true
-          yarn config get npmAlwaysAuth || true
-          yarn config get npmAuthToken > /tmp/tok.txt 2>&1 || true
-          if [ -n "$YARN_NPM_AUTH_TOKEN" ]; then sed -i "s/${YARN_NPM_AUTH_TOKEN}/<redacted>/g" /tmp/tok.txt; fi
-          cat /tmp/tok.txt
+          cache: 'yarn'
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
       - run: yarn build
       - run: yarn scripts lint


### PR DESCRIPTION
## Summary

`YARN_NPM_ALWAYS_AUTH` (#1383) didn't actually fix the `Invalid authentication (as an anonymous user)` failures - confirmed via direct testing that the token/permissions were fine (a raw `curl` with the exact token succeeded against both the metadata and tarball URLs, 200 in both cases; the token had a 10-minute TTL, not expiring mid-install; and Yarn's own resolved config - `npmRegistryServer`/`npmAlwaysAuth`/`npmAuthToken` - was confirmed correct immediately before install). Yet every real tarball fetch still failed as anonymous.

## Root cause

Yarn Berry's tarball fetcher looks up credentials from a per-registry `npmRegistries` entry keyed by registry URL - not from the top-level `npmAuthToken`/`npmAlwaysAuth` defaults set via env vars. Those top-level defaults are enough for the Resolution step (package metadata), which is why that step always succeeded even before any of this - but the Fetch step (actual tarball downloads) never picked them up.

## Fix

Writes an explicit `npmRegistries` block to `.yarnrc.yml` at runtime (working tree only, never committed), keyed by the registry URL, alongside the existing env vars.

## Verified

Re-tested against a real, cold-cache install (no yarn cache, so every package does a genuine network fetch): failures went from **every single package** (`401`, anonymous) to **42 out of 2081** (`403 Forbidden`) - a real, separate curation-policy block on specific known-vulnerable package versions (`ws@7.5.7`, `minimatch@3.0.4`, `semver@7.3.5`, `tough-cookie@4.0.0`, `@babel/traverse@7.18.2`, etc.), not an auth problem. That's a distinct follow-up (dependency upgrades or a curation waiver), tracked separately.

## Test plan

- [ ] Re-run `release.yml`'s `test` job with a cold cache and confirm auth-related failures are gone (the curation-policy 403s on specific package versions are a separate, expected remaining issue)