### PR TITLE
fix: manual release runs should version pending changesets and always re-deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,9 +61,40 @@ jobs:
       - run: yarn scripts lint
       - run: yarn scripts test
 
+  build:
+    name: Build release artifacts
+    needs: [should-release, test]
+    if: needs.should-release.outputs.release == 'true'
+    runs-on: ubuntu-latest-large
+    permissions:
+      contents: read
+      id-token: write # Artifactory OIDC
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
+        with:
+          node-version: 20
+      - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
+      - run: yarn build --force
+      # publish (npm) and deploy-cdn need the exact same build - built once
+      # here and shared via artifact, rather than each job rebuilding
+      # independently (which cost double the build time and risked the two
+      # destinations ending up with subtly different bits).
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: release-build-${{ github.run_id }}
+          path: |
+            packages/*/dist
+            packages/consent/*/dist
+          retention-days: 1
+          if-no-files-found: error
+
   publish:
     name: Publish to npm
-    needs: [should-release, test]
+    needs: [should-release, build]
     if: needs.should-release.outputs.release == 'true'
     runs-on: ubuntu-latest-large
     environment: production # manual-approval gate before publish
@@ -89,12 +120,20 @@ jobs:
         with:
           node-version: 24
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: release-build-${{ github.run_id }}
+          path: .
       - name: Configure git for tag push
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - name: Publish packages + push tags
-        run: yarn release
+        # release:publish-only skips the clean+build the plain `release`
+        # script does - build already happened once in the build job above,
+        # and its output was just restored from the artifact.
+        run: yarn release:publish-only
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub releases from tags
@@ -104,7 +143,7 @@ jobs:
 
   deploy-cdn:
     name: Deploy to CDN
-    needs: [should-release, test, publish]
+    needs: [should-release, build]
     if: needs.should-release.outputs.release == 'true'
     runs-on: ubuntu-latest-large
     environment: production # same manual-approval gate as npm publish
@@ -140,6 +179,11 @@ jobs:
         with:
           node-version: 20
       - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: release-build-${{ github.run_id }}
+          path: .
       - name: Assume AWS role via OIDC
         # aws-actions/configure-aws-credentials isn't on segmentio/analytics-next's
         # allowed-actions list (third-party, not enterprise-owned/GitHub-created) -
@@ -150,4 +194,7 @@ jobs:
           role-arn: arn:aws:iam::812113486725:role/ajs-private-assets-upload
           role-session-name: gha-analytics-next-cdn-deploy
           aws-region: us-west-2
-      - run: yarn run -T browser release:cdn
+      # release:cdn:no-build skips the `yarn . build` the plain release:cdn
+      # script does - build already happened once in the build job above,
+      # and its output was just restored from the artifact.
+      - run: yarn run -T browser release:cdn:no-build

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "changeset": "changeset",
     "update-versions-and-changelogs": "changeset version && yarn version-run-all && bash scripts/update-lockfile.sh",
     "release": "yarn clean && yarn build --force && changeset publish && git push origin HEAD:master --follow-tags --no-verify && yarn scripts purge-cdn-cache",
+    "release:publish-only": "changeset publish && git push origin HEAD:master --follow-tags --no-verify && yarn scripts purge-cdn-cache",
     "version-run-all": "yarn workspaces foreach -vpt --no-private run version",
     "core": "yarn workspace @segment/analytics-core",
     "browser": "yarn workspace @segment/analytics-next",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,6 +35,7 @@
     "watch": "yarn concurrently 'WATCH=true yarn umd --watch' 'yarn pkg --watch'",
     "build": "yarn clean && yarn build-prep && yarn concurrently 'NODE_ENV=production yarn umd' 'yarn pkg' 'yarn cjs'",
     "release:cdn": "yarn . build && NODE_ENV=production bash scripts/release.sh && NODE_ENV=stage bash scripts/release.sh",
+    "release:cdn:no-build": "NODE_ENV=production bash scripts/release.sh && NODE_ENV=stage bash scripts/release.sh",
     "pkg": "yarn tsc -p tsconfig.build.json",
     "cjs": "yarn tsc -p tsconfig.build.json --outDir ./dist/cjs --module commonjs",
     "clean": "rm -rf dist",

--- a/scripts/create-release-from-tags/index.ts
+++ b/scripts/create-release-from-tags/index.ts
@@ -40,9 +40,10 @@ export const getConfig = async (): Promise<Config> => {
   const isDryRun = Boolean(DRY_RUN)
   const tags = TAGS ? parseRawTags(TAGS) : await getCurrentGitTags()
 
-  if (!tags.length) {
-    throw new Error('No git tags found.')
-  }
+  // No tags at HEAD is expected, not exceptional: a manual release run with
+  // no pending changesets publishes nothing new, so `changeset publish`
+  // correctly creates no tags. Let createReleaseFromTags no-op on this
+  // rather than treating it as a hard failure.
   return {
     isDryRun,
     tags,
@@ -256,6 +257,11 @@ const createGithubReleaseFromTag = async (
 }
 
 export const createReleaseFromTags = async (config: Config) => {
+  if (!config.tags.length) {
+    console.log('No git tags at HEAD - nothing new to release. Skipping.')
+    return
+  }
+
   console.log('Processing tags:', config.tags, '\n')
 
   for (const tag of config.tags) {


### PR DESCRIPTION
## Summary

Manually `workflow_dispatch`-ing this workflow to test `deploy-cdn` (against a non-release commit - no pending changeset, no version bump) surfaced `create-release-from-tags` throwing `No git tags found`, since `changeset publish` correctly produced zero new tags (nothing new to publish). That's an expected outcome for a no-op release run, not a failure - it now logs and returns instead of throwing.

`Deploy to CDN` never got a chance to run in that failed run, since it depends on `publish` succeeding - this fix is what actually lets `deploy-cdn` run on a manual dispatch that isn't a real version bump, so the current build gets re-uploaded to the CDN.

## What this PR does NOT do (reverted from an earlier version)

An earlier version of this PR also had a manual `workflow_dispatch` run version pending changesets directly and push a "Version Packages" commit straight to `master`, bypassing PR review. That was wrong: a release should be a read-only operation against a commit already on `master` - tag it, publish it to npm, cut a GitHub release, deploy it to the CDN - never a vehicle for landing new code (a version bump is a code change and belongs in a reviewed PR like every other change). That step has been removed.

The correct fix for "how does a new version actually get released" is making the normal, reviewed path work again: `release-creator.yml` opens a "Version Packages" PR for pending changesets, someone reviews and merges it, and *that* merge is the commit a release tags and publishes.

## Also: build once, share the artifact between npm publish and CDN deploy

`publish` and `deploy-cdn` each ran their own full build independently (`yarn build --force` inside `yarn release`, and `yarn . build` inside `release:cdn`) - double the build time, and no guarantee the two destinations ever got the exact same bits, since each build was a separate `yarn install` + compile on a separate runner.

Added a `build` job that runs once (after `test` passes), uploads `packages/*/dist` and `packages/consent/*/dist` as a single GitHub Actions artifact (`actions/upload-artifact`/`download-artifact` - both GitHub-owned, no allowed-actions issue). `publish` and `deploy-cdn` now both depend only on `build` (not on each other, so they run in parallel) and download that same artifact instead of rebuilding:

- `release:publish-only` (new script) is `release` minus the clean+build - just `changeset publish`, tag push, and CDN cache purge.
- `release:cdn:no-build` (new script, `packages/browser`) is `release:cdn` minus the `yarn . build` prefix.

Both now publish/deploy the exact same, single build the `build` job produced.

## Separately found, not fixed here

`release-creator.yml` (opens the "Version Packages" PR) has failed with `startup_failure` on every run since at least 2026-07-16 - 0 jobs run, consistent with a workflow-level rejection rather than a step failure. Strong suspicion: `changesets/action@a45c4d594` is a third-party action, likely hitting the same allowed-actions restriction fixed for `aws-actions/configure-aws-credentials` in #1393. Fixing that is the actual path to cutting new releases again - not addressed in this PR.

## Test plan

- [x] `scripts/create-release-from-tags/__tests__/index.test.ts` still passes
- [x] `tsc` clean repo-wide (pre-push hook, 14/14 packages)
- [ ] Manual `workflow_dispatch` run against current `master` (no pending version bump) completes `build`, `publish`, and `deploy-cdn` without error, with `publish`/`deploy-cdn` running in parallel and neither rebuilding

🤖 Generated with [Claude Code](https://claude.com/claude-code)