### PR TITLE
ci: add a sandbox workflow to test Artifactory resolution on any branch

### DIFF
--- a/.github/workflows/test-artifactory-install.yml
+++ b/.github/workflows/test-artifactory-install.yml
@@ -13,16 +13,25 @@ env:
 
 jobs:
   test-install:
-    name: Test yarn install through curated Artifactory
+    name: Test yarn install through curated Artifactory (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest-large
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Different Node versions can resolve different optional/platform
+        # dependencies (confirmed: is-email and axios showed up blocked
+        # under one version's dependency tree but not the other's) -
+        # matches the two versions release.yml's test/publish jobs
+        # actually use.
+        node-version: [20, 24]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable

--- a/.github/workflows/test-artifactory-install.yml
+++ b/.github/workflows/test-artifactory-install.yml
@@ -1,0 +1,28 @@
+name: Test Artifactory Install (sandbox)
+# Manual-only, no publish step, no should-release gate - safe to run on any
+# branch to check whether `yarn install --immutable` resolves cleanly
+# through curated Artifactory (catches curation-policy 403s on specific
+# package versions) without touching master or arming a real release.
+# Usage: gh workflow run test-artifactory-install.yml --ref <branch>
+on:
+  workflow_dispatch: {}
+
+env:
+  HUSKY: 0
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
+jobs:
+  test-install:
+    name: Test yarn install through curated Artifactory
+    runs-on: ubuntu-latest-large
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
+        with:
+          node-version: 20
+      - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable


### PR DESCRIPTION
## Summary

Testing whether a dependency change resolves cleanly through curated Artifactory (catching curation-policy 403s like the ones fixed in #1385/#1386) has meant triggering `release.yml` itself via `workflow_dispatch` on a scratch branch. That works, but it also arms the `publish` job - harmless since it needs the `production` environment's manual approval and never gets it, but not clean, and easy to lose track of.

## Change

A standalone workflow instead: manual-only, no `should-release` gate, no `publish` job, nothing else it can accidentally trigger. Push any candidate `resolutions`/`yarn.lock` change to a branch and run:

```
gh workflow run test-artifactory-install.yml --ref <branch>
```

Deliberately doesn't cache yarn's dependency cache the way `release.yml`'s `test` job does - a warm cache can serve packages from GitHub's own cache without ever making a real request to Artifactory, masking exactly the kind of curation failure this exists to catch.