### PR TITLE
ci: fix deploy-cdn's disallowed action (aws-actions/configure-aws-credentials)

### DIFF
--- a/.github/actions/aws-oidc-assume-role/action.yml
+++ b/.github/actions/aws-oidc-assume-role/action.yml
@@ -17,6 +17,14 @@ runs:
   steps:
     - name: Assume AWS role via OIDC
       shell: bash
+      env:
+        # Passed through env, not interpolated directly into the script body
+        # below (${{ inputs.x }} inline in a run: step is a shell-injection
+        # risk - a malicious input value becomes literal script text before
+        # the shell ever runs it, rather than being treated as data).
+        INPUT_ROLE_ARN: ${{ inputs.role-arn }}
+        INPUT_ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
+        INPUT_AWS_REGION: ${{ inputs.aws-region }}
       run: |
         set -euo pipefail
 
@@ -48,8 +56,8 @@ runs:
         #    Action involved - just the OIDC token and the AWS CLI, both
         #    already present on the runner.
         CREDS=$(aws sts assume-role-with-web-identity \
-          --role-arn "${{ inputs.role-arn }}" \
-          --role-session-name "${{ inputs.role-session-name }}" \
+          --role-arn "$INPUT_ROLE_ARN" \
+          --role-session-name "$INPUT_ROLE_SESSION_NAME" \
           --web-identity-token "$GITHUB_JWT" \
           --query 'Credentials' --output json)
 
@@ -70,8 +78,8 @@ runs:
           echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
           echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
           echo "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
-          echo "AWS_REGION=${{ inputs.aws-region }}"
-          echo "AWS_DEFAULT_REGION=${{ inputs.aws-region }}"
+          echo "AWS_REGION=${INPUT_AWS_REGION}"
+          echo "AWS_DEFAULT_REGION=${INPUT_AWS_REGION}"
         } >> "$GITHUB_ENV"
 
-        echo "::notice::Assumed AWS role ${{ inputs.role-arn }}"
+        echo "::notice::Assumed AWS role ${INPUT_ROLE_ARN}"

--- a/.github/actions/aws-oidc-assume-role/action.yml
+++ b/.github/actions/aws-oidc-assume-role/action.yml
@@ -1,0 +1,77 @@
+name: 'AWS OIDC Assume Role'
+description: 'Exchange the GitHub OIDC token for short-lived AWS credentials via sts:AssumeRoleWithWebIdentity, without a third-party Action'
+
+inputs:
+  role-arn:
+    description: 'ARN of the AWS IAM role to assume'
+    required: true
+  role-session-name:
+    description: 'Session name for the assumed-role credentials'
+    required: true
+  aws-region:
+    description: 'AWS region to export for subsequent AWS CLI/SDK calls'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Assume AWS role via OIDC
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # jq and the AWS CLI are present on ubuntu-latest(-large) today, but
+        # not guaranteed on every runner - fail early with a clear message
+        # rather than a confusing parse error further down.
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::jq is required by the aws-oidc-assume-role action but was not found on the runner."
+          exit 1
+        fi
+        if ! command -v aws >/dev/null 2>&1; then
+          echo "::error::aws CLI is required by the aws-oidc-assume-role action but was not found on the runner."
+          exit 1
+        fi
+
+        # 1. Request a GitHub OIDC JWT scoped to sts.amazonaws.com - AWS's
+        #    documented audience for OIDC federation from GitHub Actions.
+        GITHUB_JWT=$(curl -sS \
+          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" \
+          | jq -r '.value')
+
+        if [ -z "$GITHUB_JWT" ] || [ "$GITHUB_JWT" = "null" ]; then
+          echo "::error::Failed to obtain a GitHub OIDC token."
+          exit 1
+        fi
+
+        # 2. Exchange it for short-lived AWS credentials. No third-party
+        #    Action involved - just the OIDC token and the AWS CLI, both
+        #    already present on the runner.
+        CREDS=$(aws sts assume-role-with-web-identity \
+          --role-arn "${{ inputs.role-arn }}" \
+          --role-session-name "${{ inputs.role-session-name }}" \
+          --web-identity-token "$GITHUB_JWT" \
+          --query 'Credentials' --output json)
+
+        AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r '.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r '.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r '.SessionToken')
+
+        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" = "null" ]; then
+          echo "::error::sts assume-role-with-web-identity did not return credentials."
+          exit 1
+        fi
+
+        echo "::add-mask::$AWS_ACCESS_KEY_ID"
+        echo "::add-mask::$AWS_SECRET_ACCESS_KEY"
+        echo "::add-mask::$AWS_SESSION_TOKEN"
+
+        {
+          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+          echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+          echo "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
+          echo "AWS_REGION=${{ inputs.aws-region }}"
+          echo "AWS_DEFAULT_REGION=${{ inputs.aws-region }}"
+        } >> "$GITHUB_ENV"
+
+        echo "::notice::Assumed AWS role ${{ inputs.role-arn }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,10 +140,14 @@ jobs:
         with:
           node-version: 20
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      - name: Assume AWS role via OIDC
+        # aws-actions/configure-aws-credentials isn't on segmentio/analytics-next's
+        # allowed-actions list (third-party, not enterprise-owned/GitHub-created) -
+        # this local composite action does the same OIDC token exchange by hand,
+        # mirroring the artifactory-oidc action above.
+        uses: ./.github/actions/aws-oidc-assume-role
         with:
-          role-to-assume: arn:aws:iam::812113486725:role/ajs-private-assets-upload
+          role-arn: arn:aws:iam::812113486725:role/ajs-private-assets-upload
           role-session-name: gha-analytics-next-cdn-deploy
           aws-region: us-west-2
       - run: yarn run -T browser release:cdn


### PR DESCRIPTION
## Summary

#1392 merged `deploy-cdn` using `aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c` (pinned to a full SHA), but that's still rejected by segmentio/analytics-next's allowed-actions policy: third-party actions must be enterprise-owned or created by GitHub, and being SHA-pinned doesn't exempt it from that.

Rather than wait on the allow-list to be expanded, this replaces it with a local composite action, `aws-oidc-assume-role`, that does the same GitHub OIDC -> `sts:AssumeRoleWithWebIdentity` exchange by hand via `curl` + the AWS CLI (both already on `ubuntu-latest-large`) - no third-party Action involved. This mirrors the `artifactory-oidc` action this repo already uses for the exact same class of problem on the Artifactory side.

## Test plan

- [ ] Confirm no `unrecognized action` / not-allowed error on this workflow file
- [ ] First real release trigger (next "Version Packages" merge, or a manual `workflow_dispatch`) exercises `deploy-cdn` end-to-end - this path has never run successfully yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)