### PR TITLE
fix: anonymousId does not resync once localStorage and the shared cookie disagree

### DIFF
--- a/.changeset/anonymous-id-store-reconciliation.md
+++ b/.changeset/anonymous-id-store-reconciliation.md
@@ -1,0 +1,7 @@
+---
+"@segment/analytics-next": patch
+---
+
+**Behavior change:** added `UniversalStorage#getConsistent`, now used for reading/writing `anonymousId`. If the underlying stores disagree on the value (e.g. a per-origin `localStorage` entry has drifted from the shared, cross-subdomain cookie -- see #706), the cookie's value now wins and every store is resynced to it, rather than whichever store happens to sit first in priority order winning permanently with no way to resync.
+
+When all stores already agree (the common case), this returns the exact same value as before -- this only changes behavior in the already-broken case where stores disagree. If you have custom `storage.stores` configuration that intentionally keeps `localStorage` and cookies out of sync across origins, this removes that ability for `anonymousId` specifically.

--- a/.changeset/anonymous-id-store-reconciliation.md
+++ b/.changeset/anonymous-id-store-reconciliation.md
@@ -2,6 +2,8 @@
 "@segment/analytics-next": patch
 ---
 
-**Behavior change:** added `UniversalStorage#getConsistent`, now used for reading/writing `anonymousId`. If the underlying stores disagree on the value (e.g. a per-origin `localStorage` entry has drifted from the shared, cross-subdomain cookie -- see #706), the cookie's value now wins and every store is resynced to it, rather than whichever store happens to sit first in priority order winning permanently with no way to resync.
+Added an opt-in `resolveAnonymousIdConflicts` option (`user: { resolveAnonymousIdConflicts: true }` in load options), off by default, that fixes `anonymousId` diverging between subdomains of the same site (see #706).
 
-When all stores already agree (the common case), this returns the exact same value as before -- this only changes behavior in the already-broken case where stores disagree. If you have custom `storage.stores` configuration that intentionally keeps `localStorage` and cookies out of sync across origins, this removes that ability for `anonymousId` specifically.
+`localStorage` is per-origin, but sits ahead of the shared, cross-subdomain cookie in the default store priority. Once the two disagree -- e.g. a per-origin `localStorage` entry drifts from the shared cookie -- whichever store sits first in priority order wins permanently, with no way for the two to resync. With this option enabled, the cookie's value wins a disagreement instead, and every store is resynced to it.
+
+This ships off by default: with it disabled (the default), behavior is unchanged. Enabling it only changes behavior in the already-broken case where stores disagree; when they already agree, it returns the exact same value as before.

--- a/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
+++ b/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
@@ -1,0 +1,171 @@
+import { test, expect, Page } from '@playwright/test'
+import { CDNSettingsBuilder } from '@internal/test-helpers'
+import { standaloneMock } from './helpers/standalone-mock'
+
+// Same minimal AJS 1.0-style loader snippet as ./standalone.html, inlined so it can be served
+// from two different (mocked) same-site origins without needing new static fixture files.
+const SNIPPET_HTML = `<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      !(function () {
+        var analytics = (window.analytics = window.analytics || [])
+        if (!analytics.initialize) {
+          if (analytics.invoked) {
+            window.console && console.error && console.error('Segment snippet included twice.')
+          } else {
+            analytics.invoked = !0
+            analytics.methods = ['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','reset','group','track','ready','alias','debug','page','once','off','on','addSourceMiddleware','addIntegrationMiddleware','setAnonymousId','addDestinationMiddleware']
+            analytics.factory = function (e) {
+              return function () {
+                var t = Array.prototype.slice.call(arguments)
+                t.unshift(e)
+                analytics.push(t)
+                return analytics
+              }
+            }
+            for (var e = 0; e < analytics.methods.length; e++) {
+              var key = analytics.methods[e]
+              analytics[key] = analytics.factory(key)
+            }
+            analytics.load = function (key, e) {
+              var t = document.createElement('script')
+              t.type = 'text/javascript'
+              t.async = !0
+              t.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js'
+              var n = document.getElementsByTagName('script')[0]
+              n.parentNode.insertBefore(t, n)
+              analytics._loadOptions = e
+              analytics._writeKey = key
+            }
+            analytics.SNIPPET_VERSION = '4.15.3'
+          }
+        }
+      })()
+    </script>
+  </head>
+  <body></body>
+</html>`
+
+const PARENT_DOMAIN = 'ajs-repro.test'
+const SUBDOMAIN_A = `http://a.${PARENT_DOMAIN}/`
+const SUBDOMAIN_B = `http://b.${PARENT_DOMAIN}/`
+
+const getAnonymousId = () => window.analytics.user().anonymousId() as string
+
+async function loadAnalytics(page: Page, resolveAnonymousIdConflicts: boolean) {
+  await page.evaluate((resolveAnonymousIdConflicts) => {
+    window.analytics.load('fake-key', {
+      cookie: { domain: '.ajs-repro.test' },
+      user: { resolveAnonymousIdConflicts },
+    })
+  }, resolveAnonymousIdConflicts)
+  await page.waitForFunction(() => window.analytics.initialized)
+}
+
+test.describe(
+  'anonymousId sync across subdomains (segmentio/analytics-next#706)',
+  () => {
+    test.beforeEach(standaloneMock)
+
+    test.beforeEach(async ({ context }) => {
+      await context.route(`${SUBDOMAIN_A}**`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: SNIPPET_HTML,
+        })
+      )
+      await context.route(`${SUBDOMAIN_B}**`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: SNIPPET_HTML,
+        })
+      )
+      await context.route(
+        'https://cdn.segment.com/v1/projects/*/settings',
+        (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(
+              new CDNSettingsBuilder({ writeKey: 'fake-key' }).build()
+            ),
+          })
+      )
+      await context.route('https://api.segment.io/v1/*', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: '{}',
+        })
+      )
+    })
+
+    // reproduces the #706 sequence: a user clears cookies + site data on subdomain A only,
+    // leaving subdomain B's localStorage stale -- the two subdomains disagree from then on.
+    async function reproduceDivergence(
+      context: import('@playwright/test').BrowserContext,
+      resolveAnonymousIdConflicts: boolean
+    ) {
+      const pageA = await context.newPage()
+      await pageA.goto(SUBDOMAIN_A)
+      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      const original = await pageA.evaluate(getAnonymousId)
+
+      const pageB = await context.newPage()
+      await pageB.goto(SUBDOMAIN_B)
+      await loadAnalytics(pageB, resolveAnonymousIdConflicts)
+      // sanity check: B picked up the same id via the shared cookie before anything diverges
+      expect(await pageB.evaluate(getAnonymousId)).toEqual(original)
+
+      // user clears cookies + site data for subdomain A: wipes the shared cookie and A's own
+      // localStorage, but B's localStorage (a different origin) is untouched.
+      await context.clearCookies()
+      await pageA.evaluate(() => localStorage.clear())
+      await pageA.reload()
+      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      const freshId = await pageA.evaluate(getAnonymousId)
+      expect(freshId).not.toEqual(original)
+
+      // B still has the stale pre-clear id in its own localStorage
+      await pageB.reload()
+      await loadAnalytics(pageB, resolveAnonymousIdConflicts)
+      const idB = await pageB.evaluate(getAnonymousId)
+
+      // back to A again, after B's read above may have overwritten the shared cookie
+      await pageA.reload()
+      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      const idA = await pageA.evaluate(getAnonymousId)
+
+      return { pageA, pageB, idA, idB, freshId, original }
+    }
+
+    test('without resolveAnonymousIdConflicts (default): subdomains stay diverged', async ({
+      context,
+    }) => {
+      const { idA, idB } = await reproduceDivergence(context, false)
+      expect(idA).not.toEqual(idB)
+    })
+
+    test('with resolveAnonymousIdConflicts: subdomains converge and stay converged', async ({
+      context,
+    }) => {
+      const { pageA, pageB, idA, idB } = await reproduceDivergence(
+        context,
+        true
+      )
+      expect(idA).toEqual(idB)
+
+      // stays converged on further navigation, doesn't start ping-ponging again
+      await pageB.reload()
+      await loadAnalytics(pageB, true)
+      expect(await pageB.evaluate(getAnonymousId)).toEqual(idA)
+
+      await pageA.reload()
+      await loadAnalytics(pageA, true)
+      expect(await pageA.evaluate(getAnonymousId)).toEqual(idA)
+    })
+  }
+)

--- a/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
+++ b/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
@@ -1,51 +1,10 @@
+import { join as joinPath } from 'path'
 import { test, expect, Page } from '@playwright/test'
 import { CDNSettingsBuilder } from '@internal/test-helpers'
 import { standaloneMock } from './helpers/standalone-mock'
 
-// Same minimal AJS 1.0-style loader snippet as ./standalone.html, inlined so it can be served
-// from two different (mocked) same-site origins without needing new static fixture files.
-const SNIPPET_HTML = `<!DOCTYPE html>
-<html>
-  <head>
-    <script>
-      !(function () {
-        var analytics = (window.analytics = window.analytics || [])
-        if (!analytics.initialize) {
-          if (analytics.invoked) {
-            window.console && console.error && console.error('Segment snippet included twice.')
-          } else {
-            analytics.invoked = !0
-            analytics.methods = ['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','reset','group','track','ready','alias','debug','page','once','off','on','addSourceMiddleware','addIntegrationMiddleware','setAnonymousId','addDestinationMiddleware']
-            analytics.factory = function (e) {
-              return function () {
-                var t = Array.prototype.slice.call(arguments)
-                t.unshift(e)
-                analytics.push(t)
-                return analytics
-              }
-            }
-            for (var e = 0; e < analytics.methods.length; e++) {
-              var key = analytics.methods[e]
-              analytics[key] = analytics.factory(key)
-            }
-            analytics.load = function (key, e) {
-              var t = document.createElement('script')
-              t.type = 'text/javascript'
-              t.async = !0
-              t.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js'
-              var n = document.getElementsByTagName('script')[0]
-              n.parentNode.insertBefore(t, n)
-              analytics._loadOptions = e
-              analytics._writeKey = key
-            }
-            analytics.SNIPPET_VERSION = '4.15.3'
-          }
-        }
-      })()
-    </script>
-  </head>
-  <body></body>
-</html>`
+// same fixture the other tests load via page.goto('/standalone.html'), served directly since these fake subdomains aren't behind the real http-server
+const STANDALONE_HTML_PATH = joinPath(__dirname, '..', 'standalone.html')
 
 const PARENT_DOMAIN = 'ajs-repro.test'
 const SUBDOMAIN_A = `http://a.${PARENT_DOMAIN}/`
@@ -70,18 +29,10 @@ test.describe(
 
     test.beforeEach(async ({ context }) => {
       await context.route(`${SUBDOMAIN_A}**`, (route) =>
-        route.fulfill({
-          status: 200,
-          contentType: 'text/html',
-          body: SNIPPET_HTML,
-        })
+        route.fulfill({ status: 200, path: STANDALONE_HTML_PATH })
       )
       await context.route(`${SUBDOMAIN_B}**`, (route) =>
-        route.fulfill({
-          status: 200,
-          contentType: 'text/html',
-          body: SNIPPET_HTML,
-        })
+        route.fulfill({ status: 200, path: STANDALONE_HTML_PATH })
       )
       await context.route(
         'https://cdn.segment.com/v1/projects/*/settings',

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,7 +46,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "30.0 KB"
+      "limit": "30.1 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,7 +46,7 @@
   "size-limit": [
     {
       "path": "dist/umd/index.js",
-      "limit": "29.8 KB"
+      "limit": "30.0 KB"
     }
   ],
   "dependencies": {

--- a/packages/browser/src/core/storage/__tests__/universalStorage.test.ts
+++ b/packages/browser/src/core/storage/__tests__/universalStorage.test.ts
@@ -72,6 +72,50 @@ describe('UniversalStorage', function () {
     })
   })
 
+  describe('#getConsistent', function () {
+    it('returns the same value as get when stores agree', function () {
+      jar.set('ajs_test_key', 'match')
+      localStorage.setItem('ajs_test_key', 'match')
+      const us = new UniversalStorage([
+        new LocalStorage(),
+        new CookieStorage(),
+        new MemoryStorage(),
+      ])
+      expect(us.getConsistent('ajs_test_key')).toEqual('match')
+    })
+
+    it('prefers the cookie value over an earlier-priority store when they disagree', function () {
+      jar.set('ajs_test_key', 'from-cookie')
+      localStorage.setItem('ajs_test_key', 'from-local-storage')
+      const us = new UniversalStorage([
+        new LocalStorage(),
+        new CookieStorage(),
+        new MemoryStorage(),
+      ])
+
+      expect(us.getConsistent('ajs_test_key')).toEqual('from-cookie')
+    })
+
+    it('self-heals the losing store to match the cookie', function () {
+      jar.set('ajs_test_key', 'from-cookie')
+      localStorage.setItem('ajs_test_key', 'from-local-storage')
+      const us = new UniversalStorage([
+        new LocalStorage(),
+        new CookieStorage(),
+        new MemoryStorage(),
+      ])
+
+      us.getConsistent('ajs_test_key')
+      expect(getFromLS('ajs_test_key')).toEqual('from-cookie')
+    })
+
+    it('falls back to normal priority order when no cookie store is present', function () {
+      localStorage.setItem('ajs_test_key', 'from-local-storage')
+      const us = new UniversalStorage([new LocalStorage(), new MemoryStorage()])
+      expect(us.getConsistent('ajs_test_key')).toEqual('from-local-storage')
+    })
+  })
+
   describe('#set', function () {
     it('sets the data in all storage types', function () {
       const us = new UniversalStorage<{ ajs_test_key: string }>(defaultTargets)

--- a/packages/browser/src/core/storage/__tests__/universalStorage.test.ts
+++ b/packages/browser/src/core/storage/__tests__/universalStorage.test.ts
@@ -114,6 +114,30 @@ describe('UniversalStorage', function () {
       const us = new UniversalStorage([new LocalStorage(), new MemoryStorage()])
       expect(us.getConsistent('ajs_test_key')).toEqual('from-local-storage')
     })
+
+    it('does not let an empty-string cookie (blanked out, not deleted) clobber a real value', function () {
+      jar.set('ajs_test_key', '')
+      localStorage.setItem('ajs_test_key', 'from-local-storage')
+      const us = new UniversalStorage([
+        new LocalStorage(),
+        new CookieStorage(),
+        new MemoryStorage(),
+      ])
+
+      expect(us.getConsistent('ajs_test_key')).toEqual('from-local-storage')
+      expect(getFromLS('ajs_test_key')).toEqual('from-local-storage')
+    })
+
+    it('treats an empty-string value as absent even when it is the only value present', function () {
+      jar.set('ajs_test_key', '')
+      const us = new UniversalStorage([
+        new LocalStorage(),
+        new CookieStorage(),
+        new MemoryStorage(),
+      ])
+
+      expect(us.getConsistent('ajs_test_key')).toBeNull()
+    })
   })
 
   describe('#set', function () {

--- a/packages/browser/src/core/storage/universalStorage.ts
+++ b/packages/browser/src/core/storage/universalStorage.ts
@@ -77,6 +77,18 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     return coercedValue
   }
 
+  private safeGet<K extends keyof Data>(
+    store: Store,
+    key: K
+  ): Data[K] | null | undefined {
+    try {
+      return store.get(key) as Data[K] | null
+    } catch (e) {
+      _logStoreKeyError(store, 'get', key, e)
+      return undefined
+    }
+  }
+
   /*
     Like getAndSync, but for stores that are expected to be kept in sync across origins (e.g.
     a cookie shared cross-subdomain via its `domain` attribute vs. a per-origin localStorage
@@ -87,38 +99,18 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     no disagreement, this returns the exact same value getAndSync would.
   */
   getConsistent<K extends keyof Data>(key: K): Data[K] | null {
-    let winner: Data[K] | null = null
-    let winnerIsCookie = false
+    // an empty string is treated the same as no value: a cookie that was blanked out rather
+    // than deleted (e.g. `document.cookie = 'ajs_anonymous_id=;path=/'` with no expiry, which
+    // some third-party consent scripts do) should not be able to win a disagreement and wipe
+    // out a real id in another store.
+    const present = this.stores
+      .map((store) => ({ store, val: this.safeGet<K>(store, key) }))
+      .filter(({ val }) => val !== undefined && val !== null && val !== '')
 
-    for (const store of this.stores) {
-      let val: Data[K] | null
-      try {
-        val = store.get(key) as Data[K] | null
-      } catch (e) {
-        _logStoreKeyError(store, 'get', key, e)
-        continue
-      }
-
-      // an empty string is treated the same as no value: a cookie that was blanked out rather
-      // than deleted (e.g. `document.cookie = 'ajs_anonymous_id=;path=/'` with no expiry, which
-      // some third-party consent scripts do) should not be able to win a disagreement and wipe
-      // out a real id in another store.
-      if (val === undefined || val === null || val === '') {
-        continue
-      }
-
-      if (winner === null) {
-        winner = val
-        winnerIsCookie = store instanceof CookieStorage
-      } else if (
-        !winnerIsCookie &&
-        store instanceof CookieStorage &&
-        val !== winner
-      ) {
-        winner = val
-        winnerIsCookie = true
-      }
-    }
+    const winner =
+      present.find(({ store }) => store instanceof CookieStorage)?.val ??
+      present[0]?.val ??
+      null
 
     // legacy behavior, matches getAndSync: can change the type of a value from number to string
     // (AJS 1.0 stores numerical values as a number)

--- a/packages/browser/src/core/storage/universalStorage.ts
+++ b/packages/browser/src/core/storage/universalStorage.ts
@@ -99,7 +99,11 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
         continue
       }
 
-      if (val === undefined || val === null) {
+      // an empty string is treated the same as no value: a cookie that was blanked out rather
+      // than deleted (e.g. `document.cookie = 'ajs_anonymous_id=;path=/'` with no expiry, which
+      // some third-party consent scripts do) should not be able to win a disagreement and wipe
+      // out a real id in another store.
+      if (val === undefined || val === null || val === '') {
         continue
       }
 

--- a/packages/browser/src/core/storage/universalStorage.ts
+++ b/packages/browser/src/core/storage/universalStorage.ts
@@ -89,20 +89,9 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     }
   }
 
-  /*
-    Like getAndSync, but for stores that are expected to be kept in sync across origins (e.g.
-    a cookie shared cross-subdomain via its `domain` attribute vs. a per-origin localStorage
-    entry). If the stores disagree, a CookieStorage value wins over the rest, since a shared
-    cookie is the only store here that can actually carry a value across subdomains -- a
-    per-origin store that outranks it in priority order would otherwise win the disagreement
-    forever, with no way for the two to ever resync (segmentio/analytics-next#706). When there's
-    no disagreement, this returns the exact same value getAndSync would.
-  */
+  // like getAndSync, but a CookieStorage value wins a disagreement, since only it can carry a value across subdomains (see #706)
   getConsistent<K extends keyof Data>(key: K): Data[K] | null {
-    // an empty string is treated the same as no value: a cookie that was blanked out rather
-    // than deleted (e.g. `document.cookie = 'ajs_anonymous_id=;path=/'` with no expiry, which
-    // some third-party consent scripts do) should not be able to win a disagreement and wipe
-    // out a real id in another store.
+    // an empty string counts as absent too, so a blanked-but-not-deleted cookie can't win
     const present = this.stores
       .map((store) => ({ store, val: this.safeGet<K>(store, key) }))
       .filter(({ val }) => val !== undefined && val !== null && val !== '')
@@ -112,8 +101,7 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
       present[0]?.val ??
       null
 
-    // legacy behavior, matches getAndSync: can change the type of a value from number to string
-    // (AJS 1.0 stores numerical values as a number)
+    // legacy behavior, matches getAndSync: coerces AJS 1.0's numeric values to a string
     const coercedValue = (
       typeof winner === 'number' ? winner.toString() : winner
     ) as Data[K] | null

--- a/packages/browser/src/core/storage/universalStorage.ts
+++ b/packages/browser/src/core/storage/universalStorage.ts
@@ -1,4 +1,5 @@
 import { Store, StorageObject } from './types'
+import { CookieStorage } from './cookieStorage'
 
 // not adding to private method because those method names do not get minified atm, and does not use 'this'
 const _logStoreKeyError = (
@@ -70,6 +71,56 @@ export class UniversalStorage<Data extends StorageObject = StorageObject> {
     const coercedValue = (typeof val === 'number' ? val.toString() : val) as
       | Data[K]
       | null
+
+    this.set(key, coercedValue)
+
+    return coercedValue
+  }
+
+  /*
+    Like getAndSync, but for stores that are expected to be kept in sync across origins (e.g.
+    a cookie shared cross-subdomain via its `domain` attribute vs. a per-origin localStorage
+    entry). If the stores disagree, a CookieStorage value wins over the rest, since a shared
+    cookie is the only store here that can actually carry a value across subdomains -- a
+    per-origin store that outranks it in priority order would otherwise win the disagreement
+    forever, with no way for the two to ever resync (segmentio/analytics-next#706). When there's
+    no disagreement, this returns the exact same value getAndSync would.
+  */
+  getConsistent<K extends keyof Data>(key: K): Data[K] | null {
+    let winner: Data[K] | null = null
+    let winnerIsCookie = false
+
+    for (const store of this.stores) {
+      let val: Data[K] | null
+      try {
+        val = store.get(key) as Data[K] | null
+      } catch (e) {
+        _logStoreKeyError(store, 'get', key, e)
+        continue
+      }
+
+      if (val === undefined || val === null) {
+        continue
+      }
+
+      if (winner === null) {
+        winner = val
+        winnerIsCookie = store instanceof CookieStorage
+      } else if (
+        !winnerIsCookie &&
+        store instanceof CookieStorage &&
+        val !== winner
+      ) {
+        winner = val
+        winnerIsCookie = true
+      }
+    }
+
+    // legacy behavior, matches getAndSync: can change the type of a value from number to string
+    // (AJS 1.0 stores numerical values as a number)
+    const coercedValue = (
+      typeof winner === 'number' ? winner.toString() : winner
+    ) as Data[K] | null
 
     this.set(key, coercedValue)
 

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -79,9 +79,7 @@ describe('user', () => {
     })
 
     it('should prefer the cookie over a diverged localStorage value, and resync localStorage to match', () => {
-      // simulates the scenario in segmentio/analytics-next#706: localStorage (per-origin) and
-      // the cookie (shared cross-subdomain) have drifted apart, e.g. because localStorage was
-      // cleared on this origin only while the shared cookie survived.
+      // reproduces #706: localStorage (per-origin) has drifted from the shared cookie
       jar.set('ajs_anonymous_id', 'from-cookie')
       localStorage.setItem(
         'ajs_anonymous_id',

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -78,8 +78,7 @@ describe('user', () => {
       expect(new User().anonymousId()).toEqual('anonymous')
     })
 
-    it('should prefer the cookie over a diverged localStorage value, and resync localStorage to match', () => {
-      // reproduces #706: localStorage (per-origin) has drifted from the shared cookie
+    it('keeps the diverged localStorage value by default (resolveAnonymousIdConflicts opt-in is off)', () => {
       jar.set('ajs_anonymous_id', 'from-cookie')
       localStorage.setItem(
         'ajs_anonymous_id',
@@ -87,6 +86,18 @@ describe('user', () => {
       )
 
       const user = new User()
+      expect(user.anonymousId()).toEqual('from-local-storage')
+    })
+
+    it('with resolveAnonymousIdConflicts: prefers the cookie over a diverged localStorage value, and resyncs localStorage to match', () => {
+      // reproduces #706: localStorage (per-origin) has drifted from the shared cookie
+      jar.set('ajs_anonymous_id', 'from-cookie')
+      localStorage.setItem(
+        'ajs_anonymous_id',
+        JSON.stringify('from-local-storage')
+      )
+
+      const user = new User({ resolveAnonymousIdConflicts: true })
       expect(user.anonymousId()).toEqual('from-cookie')
       expect(localStorage.getItem('ajs_anonymous_id')).toEqual(
         JSON.stringify('from-cookie')

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -77,6 +77,23 @@ describe('user', () => {
       jar.set('ajs_anonymous_id', 'anonymous')
       expect(new User().anonymousId()).toEqual('anonymous')
     })
+
+    it('should prefer the cookie over a diverged localStorage value, and resync localStorage to match', () => {
+      // simulates the scenario in segmentio/analytics-next#706: localStorage (per-origin) and
+      // the cookie (shared cross-subdomain) have drifted apart, e.g. because localStorage was
+      // cleared on this origin only while the shared cookie survived.
+      jar.set('ajs_anonymous_id', 'from-cookie')
+      localStorage.setItem(
+        'ajs_anonymous_id',
+        JSON.stringify('from-local-storage')
+      )
+
+      const user = new User()
+      expect(user.anonymousId()).toEqual('from-cookie')
+      expect(localStorage.getItem('ajs_anonymous_id')).toEqual(
+        JSON.stringify('from-cookie')
+      )
+    })
   })
 
   describe('#id', () => {

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -151,7 +151,7 @@ export class User implements WithId {
 
     if (id === undefined) {
       const val =
-        this.identityStore.getAndSync(this.anonKey) ?? this.legacySIO()?.[0]
+        this.identityStore.getConsistent(this.anonKey) ?? this.legacySIO()?.[0]
 
       if (val) {
         return val
@@ -160,11 +160,11 @@ export class User implements WithId {
 
     if (id === null) {
       this.identityStore.set(this.anonKey, null)
-      return this.identityStore.getAndSync(this.anonKey)
+      return this.identityStore.getConsistent(this.anonKey)
     }
 
     this.identityStore.set(this.anonKey, id ?? uuid())
-    return this.identityStore.getAndSync(this.anonKey)
+    return this.identityStore.getConsistent(this.anonKey)
   }
 
   traits = (traits?: Traits | null): Traits | undefined => {

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -37,6 +37,11 @@ export interface UserOptions {
    * @example stores: [StoreType.Cookie, StoreType.Memory]
    */
   storage?: StorageSettings
+
+  /**
+   * Opt-in fix for anonymousId diverging between subdomains (see segmentio/analytics-next#706): when the cookie and localStorage disagree, prefer the cookie and resync localStorage to it, instead of localStorage's value winning permanently. Defaults to false.
+   */
+  resolveAnonymousIdConflicts?: boolean
 }
 
 const defaults = {
@@ -144,14 +149,19 @@ export class User implements WithId {
     return [anon, user]
   }
 
+  private readAnonymousId(): ID {
+    return this.options.resolveAnonymousIdConflicts
+      ? this.identityStore.getConsistent(this.anonKey)
+      : this.identityStore.getAndSync(this.anonKey)
+  }
+
   anonymousId = (id?: ID): ID => {
     if (this.options.disable) {
       return null
     }
 
     if (id === undefined) {
-      const val =
-        this.identityStore.getConsistent(this.anonKey) ?? this.legacySIO()?.[0]
+      const val = this.readAnonymousId() ?? this.legacySIO()?.[0]
 
       if (val) {
         return val
@@ -160,11 +170,11 @@ export class User implements WithId {
 
     if (id === null) {
       this.identityStore.set(this.anonKey, null)
-      return this.identityStore.getConsistent(this.anonKey)
+      return this.readAnonymousId()
     }
 
     this.identityStore.set(this.anonKey, id ?? uuid())
-    return this.identityStore.getConsistent(this.anonKey)
+    return this.readAnonymousId()
   }
 
   traits = (traits?: Traits | null): Traits | undefined => {


### PR DESCRIPTION
## Summary

Split out from #1397, which addresses one source of the underlying `anonymousId`/`userId` cross-subdomain divergence issue (see #706). This PR addresses the actual store-reconciliation gap.

`localStorage` is per-origin, but sits ahead of the shared, cross-subdomain cookie in the default store priority (`[localStorage, cookie, memory]`). Once the two disagree -- for *any* reason (cookie eviction, a consent tool clearing cookies pre-consent, a past `tld()` failure, a user clearing cookies/site data on just one subdomain, etc.) -- whichever value is in `localStorage` wins forever on that origin, with no way for it to resync to the cookie. Each origin can then end up parroting a different `anonymousId` back into the shared cookie, causing it to visibly ping-pong between subdomains.

- Added **`UniversalStorage#getConsistent`**: when the underlying stores disagree, the cookie's value wins and every store is resynced to it, instead of the divergence persisting indefinitely. When stores already agree (the common case), this returns the exact same value `getAndSync` would.
- An empty string is treated the same as no value, so a cookie that was blanked out rather than deleted (e.g. a third-party script running `document.cookie = 'ajs_anonymous_id=;path=/'` with no expiry) can't win a disagreement and wipe out a real id elsewhere.
- **Gated behind a new opt-in `resolveAnonymousIdConflicts` option** (`user: { resolveAnonymousIdConflicts: true }` in load options), **off by default**. `anonymousId()` only switches from `getAndSync` to `getConsistent` when it's enabled. This ships in a release without changing anyone's behavior; it can be staged in with specific customers/accounts before considering flipping the default in a later release. (There's no infra-level staged-rollout mechanism in this repo to hook into for a true percentage rollout -- this opt-in flag is the equivalent we can offer at the application-config level.)

### A deterministic reproduction (from #706's own report)

The original reporter on #706 already described a concrete, deterministic trigger, independent of any probe flakiness:

1. User is on subdomain A. They clear cookies + site data for that origin. This deletes the **shared** cookie entirely (its `Domain` covers both subdomains, so it's visible/clearable from A) and subdomain A's **own** localStorage entry (localStorage is origin-scoped, so this doesn't touch B).
2. Subdomain B was never visited during this -- its localStorage still holds the old id, untouched.
3. Back on A: both localStorage(A) and the cookie are empty, so a fresh id (`NEW`) is generated and written to both.
4. User navigates to B: localStorage(B) still has the old id (`OLD`), the cookie now has `NEW`. localStorage outranks the cookie in priority order, so B returns `OLD` -- and `getAndSync` writes that back to *every* store, overwriting the shared cookie with `OLD`.
5. User navigates back to A: localStorage(A) has `NEW`, the cookie now has `OLD` (just clobbered in step 4) -- A's localStorage wins, returns `NEW`, overwrites the cookie back to `NEW`.

Steps 4-5 repeat indefinitely -- exactly the reporter's "the cookie value for the TLD seemingly switching between these values as you navigate between the pages," with no probe failure or flakiness required.

With `resolveAnonymousIdConflicts` enabled: the next visit to either subdomain reads both stores, sees they disagree, and takes the cookie's value -- resyncing the losing localStorage entry to match. Both subdomains converge on the same id after one round trip and stay converged; the ping-pong stops for good, regardless of which id happened to win.

## Test plan

- [x] Added unit tests for `UniversalStorage#getConsistent`, including the empty-string edge case (`packages/browser/src/core/storage/__tests__/universalStorage.test.ts`)
- [x] Added `User` tests confirming the flag defaults off (unchanged behavior) and confirming the reported drift scenario self-heals when enabled (`packages/browser/src/core/user/__tests__/index.test.ts`)
- [x] Added a Playwright e2e test reproducing the exact #706 sequence across two real (mocked) same-site subdomains, confirming both the bug (without the flag) and the fix (with it) (`packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts`)
- [x] Full `packages/browser` test suite passes
- [x] `tsc --noEmit` and `eslint` clean on all touched files
