### PR TITLE
fix: make anonymousId cross-subdomain reconciliation the default

### DIFF
--- a/.changeset/remove-anonymous-id-conflict-flag.md
+++ b/.changeset/remove-anonymous-id-conflict-flag.md
@@ -1,0 +1,7 @@
+---
+"@segment/analytics-next": patch
+---
+
+Removed the `resolveAnonymousIdConflicts` option, added in the previous release, and made its behavior the unconditional default: when the cookie and localStorage disagree on `anonymousId`, the cookie always wins and every store is resynced to it, instead of localStorage's value winning permanently (see #706).
+
+**Behavior change:** this is no longer opt-in. It only changes behavior for sources where the cookie and localStorage already disagree -- when they agree (the common case), the result is unchanged. If any customer explicitly set `resolveAnonymousIdConflicts: false` in their load options, that field is now ignored (harmless); the option was only in the previous release, so no meaningful adoption window existed for anyone relying on its absence.

--- a/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
+++ b/packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts
@@ -12,13 +12,12 @@ const SUBDOMAIN_B = `http://b.${PARENT_DOMAIN}/`
 
 const getAnonymousId = () => window.analytics.user().anonymousId() as string
 
-async function loadAnalytics(page: Page, resolveAnonymousIdConflicts: boolean) {
-  await page.evaluate((resolveAnonymousIdConflicts) => {
+async function loadAnalytics(page: Page) {
+  await page.evaluate(() => {
     window.analytics.load('fake-key', {
       cookie: { domain: '.ajs-repro.test' },
-      user: { resolveAnonymousIdConflicts },
     })
-  }, resolveAnonymousIdConflicts)
+  })
   await page.waitForFunction(() => window.analytics.initialized)
 }
 
@@ -54,20 +53,17 @@ test.describe(
       )
     })
 
-    // reproduces the #706 sequence: a user clears cookies + site data on subdomain A only,
-    // leaving subdomain B's localStorage stale -- the two subdomains disagree from then on.
-    async function reproduceDivergence(
-      context: import('@playwright/test').BrowserContext,
-      resolveAnonymousIdConflicts: boolean
-    ) {
+    test('subdomains converge and stay converged after diverging (segmentio/analytics-next#706)', async ({
+      context,
+    }) => {
       const pageA = await context.newPage()
       await pageA.goto(SUBDOMAIN_A)
-      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      await loadAnalytics(pageA)
       const original = await pageA.evaluate(getAnonymousId)
 
       const pageB = await context.newPage()
       await pageB.goto(SUBDOMAIN_B)
-      await loadAnalytics(pageB, resolveAnonymousIdConflicts)
+      await loadAnalytics(pageB)
       // sanity check: B picked up the same id via the shared cookie before anything diverges
       expect(await pageB.evaluate(getAnonymousId)).toEqual(original)
 
@@ -76,46 +72,29 @@ test.describe(
       await context.clearCookies()
       await pageA.evaluate(() => localStorage.clear())
       await pageA.reload()
-      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      await loadAnalytics(pageA)
       const freshId = await pageA.evaluate(getAnonymousId)
       expect(freshId).not.toEqual(original)
 
-      // B still has the stale pre-clear id in its own localStorage
-      await pageB.reload()
-      await loadAnalytics(pageB, resolveAnonymousIdConflicts)
-      const idB = await pageB.evaluate(getAnonymousId)
-
-      // back to A again, after B's read above may have overwritten the shared cookie
+      // A re-agrees with the now-updated shared cookie
       await pageA.reload()
-      await loadAnalytics(pageA, resolveAnonymousIdConflicts)
+      await loadAnalytics(pageA)
       const idA = await pageA.evaluate(getAnonymousId)
 
-      return { pageA, pageB, idA, idB, freshId, original }
-    }
+      // B still has the stale pre-clear id in its own localStorage, but resolves to the cookie
+      await pageB.reload()
+      await loadAnalytics(pageB)
+      const idB = await pageB.evaluate(getAnonymousId)
 
-    test('without resolveAnonymousIdConflicts (default): subdomains stay diverged', async ({
-      context,
-    }) => {
-      const { idA, idB } = await reproduceDivergence(context, false)
-      expect(idA).not.toEqual(idB)
-    })
-
-    test('with resolveAnonymousIdConflicts: subdomains converge and stay converged', async ({
-      context,
-    }) => {
-      const { pageA, pageB, idA, idB } = await reproduceDivergence(
-        context,
-        true
-      )
       expect(idA).toEqual(idB)
 
       // stays converged on further navigation, doesn't start ping-ponging again
       await pageB.reload()
-      await loadAnalytics(pageB, true)
+      await loadAnalytics(pageB)
       expect(await pageB.evaluate(getAnonymousId)).toEqual(idA)
 
       await pageA.reload()
-      await loadAnalytics(pageA, true)
+      await loadAnalytics(pageA)
       expect(await pageA.evaluate(getAnonymousId)).toEqual(idA)
     })
   }

--- a/packages/browser/src/core/user/__tests__/index.test.ts
+++ b/packages/browser/src/core/user/__tests__/index.test.ts
@@ -78,18 +78,7 @@ describe('user', () => {
       expect(new User().anonymousId()).toEqual('anonymous')
     })
 
-    it('keeps the diverged localStorage value by default (resolveAnonymousIdConflicts opt-in is off)', () => {
-      jar.set('ajs_anonymous_id', 'from-cookie')
-      localStorage.setItem(
-        'ajs_anonymous_id',
-        JSON.stringify('from-local-storage')
-      )
-
-      const user = new User()
-      expect(user.anonymousId()).toEqual('from-local-storage')
-    })
-
-    it('with resolveAnonymousIdConflicts: prefers the cookie over a diverged localStorage value, and resyncs localStorage to match', () => {
+    it('prefers the cookie over a diverged localStorage value, and resyncs localStorage to match', () => {
       // reproduces #706: localStorage (per-origin) has drifted from the shared cookie
       jar.set('ajs_anonymous_id', 'from-cookie')
       localStorage.setItem(
@@ -97,7 +86,7 @@ describe('user', () => {
         JSON.stringify('from-local-storage')
       )
 
-      const user = new User({ resolveAnonymousIdConflicts: true })
+      const user = new User()
       expect(user.anonymousId()).toEqual('from-cookie')
       expect(localStorage.getItem('ajs_anonymous_id')).toEqual(
         JSON.stringify('from-cookie')

--- a/packages/browser/src/core/user/index.ts
+++ b/packages/browser/src/core/user/index.ts
@@ -37,11 +37,6 @@ export interface UserOptions {
    * @example stores: [StoreType.Cookie, StoreType.Memory]
    */
   storage?: StorageSettings
-
-  /**
-   * Opt-in fix for anonymousId diverging between subdomains (see segmentio/analytics-next#706): when the cookie and localStorage disagree, prefer the cookie and resync localStorage to it, instead of localStorage's value winning permanently. Defaults to false.
-   */
-  resolveAnonymousIdConflicts?: boolean
 }
 
 const defaults = {
@@ -149,19 +144,14 @@ export class User implements WithId {
     return [anon, user]
   }
 
-  private readAnonymousId(): ID {
-    return this.options.resolveAnonymousIdConflicts
-      ? this.identityStore.getConsistent(this.anonKey)
-      : this.identityStore.getAndSync(this.anonKey)
-  }
-
   anonymousId = (id?: ID): ID => {
     if (this.options.disable) {
       return null
     }
 
     if (id === undefined) {
-      const val = this.readAnonymousId() ?? this.legacySIO()?.[0]
+      const val =
+        this.identityStore.getConsistent(this.anonKey) ?? this.legacySIO()?.[0]
 
       if (val) {
         return val
@@ -170,11 +160,11 @@ export class User implements WithId {
 
     if (id === null) {
       this.identityStore.set(this.anonKey, null)
-      return this.readAnonymousId()
+      return this.identityStore.getConsistent(this.anonKey)
     }
 
     this.identityStore.set(this.anonKey, id ?? uuid())
-    return this.readAnonymousId()
+    return this.identityStore.getConsistent(this.anonKey)
   }
 
   traits = (traits?: Traits | null): Traits | undefined => {


### PR DESCRIPTION
## Summary

Follow-up to #1398 (released as `1.84.2`). That PR shipped `resolveAnonymousIdConflicts` as an opt-in, default-off flag -- a cautious first step taken before we'd confirmed how staged rollout actually works for this SDK.

Since then we traced the real delivery path end-to-end (`ajs-renderer` -> `analytics.js-versions` -> Flagon gates): which build of analytics-next a given source's CDN bundle contains is already controlled per-source, via `v2projects` pins and the `ajs-renderer`/`v2rollout` Flagon gate. That makes an *application-level* opt-in redundant -- exposure to this fix is governed by which code a source receives, not by a flag inside that code. Keeping the flag just adds a second, unnecessary gate: a source could receive the fix and still see the bug because nobody flipped an option in their `load()` call.

This PR removes `resolveAnonymousIdConflicts` and makes `UniversalStorage#getConsistent` the sole `anonymousId` resolution path -- no flag, no default to reason about.

**Behavior change:** no longer opt-in. Only affects sources where the cookie and localStorage already disagree (the broken case); when they agree, behavior is unchanged. The flag only existed for one release, so there's no meaningful adoption window for anyone depending on its absence.

## Test plan

- [x] Updated `User` unit tests to drop the flag parameter -- reconciliation is now the only path (`packages/browser/src/core/user/__tests__/index.test.ts`)
- [x] Updated the Playwright e2e reproduction of #706 to drop the flag and assert convergence unconditionally (`packages/browser-integration-tests/src/anonymous-id-subdomain-sync.test.ts`) -- verified locally against a fresh build, including a full instrumented state-trace confirming the cookie wins the disagreement and resyncs localStorage as expected
- [x] Full `packages/browser` unit suite passes (unrelated pre-existing flake in `ajs-destination`/Amplitude tests, confirmed by rerun)
- [x] Full `browser-integration-tests` e2e suite passes
- [x] `tsc --noEmit` and `eslint` clean on all touched files
- [x] Bundle size actually decreased slightly (~29.96 kB, under the existing 30.1 kB limit) from removing the flag branch