### PR TITLE
Version Packages

### DIFF
--- a/.changeset/remove-anonymous-id-conflict-flag.md
+++ b/.changeset/remove-anonymous-id-conflict-flag.md
@@ -1,7 +1,0 @@
----
-"@segment/analytics-next": patch
----
-
-Removed the `resolveAnonymousIdConflicts` option, added in the previous release, and made its behavior the unconditional default: when the cookie and localStorage disagree on `anonymousId`, the cookie always wins and every store is resynced to it, instead of localStorage's value winning permanently (see #706).
-
-**Behavior change:** this is no longer opt-in. It only changes behavior for sources where the cookie and localStorage already disagree -- when they agree (the common case), the result is unchanged. If any customer explicitly set `resolveAnonymousIdConflicts: false` in their load options, that field is now ignored (harmless); the option was only in the previous release, so no meaningful adoption window existed for anyone relying on its absence.

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @segment/analytics-next
 
+## 1.84.3
+
+### Patch Changes
+
+- [#1400](https://github.com/segmentio/analytics-next/pull/1400) [`d49e05f7`](https://github.com/segmentio/analytics-next/commit/d49e05f7ed9dce6f2239c0e3687dd7ef1f247c72) Thanks [@abueide](https://github.com/abueide)! - Removed the `resolveAnonymousIdConflicts` option, added in the previous release, and made its behavior the unconditional default: when the cookie and localStorage disagree on `anonymousId`, the cookie always wins and every store is resynced to it, instead of localStorage's value winning permanently (see #706).
+
+  **Behavior change:** this is no longer opt-in. It only changes behavior for sources where the cookie and localStorage already disagree -- when they agree (the common case), the result is unchanged. If any customer explicitly set `resolveAnonymousIdConflicts: false` in their load options, that field is now ignored (harmless); the option was only in the previous release, so no meaningful adoption window existed for anyone relying on its absence.
+
 ## 1.84.2
 
 ### Patch Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-next",
-  "version": "1.84.2",
+  "version": "1.84.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/analytics-next",

--- a/packages/browser/src/generated/version.ts
+++ b/packages/browser/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is generated.
-export const version = '1.84.2'
+export const version = '1.84.3'


### PR DESCRIPTION
## Summary

Manual version bump (the `Changeset Release Creator` bot is still broken -- see #1399 for the ongoing org-level Actions allow-list issue). Same as before: ran `yarn update-versions-and-changelogs` against the one changeset currently pending on `master`, from #1400 (removing the `resolveAnonymousIdConflicts` opt-in flag, making cross-subdomain `anonymousId` reconciliation unconditional).

`@segment/analytics-next` bumps `1.84.2` -> `1.84.3`.

Merging this (commit message starts with `Version Packages`) triggers `publish.yml`'s `should-release` check on push to `master`, which runs the real npm publish + CDN deploy.

## Test plan

- [x] Relevant test suites pass (`src/generated`, `src/core/user`, `src/core/storage`)
- [x] `tsc --noEmit` clean
- [x] Verified `packages/browser/src/generated/version.ts` and `package.json` both read `1.84.3`
- [x] Verified the generated `CHANGELOG.md` entry attributes #1400 correctly