### PR TITLE
Version Packages

### DIFF
--- a/.changeset/anonymous-id-store-reconciliation.md
+++ b/.changeset/anonymous-id-store-reconciliation.md
@@ -1,9 +1,0 @@
----
-"@segment/analytics-next": patch
----
-
-Added an opt-in `resolveAnonymousIdConflicts` option (`user: { resolveAnonymousIdConflicts: true }` in load options), off by default, that fixes `anonymousId` diverging between subdomains of the same site (see #706).
-
-`localStorage` is per-origin, but sits ahead of the shared, cross-subdomain cookie in the default store priority. Once the two disagree -- e.g. a per-origin `localStorage` entry drifts from the shared cookie -- whichever store sits first in priority order wins permanently, with no way for the two to resync. With this option enabled, the cookie's value wins a disagreement instead, and every store is resynced to it.
-
-This ships off by default: with it disabled (the default), behavior is unchanged. Enabling it only changes behavior in the already-broken case where stores disagree; when they already agree, it returns the exact same value as before.

--- a/.changeset/bump-is-email-curation.md
+++ b/.changeset/bump-is-email-curation.md
@@ -1,9 +1,0 @@
----
-"@segment/analytics-next": patch
----
-
-Bump the transitive `is-email` dependency (pulled in via `@segment/facade`) from 0.1.1 to 1.0.2.
-
-This was forced because 0.1.1 (and every other 0.x release) is blocked by our npm registry's curation policy, which would otherwise prevent any release from installing.
-
-**Behavior change:** `@segment/facade`'s internal email-format detection (used when processing `identify`/`track`/`page`/`group` calls) becomes stricter as a result. `is-email@0.1.1` used a very loose pattern (`/.+@.+\..+/`, matching almost anything shaped like `x@y.z`); `is-email@1.0.2` uses a proper RFC-5321-style pattern and caps input at 320 characters. In the rare case where a trait value was being loosely classified as an email-shaped string before, it may no longer be after this change (or vice versa, in edge cases the old pattern rejected that the stricter one accepts, like values containing `+`, `.`, or other pattern-valid characters outside the old pattern's assumptions). If you depend on this classification (directly or indirectly), verify your integration continues to see the values you expect.

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @segment/analytics-next
 
+## 1.84.2
+
+### Patch Changes
+
+- [#1398](https://github.com/segmentio/analytics-next/pull/1398) [`e7592fb8`](https://github.com/segmentio/analytics-next/commit/e7592fb84f6778530fe63704309cc60bb0bda85e) Thanks [@abueide](https://github.com/abueide)! - Added an opt-in `resolveAnonymousIdConflicts` option (`user: { resolveAnonymousIdConflicts: true }` in load options), off by default, that fixes `anonymousId` diverging between subdomains of the same site (see #706).
+
+  `localStorage` is per-origin, but sits ahead of the shared, cross-subdomain cookie in the default store priority. Once the two disagree -- e.g. a per-origin `localStorage` entry drifts from the shared cookie -- whichever store sits first in priority order wins permanently, with no way for the two to resync. With this option enabled, the cookie's value wins a disagreement instead, and every store is resynced to it.
+
+  This ships off by default: with it disabled (the default), behavior is unchanged. Enabling it only changes behavior in the already-broken case where stores disagree; when they already agree, it returns the exact same value as before.
+
+* [#1388](https://github.com/segmentio/analytics-next/pull/1388) [`b4fd75d4`](https://github.com/segmentio/analytics-next/commit/b4fd75d40e2f8ddf0b72de7f9864ee08e95beba0) Thanks [@abueide](https://github.com/abueide)! - Bump the transitive `is-email` dependency (pulled in via `@segment/facade`) from 0.1.1 to 1.0.2.
+
+  This was forced because 0.1.1 (and every other 0.x release) is blocked by our npm registry's curation policy, which would otherwise prevent any release from installing.
+
+  **Behavior change:** `@segment/facade`'s internal email-format detection (used when processing `identify`/`track`/`page`/`group` calls) becomes stricter as a result. `is-email@0.1.1` used a very loose pattern (`/.+@.+\..+/`, matching almost anything shaped like `x@y.z`); `is-email@1.0.2` uses a proper RFC-5321-style pattern and caps input at 320 characters. In the rare case where a trait value was being loosely classified as an email-shaped string before, it may no longer be after this change (or vice versa, in edge cases the old pattern rejected that the stricter one accepts, like values containing `+`, `.`, or other pattern-valid characters outside the old pattern's assumptions). If you depend on this classification (directly or indirectly), verify your integration continues to see the values you expect.
+
 ## 1.84.1
 
 ### Patch Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-next",
-  "version": "1.84.1",
+  "version": "1.84.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/analytics-next",

--- a/packages/browser/src/generated/version.ts
+++ b/packages/browser/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.84.1'
+export const version = '1.84.2'


### PR DESCRIPTION
## Summary

Manual version bump, standing in for the `Changeset Release Creator` workflow — that workflow has had a **100% `startup_failure` rate on every trigger since 2026-07-15** (the last successful run was 2026-04-29), so no "Version Packages" PR has been auto-created since then. That's an existing infra issue independent of this change; someone with org Actions-policy access should look into why `release-creator.yml` fails at startup.

This is exactly what that bot would have produced: ran `yarn update-versions-and-changelogs` against the two changesets currently pending on `master`:
- #1398 (`resolveAnonymousIdConflicts` opt-in fix)
- #1388 (is-email dependency bump, merged back in July, also never released because of the same broken bot)

`@segment/analytics-next` bumps `1.84.1` -> `1.84.2`.

Merging this (commit message starts with `Version Packages`) will make `publish.yml`'s `should-release` check pass on push to `master`, triggering the real npm publish + CDN deploy.

## Test plan

- [x] Full `packages/browser` test suite passes (849 passed, 4 pre-existing skips)
- [x] `tsc --noEmit` clean
- [x] Verified `packages/browser/src/generated/version.ts` and `package.json` both read `1.84.2`
- [x] Verified the generated `CHANGELOG.md` entry attributes both PRs correctly