### PR TITLE
fix(node): count event bytes correctly so the size limits are enforced

### DIFF
--- a/.changeset/fix-node-event-size-guard.md
+++ b/.changeset/fix-node-event-size-guard.md
@@ -1,0 +1,5 @@
+---
+'@segment/analytics-node': patch
+---
+
+Fix the per-event and batch size limits, which were not enforced. `ContextBatch.calculateSize` used a broken byte-count regex (`split(/%..|i/)`) that counted only `%XX` escapes plus the letter "i" instead of UTF-8 bytes, so a ~39 KB event measured as ~21 bytes and passed the 32 KB per-event guard. Restored the correct byte count so oversized events are rejected before they are sent.

--- a/packages/node/src/plugins/segmentio/__tests__/context-batch.test.ts
+++ b/packages/node/src/plugins/segmentio/__tests__/context-batch.test.ts
@@ -1,0 +1,29 @@
+import { ContextBatch } from '../context-batch'
+import { NodeEventFactory } from '../../../app/event-factory'
+import { Context } from '../../../app/context'
+
+const eventFactory = new NodeEventFactory()
+const pending = (context: Context) => ({ resolver: () => undefined, context })
+
+describe('ContextBatch', () => {
+  it('rejects an event that exceeds the 32 KB per-event size limit', () => {
+    // ~40 KB of JSON, well over the 32 KB per-event cap
+    const event = eventFactory.track(
+      'big',
+      { data: 'a'.repeat(40000) },
+      { userId: 'u' }
+    )
+    const batch = new ContextBatch(100)
+    const result = batch.tryAdd(pending(new Context(event)))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.message).toContain('exceeds maximum event size')
+    }
+  })
+
+  it('accepts a normal small event', () => {
+    const event = eventFactory.track('small', { ok: true }, { userId: 'u' })
+    const batch = new ContextBatch(100)
+    expect(batch.tryAdd(pending(new Context(event))).success).toBe(true)
+  })
+})

--- a/packages/node/src/plugins/segmentio/context-batch.ts
+++ b/packages/node/src/plugins/segmentio/context-batch.ts
@@ -53,7 +53,7 @@ export class ContextBatch {
   }
 
   private calculateSize(ctx: Context): number {
-    return encodeURI(JSON.stringify(ctx.event)).split(/%..|i/).length
+    return encodeURI(JSON.stringify(ctx.event)).split(/%..|./).length - 1
   }
 
   getEvents(): SegmentEvent[] {


### PR DESCRIPTION
### What I hit

Sending server-side events with `@segment/analytics-node`, oversized events weren't being caught by the client's size guard, so they'd ship and the API would reject the whole batch. It turned out the 32 KB per-event and 480 KB batch limits were not being enforced at all.

### Root cause

`ContextBatch.calculateSize` (`packages/node/src/plugins/segmentio/context-batch.ts`) is a broken copy of the well-known "count UTF-8 bytes" idiom `encodeURI(str).split(/%..|./).length - 1`:

```ts
encodeURI(JSON.stringify(ctx.event)).split(/%..|i/).length
```

The `.` (match any character) was mistyped as a literal `i`, and the trailing `- 1` was dropped. So instead of counting bytes it counts `%XX` escapes plus the letter "i". A ~39 KB event measures as ~21, passes the 32 KB guard, and gets sent. This has been the case since batching was added in #640.

### Fix

Restore the correct byte count:

```diff
-    return encodeURI(JSON.stringify(ctx.event)).split(/%..|i/).length
+    return encodeURI(JSON.stringify(ctx.event)).split(/%..|./).length - 1
```

After the fix, `calculateSize` equals `Buffer.byteLength(json, 'utf8')` across ASCII, multibyte, and URL-reserved inputs.

### Test

Added `packages/node/src/plugins/segmentio/__tests__/context-batch.test.ts`: a ~39 KB event is now rejected ("Event exceeds maximum event size of 32 KB"), a small event is still accepted. Verified fail before / pass after (revert the regex and the size test fails). The existing 500 KB test is unaffected. Included a `patch` changeset for `@segment/analytics-node`.
