### PR TITLE
fix: anonymousId/userId cookies reverting to host-only scope

### DIFF
--- a/.changeset/anonymous-id-cross-subdomain.md
+++ b/.changeset/anonymous-id-cross-subdomain.md
@@ -1,0 +1,11 @@
+---
+"@segment/analytics-next": patch
+---
+
+Fix a couple of contributing causes of `anonymousId` (and `userId`) cookies intermittently reverting to a host-only scope instead of the shared, cross-subdomain domain -- part of the same underlying issue as #706.
+
+- `tld()` now memoizes the resolved top-level domain per hostname instead of re-probing cookies (a live set/get/remove round-trip) on every single `CookieStorage` instantiation. Multiple stores were being constructed per page load, so a single transient probe failure could leave some of them silently downgraded to a host-only cookie while others kept the shared, cross-subdomain one.
+- `tld()` now logs a `console.warn` when it falls back to a host-only cookie because the probe failed (as opposed to the expected `undefined` for `localhost`/IP hosts), instead of failing silently.
+- `CookieStorage.remove()` (and `.set(key, null)`) now also clears a possible host-only duplicate of the cookie, in addition to the one at the configured `domain`. Previously, a stray host-scoped cookie left behind by a past `tld()` failure could never be cleaned up, not even by `reset()`.
+
+No behavior changes here -- these only do anything in a scenario that was already broken.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,7 +46,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "29.8 KB"
+      "limit": "30.0 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/storage/__tests__/cookieStorage.test.ts
+++ b/packages/browser/src/core/storage/__tests__/cookieStorage.test.ts
@@ -55,4 +55,41 @@ describe('cookieStorage', () => {
       })
     })
   })
+
+  describe('remove', () => {
+    it('also clears a possible host-scoped duplicate when a domain is configured', () => {
+      const jarRemoveSpy = jest.spyOn(jar, 'remove')
+      const cookie = new CookieStorage({ domain: '.example.com', path: '/' })
+
+      cookie.remove('foo')
+
+      expect(jarRemoveSpy).toHaveBeenCalledWith('foo', {
+        sameSite: 'Lax',
+        expires: 365,
+        domain: '.example.com',
+        path: '/',
+        secure: undefined,
+      })
+      expect(jarRemoveSpy).toHaveBeenCalledWith('foo', { path: '/' })
+      expect(jarRemoveSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not attempt a second removal when there is no configured domain', () => {
+      const jarRemoveSpy = jest.spyOn(jar, 'remove')
+      const cookie = new CookieStorage({ domain: undefined, path: '/' })
+
+      cookie.remove('foo')
+
+      expect(jarRemoveSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('applies the same cleanup when setting a value to null', () => {
+      const jarRemoveSpy = jest.spyOn(jar, 'remove')
+      const cookie = new CookieStorage({ domain: '.example.com', path: '/' })
+
+      cookie.set('foo', null)
+
+      expect(jarRemoveSpy).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/browser/src/core/storage/cookieStorage.ts
+++ b/packages/browser/src/core/storage/cookieStorage.ts
@@ -81,10 +81,7 @@ export class CookieStorage<Data extends StorageObject = StorageObject>
   private removeCookie<K extends keyof Data>(key: K): void {
     jar.remove(key, this.opts())
 
-    // If a prior tld() resolution ever failed (e.g. transient cookie-jar pressure), a
-    // host-only duplicate of this cookie may have been written alongside the shared one --
-    // jar.remove() above only targets the currently-configured domain, so that duplicate would
-    // otherwise be permanently unreachable, even via reset(). Clear it too, just in case.
+    // also clears a possible host-only duplicate left by a past tld() failure, otherwise unreachable
     if (this.options.domain) {
       jar.remove(key, { path: this.options.path })
     }

--- a/packages/browser/src/core/storage/cookieStorage.ts
+++ b/packages/browser/src/core/storage/cookieStorage.ts
@@ -68,13 +68,25 @@ export class CookieStorage<Data extends StorageObject = StorageObject>
     if (typeof value === 'string') {
       jar.set(key, value, this.opts())
     } else if (value === null) {
-      jar.remove(key, this.opts())
+      this.removeCookie(key)
     } else {
       jar.set(key, JSON.stringify(value), this.opts())
     }
   }
 
   remove<K extends keyof Data>(key: K): void {
-    return jar.remove(key, this.opts())
+    this.removeCookie(key)
+  }
+
+  private removeCookie<K extends keyof Data>(key: K): void {
+    jar.remove(key, this.opts())
+
+    // If a prior tld() resolution ever failed (e.g. transient cookie-jar pressure), a
+    // host-only duplicate of this cookie may have been written alongside the shared one --
+    // jar.remove() above only targets the currently-configured domain, so that duplicate would
+    // otherwise be permanently unreachable, even via reset(). Clear it too, just in case.
+    if (this.options.domain) {
+      jar.remove(key, { path: this.options.path })
+    }
   }
 }

--- a/packages/browser/src/core/user/__tests__/tld.test.ts
+++ b/packages/browser/src/core/user/__tests__/tld.test.ts
@@ -33,4 +33,43 @@ describe('topDomain', function () {
     assert.strictEqual(tld('http://app.jut.io'), 'jut.io')
     assert.strictEqual(tld('http://app.segment.io'), 'segment.io')
   })
+
+  it('memoizes the resolved domain per hostname, instead of re-probing cookies every call', function () {
+    const setSpy = jest.spyOn(cookie, 'set')
+
+    assert.strictEqual(
+      tld('http://sub.memoize-example.com/path-a'),
+      'memoize-example.com'
+    )
+    const callsAfterFirst = setSpy.mock.calls.length
+
+    assert.strictEqual(
+      tld('http://sub.memoize-example.com/path-b'),
+      'memoize-example.com'
+    )
+    assert.strictEqual(setSpy.mock.calls.length, callsAfterFirst)
+  })
+
+  it('warns and does not throw when a domain cannot be resolved (e.g. sandboxed cookie access)', function () {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(cookie, 'set').mockImplementation(() => {
+      throw new Error('cookie access blocked')
+    })
+
+    assert.strictEqual(tld('http://app.blocked-example.com'), undefined)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('app.blocked-example.com')
+
+    warnSpy.mockRestore()
+  })
+
+  it('does not warn for localhost or IP hosts, since undefined is expected there', function () {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    tld('http://localhost:3000')
+    tld('http://192.168.0.1:3000')
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
 })

--- a/packages/browser/src/core/user/tld.ts
+++ b/packages/browser/src/core/user/tld.ts
@@ -39,11 +39,7 @@ function parseUrl(url: string): URL | undefined {
   }
 }
 
-// Resolving the tld requires a live set/get/remove cookie round-trip, and analytics-next
-// creates several CookieStorage instances per page load (identity + legacy stores, x2 for
-// Group). Caching by hostname means that dance only happens once per page, which removes a
-// source of intermittent, per-instance failures that could otherwise leave some stores sharing
-// the resolved domain and others silently falling back to a host-only cookie (see #706).
+// memoized per hostname, since resolving this is a live cookie round-trip per CookieStorage instance (see #706)
 const domainCache = new Map<string, string | undefined>()
 
 export function tld(url: string): string | undefined {
@@ -77,8 +73,7 @@ export function tld(url: string): string | undefined {
     }
   }
 
-  // lvls.length === 0 means this is an IP address or localhost -- an undefined domain there is
-  // expected, not a failure, so only warn when we actually attempted and failed to resolve one.
+  // only warn on a real failure to resolve; lvls.length === 0 (IP/localhost) is expected to be undefined
   if (domain === undefined && lvls.length > 0) {
     console.warn(
       `Unable to determine a top-level domain for "${hostname}". Falling back to a host-only cookie, which will not be shared across subdomains.`

--- a/packages/browser/src/core/user/tld.ts
+++ b/packages/browser/src/core/user/tld.ts
@@ -39,27 +39,52 @@ function parseUrl(url: string): URL | undefined {
   }
 }
 
+// Resolving the tld requires a live set/get/remove cookie round-trip, and analytics-next
+// creates several CookieStorage instances per page load (identity + legacy stores, x2 for
+// Group). Caching by hostname means that dance only happens once per page, which removes a
+// source of intermittent, per-instance failures that could otherwise leave some stores sharing
+// the resolved domain and others silently falling back to a host-only cookie (see #706).
+const domainCache = new Map<string, string | undefined>()
+
 export function tld(url: string): string | undefined {
   const parsedUrl = parseUrl(url)
   if (!parsedUrl) return
 
+  const hostname = parsedUrl.hostname
+  if (domainCache.has(hostname)) {
+    return domainCache.get(hostname)
+  }
+
   const lvls = levels(parsedUrl)
+  let domain: string | undefined
 
   // Lookup the real top level one.
   for (let i = 0; i < lvls.length; ++i) {
     const cname = '__tld__'
-    const domain = lvls[i]
-    const opts = { domain: '.' + domain }
+    const candidate = lvls[i]
+    const opts = { domain: '.' + candidate }
 
     try {
       // cookie access throw an error if the library is ran inside a sandboxed environment (e.g. sandboxed iframe)
       cookie.set(cname, '1', opts)
       if (cookie.get(cname)) {
         cookie.remove(cname, opts)
-        return domain
+        domain = candidate
+        break
       }
     } catch (_) {
-      return
+      break
     }
   }
+
+  // lvls.length === 0 means this is an IP address or localhost -- an undefined domain there is
+  // expected, not a failure, so only warn when we actually attempted and failed to resolve one.
+  if (domain === undefined && lvls.length > 0) {
+    console.warn(
+      `Unable to determine a top-level domain for "${hostname}". Falling back to a host-only cookie, which will not be shared across subdomains.`
+    )
+  }
+
+  domainCache.set(hostname, domain)
+  return domain
 }


### PR DESCRIPTION
## Summary

Part of investigating a support ticket where a customer's `anonymousId` intermittently changed when moving between subdomains of the same site, with no `reset()` call involved. That's the same underlying issue as #706 (open since 2023). This PR addresses one contributing cause; a separate, more invasive fix for the actual store-reconciliation behavior is split into #1398 for independent review.

`tld()` resolves the shared, cross-subdomain cookie domain via a live cookie set/get/remove round-trip, and analytics-next constructs multiple `CookieStorage` instances per page load (identity + legacy stores, x2 for `Group`). Each one was re-running that probe from scratch, so a single transient failure (extension interference, cookie-jar pressure, timing) could silently downgrade just *that* instance to a host-only cookie while the others kept the shared, cross-subdomain one -- a plausible source of the "intermittent, hard to reproduce" nature of these reports.

- **`tld()` now memoizes the resolved domain per hostname**, so the probe only runs once per page load instead of once per store instance.
- **`tld()` now warns** instead of silently falling back to a host-only cookie when the probe genuinely fails (as opposed to the expected `undefined` for `localhost`/IP hosts). This failure mode was previously invisible.
- **`CookieStorage.remove()` / `.set(key, null)` now also clear a possible host-only duplicate.** If a `tld()` failure ever did leave a stray host-scoped cookie behind, nothing -- not even `reset()` -- could clean it up, since removal only ever targeted the currently-configured domain.

No behavior change on any currently-working path -- these only do anything in a scenario that was already broken. This alone reduces how often the underlying divergence occurs, but doesn't resync stores that have already diverged for other reasons (cookie eviction, a consent tool clearing cookies pre-consent, etc.) -- that's what #1398 adds.

## Test plan

- [x] Added unit tests for `tld()` memoization and the new warning (`packages/browser/src/core/user/__tests__/tld.test.ts`)
- [x] Added unit tests for the `CookieStorage` cleanup fallback (`packages/browser/src/core/storage/__tests__/cookieStorage.test.ts`)
- [x] Full `packages/browser` test suite passes (847 passed, 4 pre-existing skips)
- [x] `tsc --noEmit` and `eslint` clean on all touched files